### PR TITLE
perf: vectorise mixture density and EM E-step

### DIFF
--- a/safe_ice/core/safe_ice.py
+++ b/safe_ice/core/safe_ice.py
@@ -9,17 +9,18 @@ converts NumPy scalars to Python floats at API boundaries to avoid Any leaks.
 
 from __future__ import annotations
 
-from typing import Any, Callable, Dict, List, Optional, Tuple, TypedDict
-
 import math
 import warnings
+from collections.abc import Callable
+from typing import Any, TypedDict
+
 import numpy as np
 import numpy.typing as npt
 import scipy.stats as stats
 from scipy.optimize import minimize_scalar
-from scipy.special import gamma, ive, loggamma
+from scipy.special import loggamma
 
-from .parameters import vMFNMParameters
+from ..distributions._numeric import radii_and_directions, vmf_pdf_batch
 from ..distributions.mixture import vMFNMDistribution
 from ..distributions.nakagami import (
     InverseNakagamiDistribution,
@@ -27,7 +28,7 @@ from ..distributions.nakagami import (
 )
 from ..distributions.vmf import VonMisesFisherSampler
 from ..optimization.penalized_em import PenalizedEMOptimizer
-
+from .parameters import vMFNMParameters
 
 # ----------------------------
 # Typing aliases and structures
@@ -37,11 +38,12 @@ NDArrayF = npt.NDArray[np.float64]
 
 class _SafeICEHistory(TypedDict):
     """History container for monitoring algorithm progress."""
-    sigma: List[float]
-    cv: List[float]
-    components: List[int]
-    lambda_val: List[float]
-    pf_estimates: List[float]
+
+    sigma: list[float]
+    cv: list[float]
+    components: list[int]
+    lambda_val: list[float]
+    pf_estimates: list[float]
 
 
 class SafeICE:
@@ -81,7 +83,7 @@ class SafeICE:
         sigma0: float = 1.0,
         em_max_iter: int = 100,
         cv_tolerance: float = 0.01,
-        random_state: Optional[int | np.random.Generator] = None,
+        random_state: int | np.random.Generator | None = None,
     ) -> None:
         self.g = limit_state_function
         self.d = int(dimension)
@@ -118,9 +120,9 @@ class SafeICE:
     # -------------------------------------------------------------------------
     def run(
         self,
-        initial_params: Optional[vMFNMParameters] = None,
+        initial_params: vMFNMParameters | None = None,
         verbose: bool = True,
-    ) -> Tuple[float, Dict[str, Any]]:
+    ) -> tuple[float, dict[str, Any]]:
         """Execute the complete Safe-ICE algorithm.
 
         Returns
@@ -144,45 +146,41 @@ class SafeICE:
         sigma_t: float = float(self.sigma0)
         M: float = float(self.sigma0)  # cosine annealing scale
         lambda_t: float = self._cosine_annealing_schedule(sigma_t, M)
-        iteration_records: List[Dict[str, Any]] = []
-        all_samples: List[NDArrayF] = []
-        all_g_values: List[NDArrayF] = []
+        iteration_records: list[dict[str, Any]] = []
+        all_samples: list[NDArrayF] = []
+        all_g_values: list[NDArrayF] = []
 
         for t in range(self.max_iterations):
             if verbose:
                 print(
                     f"Iteration {t + 1:2d}: "
-                    f"\u03c3={sigma_t:.6f}, \u03bb={lambda_t:.3f}, "
+                    f"sigma={sigma_t:.6f}, lambda={lambda_t:.3f}, "
                     f"K={phi_t.K}"
                 )
 
             # Generate samples from safe importance mixture
-            samples: NDArrayF = self._generate_safe_mixture_samples(
-                phi_t, lambda_t
-            )
+            samples: NDArrayF = self._generate_safe_mixture_samples(phi_t, lambda_t)
             g_values: NDArrayF = self._evaluate_limit_state(samples)
 
             # Stopping weights and CV
-            stopping_weights: NDArrayF = (
-                self._calculate_stopping_weights(
-                    samples, g_values, sigma_t, phi_t, lambda_t
-                )
+            stopping_weights: NDArrayF = self._calculate_stopping_weights(
+                samples, g_values, sigma_t, phi_t, lambda_t
             )
-            cv_w_star: float = self._coefficient_of_variation(
-                stopping_weights
-            )
+            cv_w_star: float = self._coefficient_of_variation(stopping_weights)
 
             # Record history
             self.history["sigma"].append(float(sigma_t))
             self.history["cv"].append(float(cv_w_star))
             self.history["components"].append(int(phi_t.K))
             self.history["lambda_val"].append(float(lambda_t))
-            iteration_records.append({
-                "iteration": t + 1,
-                "K": int(phi_t.K),
-                "sigma": float(sigma_t),
-                "lambda": float(lambda_t),
-            })
+            iteration_records.append(
+                {
+                    "iteration": t + 1,
+                    "K": int(phi_t.K),
+                    "sigma": float(sigma_t),
+                    "lambda": float(lambda_t),
+                }
+            )
             all_samples.append(samples)
             all_g_values.append(g_values)
 
@@ -212,12 +210,8 @@ class SafeICE:
             lambda_t = self._cosine_annealing_schedule(sigma_t, M)
 
         # --- Final estimate via importance sampling (not crude MC) ---
-        final_samples: NDArrayF = self._generate_safe_mixture_samples(
-            phi_t, lambda_t
-        )
-        final_g_values: NDArrayF = self._evaluate_limit_state(
-            final_samples
-        )
+        final_samples: NDArrayF = self._generate_safe_mixture_samples(phi_t, lambda_t)
+        final_g_values: NDArrayF = self._evaluate_limit_state(final_samples)
         pf_estimate: float = self._estimate_failure_probability(
             final_samples, final_g_values, phi_t, lambda_t
         )
@@ -228,7 +222,7 @@ class SafeICE:
         all_samples_arr: NDArrayF = np.vstack(all_samples)
         all_g_arr: NDArrayF = np.hstack(all_g_values)
 
-        results: Dict[str, Any] = {
+        results: dict[str, Any] = {
             "failure_probability": float(pf_estimate),
             "iterations": iteration_records,
             "final_components": int(phi_t.K),
@@ -236,9 +230,7 @@ class SafeICE:
             "final_cv": float(self.history["cv"][-1]),
             "final_lambda": float(lambda_t),
             "final_samples": all_samples_arr,
-            "final_weights": np.ones(
-                all_samples_arr.shape[0], dtype=np.float64
-            ),
+            "final_weights": np.ones(all_samples_arr.shape[0], dtype=np.float64),
             "final_g_values": all_g_arr,
             "history": self.history,
             "convergence_metrics": {
@@ -273,10 +265,20 @@ class SafeICE:
             if arr.shape[0] != samples.shape[0]:
                 raise ValueError("Limit-state output shape mismatch")
         except Exception:
-            arr = np.asarray([float(self.g(s.reshape(1, -1))[0]) for s in samples], dtype=np.float64)
+            arr = np.asarray(
+                [
+                    float(np.asarray(self.g(s.reshape(1, -1))).reshape(-1)[0])
+                    for s in samples
+                ],
+                dtype=np.float64,
+            )
 
         if np.any(np.isnan(arr)):
-            warnings.warn("Limit state returned NaN values; converting to +inf.", RuntimeWarning)
+            warnings.warn(
+                "Limit state returned NaN values; converting to +inf.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
             arr = np.where(np.isnan(arr), np.inf, arr)
         arr = np.where(np.isposinf(arr), np.inf, arr)
         arr = np.where(np.isneginf(arr), -np.inf, arr)
@@ -344,8 +346,10 @@ class SafeICE:
         r: float = float(
             np.asarray(
                 NakagamiDistribution.sample(
-                    float(params.m[k]), float(params.Omega[k]),
-                    1, rng=self._rng,
+                    float(params.m[k]),
+                    float(params.Omega[k]),
+                    1,
+                    rng=self._rng,
                 ),
                 dtype=np.float64,
             )[0]
@@ -353,8 +357,10 @@ class SafeICE:
 
         a: NDArrayF = np.asarray(
             VonMisesFisherSampler.sample(
-                params.mu[k], float(params.kappa[k]),
-                1, rng=self._rng,
+                params.mu[k],
+                float(params.kappa[k]),
+                1,
+                rng=self._rng,
             )[0],
             dtype=np.float64,
         )
@@ -366,7 +372,7 @@ class SafeICE:
         k = int(self._rng.choice(params.K, p=params.pi))
 
         # Heavy-tailed parameters: m_IN = ceil(sqrt(d))
-        m_IN = max(1, int(math.ceil(math.sqrt(self.d))))
+        m_IN = max(1, math.ceil(math.sqrt(self.d)))
 
         # Match modes between Nakagami and Inverse Nakagami (Equation 34)
         Omega_IN = float(
@@ -379,7 +385,10 @@ class SafeICE:
         r: float = float(
             np.asarray(
                 InverseNakagamiDistribution.sample(
-                    float(m_IN), Omega_IN, 1, rng=self._rng,
+                    float(m_IN),
+                    Omega_IN,
+                    1,
+                    rng=self._rng,
                 ),
                 dtype=np.float64,
             )[0]
@@ -388,8 +397,10 @@ class SafeICE:
         # Direction from vMF
         a: NDArrayF = np.asarray(
             VonMisesFisherSampler.sample(
-                params.mu[k], float(params.kappa[k]),
-                1, rng=self._rng,
+                params.mu[k],
+                float(params.kappa[k]),
+                1,
+                rng=self._rng,
             )[0],
             dtype=np.float64,
         )
@@ -406,26 +417,35 @@ class SafeICE:
         # gamma_ratio_squared = [Γ(m_N)/Γ(m_N+1/2)]^2 (stable log-domain form)
         log_ratio = 2.0 * (float(loggamma(m_N)) - float(loggamma(m_N + 0.5)))
         gamma_ratio_squared: float = float(np.exp(np.clip(log_ratio, -700.0, 700.0)))
-        Omega_IN: float = float((2.0 * m_IN) / (2.0 * m_IN + 1.0)) * gamma_ratio_squared * float(
-            m_N / Omega_N
+        Omega_IN: float = (
+            float((2.0 * m_IN) / (2.0 * m_IN + 1.0))
+            * gamma_ratio_squared
+            * float(m_N / Omega_N)
         )
         # Ensure strictly positive
         return float(max(Omega_IN, 1e-6))
 
     def _calculate_stopping_weights(
         self,
-        samples: NDArrayF,
+        samples: NDArrayF,  # noqa: ARG002 - kept for signature parity
         g_values: NDArrayF,
         sigma: float,
-        params: vMFNMParameters,
-        lambda_val: float,
+        params: vMFNMParameters,  # noqa: ARG002 - kept for signature parity
+        lambda_val: float,  # noqa: ARG002 - kept for signature parity
     ) -> NDArrayF:
-        """Calculate stopping weights W*_t(u) = I_ΩF(u) / h_t(u)."""
+        """Calculate stopping weights W*_t(u) = I_ΩF(u) / h_t(u).
+
+        Only ``g_values`` and ``sigma`` enter the formula; the remaining
+        arguments mirror the other per-iteration helpers so callers can pass
+        the same tuple to each of them.
+        """
         # Indicator 1{g(u) <= 0}
         indicators: NDArrayF = (g_values <= 0.0).astype(np.float64, copy=False)
 
         # Smoothed indicator h_t(u) = Φ(-g(u)/σ_t)
-        h_values: NDArrayF = np.asarray(stats.norm.cdf(-g_values / float(sigma)), dtype=np.float64)
+        h_values: NDArrayF = np.asarray(
+            stats.norm.cdf(-g_values / float(sigma)), dtype=np.float64
+        )
 
         # Avoid divide-by-zero via max with tiny
         weights: NDArrayF = (indicators / np.maximum(h_values, 1e-15)).astype(
@@ -489,7 +509,9 @@ class SafeICE:
     ) -> NDArrayF:
         """Calculate intermediate importance weights W_t(u_i, σ)."""
         # h(u;σ) = Φ(-g/σ)
-        h_values: NDArrayF = np.asarray(stats.norm.cdf(-g_values / float(sigma)), dtype=np.float64)
+        h_values: NDArrayF = np.asarray(
+            stats.norm.cdf(-g_values / float(sigma)), dtype=np.float64
+        )
 
         # Prior density p(u)
         prior_densities: NDArrayF = self._evaluate_prior_density(samples)
@@ -500,9 +522,9 @@ class SafeICE:
         )
 
         # W_t = h * p / q_safe
-        weights: NDArrayF = (h_values * prior_densities / np.maximum(safe_densities, 1e-15)).astype(
-            np.float64, copy=False
-        )
+        weights: NDArrayF = (
+            h_values * prior_densities / np.maximum(safe_densities, 1e-15)
+        ).astype(np.float64, copy=False)
         return weights
 
     def _update_parameters_penalized_em(
@@ -542,9 +564,9 @@ class SafeICE:
         )
 
         # Importance weights
-        importance_weights: NDArrayF = (prior_densities / np.maximum(safe_densities, 1e-15)).astype(
-            np.float64, copy=False
-        )
+        importance_weights: NDArrayF = (
+            prior_densities / np.maximum(safe_densities, 1e-15)
+        ).astype(np.float64, copy=False)
 
         # Monte Carlo estimate
         pf_estimate: float = float(np.mean(indicators * importance_weights))
@@ -563,14 +585,17 @@ class SafeICE:
         """Evaluate safe mixture density q_safe(u; φ)."""
         # Light-tailed component (vMF-Nakagami mixture)
         vmfnm_dist = vMFNMDistribution(params)
-        light_densities: NDArrayF = np.asarray(vmfnm_dist.pdf(samples), dtype=np.float64)
+        light_densities: NDArrayF = np.asarray(
+            vmfnm_dist.pdf(samples), dtype=np.float64
+        )
 
         # Heavy-tailed component (inverse Nakagami radial + vMF angular)
         heavy_densities: NDArrayF = self._evaluate_heavy_tailed_density(samples, params)
 
         # Combine
         safe_densities: NDArrayF = (
-            float(lambda_val) * light_densities + (1.0 - float(lambda_val)) * heavy_densities
+            float(lambda_val) * light_densities
+            + (1.0 - float(lambda_val)) * heavy_densities
         ).astype(np.float64, copy=False)
         return safe_densities
 
@@ -579,50 +604,31 @@ class SafeICE:
     ) -> NDArrayF:
         """Evaluate density of the heavy-tailed component for each sample."""
         n_samples = int(samples.shape[0])
+        radii, directions = radii_and_directions(samples)
+
+        # The inverse-Nakagami shape depends only on the problem dimension, so
+        # it is hoisted out of the per-component loop.
+        m_IN = max(1, math.ceil(math.sqrt(self.d)))
+
         densities: NDArrayF = np.zeros(n_samples, dtype=np.float64)
-
-        for i, sample in enumerate(samples):
-            # Polar decomposition u = r * a
-            r: float = float(np.linalg.norm(sample))
-            if r > 1e-12:
-                a: NDArrayF = (sample / r).astype(np.float64, copy=False)
-            else:
-                # Degenerate direction (rare): set a = e1, r tiny
-                a = np.zeros(self.d, dtype=np.float64)
-                a[0] = 1.0
-                r = 1e-12
-
-            # Mixture across components
-            mixture_val: float = 0.0
-            for k in range(params.K):
-                # Radial: Inverse Nakagami with mode-matching parameters
-                m_IN = max(1, int(math.ceil(math.sqrt(self.d))))
-                Omega_IN = float(
-                    self._calculate_matched_omega_inverse_nakagami(
-                        float(params.m[k]), float(params.Omega[k]), float(m_IN)
-                    )
+        for k in range(params.K):
+            # Radial: Inverse Nakagami with mode-matching parameters
+            Omega_IN = float(
+                self._calculate_matched_omega_inverse_nakagami(
+                    float(params.m[k]), float(params.Omega[k]), float(m_IN)
                 )
+            )
+            radial_density: NDArrayF = np.asarray(
+                InverseNakagamiDistribution.pdf(radii, int(m_IN), Omega_IN),
+                dtype=np.float64,
+            )
 
-                # Many SciPy/NumPy pdfs are typed for arrays; pass 1-D array then extract
-                r_arr: NDArrayF = np.asarray([r], dtype=np.float64)
-                radial_density_arr: NDArrayF = np.asarray(
-                    InverseNakagamiDistribution.pdf(r_arr, int(m_IN), Omega_IN),
-                    dtype=np.float64,
-                )
-                radial_density: float = float(radial_density_arr[0])
+            # Angular: vMF density at each direction
+            angular_density: NDArrayF = vmf_pdf_batch(
+                directions, params.mu[k], float(params.kappa[k])
+            )
 
-                # Angular: vMF density at direction a
-                angular_density: float = float(
-                    self._vmf_pdf_single(
-                        a,
-                        params.mu[k],
-                        float(params.kappa[k]),
-                    )
-                )
-
-                mixture_val += float(params.pi[k]) * radial_density * angular_density
-
-            densities[i] = float(mixture_val)
+            densities += float(params.pi[k]) * radial_density * angular_density
 
         return densities
 
@@ -635,36 +641,5 @@ class SafeICE:
         Returns the density with respect to the surface area measure on the
         unit sphere, so that ∫_{S^{d-1}} f(a) dω(a) = 1.
         """
-        d = int(x.shape[0])
-
-        if float(kappa) == 0.0:
-            # Uniform density on S^{d-1}: 1 / surface_area
-            surface_area: float = float(
-                2.0 * (math.pi ** (d / 2.0)) / float(gamma(d / 2.0))
-            )
-            return 1.0 / surface_area
-
-        nu: float = float(d / 2.0 - 1.0)
-
-        # Use exponentially-scaled Bessel to avoid overflow for large κ:
-        # ive(ν, κ) = iv(ν, κ) · exp(−κ), so log iv(ν, κ) = log ive(ν, κ) + κ
-        ive_val: float = float(ive(nu, kappa))
-        if ive_val <= 0.0 or not np.isfinite(ive_val):
-            return 0.0
-
-        log_C: float = (
-            nu * float(np.log(kappa))
-            - (d / 2.0) * float(np.log(2.0 * math.pi))
-            - float(np.log(ive_val))
-            - float(kappa)
-        )
-        dot_val: float = float(np.dot(x, mu))
-        log_pdf: float = log_C + float(kappa) * dot_val
-
-        if not np.isfinite(log_pdf):
-            return 0.0
-        if log_pdf < -745.0:
-            return 0.0
-        if log_pdf > 700.0:
-            return float(np.exp(700.0))
-        return float(np.exp(log_pdf))
+        x_arr: NDArrayF = np.asarray(x, dtype=np.float64).reshape(1, -1)
+        return float(vmf_pdf_batch(x_arr, mu, kappa)[0])

--- a/safe_ice/distributions/_numeric.py
+++ b/safe_ice/distributions/_numeric.py
@@ -1,0 +1,105 @@
+# safe_ice/distributions/_numeric.py
+"""Shared vectorised numerical helpers for the mixture and EM code paths.
+
+These exist so the mixture density and the EM E-step can evaluate whole sample
+batches in a few NumPy passes instead of one Python call per (sample,
+component) pair. The guard clauses mirror the scalar reference implementations
+exactly, including the order in which the non-finite and saturation cases are
+tested, so results are unchanged.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import numpy.typing as npt
+from scipy.special import gamma, ive
+
+NDArrayF = npt.NDArray[np.float64]
+
+#: Radii at or below this are treated as degenerate and clamped.
+RADIUS_FLOOR = 1e-12
+
+#: ``exp`` of a float64 overflows above this exponent; the reference code
+#: saturates rather than returning ``inf``.
+LOG_MAX = 700.0
+
+#: Below this exponent ``exp`` underflows to zero in float64.
+LOG_MIN = -745.0
+
+
+def radii_and_directions(X: NDArrayF) -> tuple[NDArrayF, NDArrayF]:
+    """Split rows of ``X`` into radii and unit directions.
+
+    Rows whose norm falls at or below :data:`RADIUS_FLOOR` are degenerate: the
+    direction is undefined, so the first basis vector is used and the radius is
+    clamped to the floor.
+
+    Returns
+    -------
+    radii : ndarray of shape (n,)
+    directions : ndarray of shape (n, d)
+    """
+    norms = np.linalg.norm(X, axis=1)
+    degenerate = norms <= RADIUS_FLOOR
+
+    directions = np.zeros_like(X)
+    finite_rows = ~degenerate
+    directions[finite_rows] = X[finite_rows] / norms[finite_rows, None]
+    directions[degenerate, 0] = 1.0
+
+    radii = np.where(degenerate, RADIUS_FLOOR, norms)
+    return radii, directions
+
+
+def exp_clamped(log_pdf: NDArrayF) -> NDArrayF:
+    """Exponentiate log-densities, mapping non-finite values to zero.
+
+    Mirrors the scalar guards: non-finite exponents yield ``0`` (checked first,
+    so ``+inf`` yields ``0`` rather than saturating), exponents below
+    :data:`LOG_MIN` underflow to ``0``, and exponents above :data:`LOG_MAX`
+    saturate at ``exp(LOG_MAX)``.
+    """
+    out = np.zeros_like(log_pdf, dtype=np.float64)
+    finite = np.isfinite(log_pdf)
+    saturated = finite & (log_pdf > LOG_MAX)
+    normal = finite & (log_pdf >= LOG_MIN) & (log_pdf <= LOG_MAX)
+
+    out[normal] = np.exp(log_pdf[normal])
+    out[saturated] = np.exp(LOG_MAX)
+    return out
+
+
+def sphere_surface_area(d: int) -> float:
+    """Surface area of the unit sphere S^{d-1} embedded in R^d."""
+    return float(2.0 * (np.pi ** (d / 2.0)) / float(gamma(d / 2.0)))
+
+
+def vmf_pdf_batch(X: NDArrayF, mu: NDArrayF, kappa: float) -> NDArrayF:
+    """von Mises-Fisher density at unit rows of ``X``, w.r.t. surface measure.
+
+    Normalised so that the integral over S^{d-1} with respect to the surface
+    area measure is one. A non-positive concentration gives the uniform density
+    on the sphere; ``kappa`` is a concentration parameter and is never negative
+    for a well-formed mixture.
+
+    Uses the exponentially-scaled Bessel function ``ive`` so that large
+    ``kappa`` does not overflow: ``ive(v, k) = iv(v, k) * exp(-k)``.
+    """
+    n, d = int(X.shape[0]), int(X.shape[1])
+
+    if kappa <= 0.0:
+        return np.full(n, 1.0 / sphere_surface_area(d), dtype=np.float64)
+
+    nu = d / 2.0 - 1.0
+    ive_val = float(ive(nu, kappa))
+    if ive_val <= 0.0 or not np.isfinite(ive_val):
+        return np.zeros(n, dtype=np.float64)
+
+    log_norm = (
+        nu * float(np.log(kappa))
+        - (d / 2.0) * float(np.log(2.0 * np.pi))
+        - float(np.log(ive_val))
+        - float(kappa)
+    )
+    log_pdf: NDArrayF = log_norm + float(kappa) * (X @ mu)
+    return exp_clamped(log_pdf)

--- a/safe_ice/distributions/mixture.py
+++ b/safe_ice/distributions/mixture.py
@@ -3,15 +3,22 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import numpy as np
 import numpy.typing as npt
-from scipy.special import iv, ive, gamma  # noqa: F401
 
 from ..core.parameters import vMFNMParameters
-from .vmf import VonMisesFisherSampler
+from ..typing import RNGLike
+from ._numeric import radii_and_directions, sphere_surface_area, vmf_pdf_batch
 from .nakagami import NakagamiDistribution
+from .vmf import VonMisesFisherSampler
 
 NDArrayF = npt.NDArray[np.float64]
+
+# ``sphere_surface_area`` moved to ``_numeric`` but is re-exported here, where
+# it has always been importable from.
+__all__ = ["sphere_surface_area", "vMFNMDistribution"]
 
 
 class vMFNMDistribution:
@@ -49,56 +56,37 @@ class vMFNMDistribution:
         n, d = X.shape
         assert d == self.params.d
 
-        out = np.zeros(n, dtype=np.float64)
-        for i in range(n):
-            xi = X[i]
-            r = float(np.linalg.norm(xi))
-            if r > 1e-12:
-                a = xi / r
-            else:
-                a = np.zeros(d, dtype=np.float64)
-                a[0] = 1.0
-                r = 1e-12
+        radii, directions = radii_and_directions(X)
+        jacobian = radii ** (d - 1)
 
-            mix_val: float = 0.0
-            jacobian = float(max(r, 1e-12) ** (d - 1))
-            for k in range(self.params.K):
-                nak = float(NakagamiDistribution.pdf(r, float(self.params.m[k]), float(self.params.Omega[k])))
-                vmf = float(self._vmf_pdf(a, self.params.mu[k], float(self.params.kappa[k])))
-                mix_val += float(self.params.pi[k]) * nak * vmf / jacobian
-            out[i] = mix_val
+        # One vectorised pass per component rather than one call per (sample,
+        # component) pair. Accumulating sequentially over k keeps the summation
+        # order of the original per-sample loop; batched norms and BLAS matvecs
+        # still shift results by ~1e-13 relative, far below sampling noise.
+        out = np.zeros(n, dtype=np.float64)
+        for k in range(self.params.K):
+            nak = np.asarray(
+                NakagamiDistribution.pdf(
+                    radii, float(self.params.m[k]), float(self.params.Omega[k])
+                ),
+                dtype=np.float64,
+            )
+            vmf = self._vmf_pdf_many(
+                directions, self.params.mu[k], float(self.params.kappa[k])
+            )
+            out += float(self.params.pi[k]) * nak * vmf / jacobian
         return out
 
     def _vmf_pdf(self, x: NDArrayF, mu: NDArrayF, kappa: float) -> float:
         """von Mises–Fisher pdf at unit x w.r.t. the surface area measure."""
-        d = int(x.size)
-        if kappa <= 0.0:
-            return 1.0 / sphere_surface_area(d)
-        v = d / 2.0 - 1.0
+        x_arr = np.asarray(x, dtype=np.float64).reshape(1, -1)
+        return float(self._vmf_pdf_many(x_arr, mu, kappa)[0])
 
-        # Use exponentially-scaled Bessel to avoid overflow for large κ
-        ive_val = float(ive(v, kappa))
-        if ive_val <= 0.0 or not np.isfinite(ive_val):
-            return 0.0
+    def _vmf_pdf_many(self, X: NDArrayF, mu: NDArrayF, kappa: float) -> NDArrayF:
+        """von Mises–Fisher pdf at unit rows of X w.r.t. the surface area measure."""
+        return vmf_pdf_batch(X, mu, kappa)
 
-        log_C = (
-            v * float(np.log(kappa))
-            - (d / 2.0) * float(np.log(2.0 * np.pi))
-            - float(np.log(ive_val))
-            - kappa
-        )
-        log_pdf = log_C + kappa * float(x @ mu)
-        if not np.isfinite(log_pdf):
-            return 0.0
-        if log_pdf < -745.0:
-            return 0.0
-        if log_pdf > 700.0:
-            return float(np.exp(700.0))
-        return float(np.exp(log_pdf))
-
-    def sample(
-        self, n_samples: int, rng: object = None
-    ) -> NDArrayF:
+    def sample(self, n_samples: int, rng: RNGLike | None = None) -> NDArrayF:
         """Sample from the mixture. Returns (n_samples, d).
 
         Parameters
@@ -106,7 +94,7 @@ class vMFNMDistribution:
         rng : numpy random generator, optional
             If *None*, the global ``np.random`` state is used.
         """
-        _rng = rng if rng is not None else np.random
+        _rng: Any = rng if rng is not None else np.random
         n, d = int(n_samples), self.params.d
         samples = np.zeros((n, d), dtype=np.float64)
 
@@ -133,8 +121,3 @@ class vMFNMDistribution:
     def log_likelihood(self, x: npt.ArrayLike) -> float:
         pdf_vals = self.pdf(x)
         return float(np.sum(np.log(np.maximum(pdf_vals, 1e-15))))
-
-
-def sphere_surface_area(d: int) -> float:
-    from scipy.special import gamma  # local import
-    return float(2.0 * (np.pi ** (d / 2.0)) / gamma(d / 2.0))

--- a/safe_ice/optimization/penalized_em.py
+++ b/safe_ice/optimization/penalized_em.py
@@ -3,16 +3,13 @@
 
 from __future__ import annotations
 
-from typing import Tuple
-
-import math
 import numpy as np
 import numpy.typing as npt
-from scipy.special import iv, ive, gamma
 
 from ..core.parameters import vMFNMParameters
-from ..distributions.nakagami import NakagamiDistribution
+from ..distributions._numeric import vmf_pdf_batch
 from ..distributions.mixture import vMFNMDistribution
+from ..distributions.nakagami import NakagamiDistribution
 
 NDArrayF = npt.NDArray[np.float64]
 
@@ -20,7 +17,9 @@ NDArrayF = npt.NDArray[np.float64]
 class PenalizedEMOptimizer:
     """Penalized EM algorithm for automatic component selection."""
 
-    def __init__(self, max_em_iterations: int = 100, em_tolerance: float = 1e-6) -> None:
+    def __init__(
+        self, max_em_iterations: int = 100, em_tolerance: float = 1e-6
+    ) -> None:
         self.max_em_iterations = int(max_em_iterations)
         self.em_tolerance = float(em_tolerance)
 
@@ -30,7 +29,7 @@ class PenalizedEMOptimizer:
         weights: NDArrayF,
         initial_params: vMFNMParameters,
         beta_init: float = 1.0,
-    ) -> Tuple[vMFNMParameters, int]:
+    ) -> tuple[vMFNMParameters, int]:
         """
         Fit vMFNM mixture using penalized EM.
 
@@ -43,7 +42,7 @@ class PenalizedEMOptimizer:
         Returns:
             (optimized_params, final_K)
         """
-        n, d = data.shape
+        _n, _d = data.shape
         params = self._copy_parameters(initial_params)
         beta: float = float(beta_init)
         K: int = int(params.K)
@@ -94,36 +93,44 @@ class PenalizedEMOptimizer:
         radii: NDArrayF,
         directions: NDArrayF,
         params: vMFNMParameters,
-        weights: NDArrayF,
+        weights: NDArrayF,  # noqa: ARG002 - applied in the M-step, not here
     ) -> NDArrayF:
-        """E-step: compute posterior responsibilities."""
+        """E-step: compute posterior responsibilities.
+
+        ``weights`` is accepted for symmetry with :meth:`_penalized_m_step`,
+        which is where importance weighting is actually applied.
+        """
         n = int(data.shape[0])
         K = int(params.K)
-        responsibilities: NDArrayF = np.zeros((n, K), dtype=np.float64)
 
-        for i in range(n):
-            r: float = float(radii[i])
-            a: NDArrayF = directions[i]
+        # Component likelihoods for every sample at once: one vectorised pass
+        # per component instead of a scalar pdf call per (sample, component).
+        comp_like: NDArrayF = np.zeros((n, K), dtype=np.float64)
+        for k in range(K):
+            nak_pdf: NDArrayF = np.asarray(
+                NakagamiDistribution.pdf(
+                    radii, float(params.m[k]), float(params.Omega[k])
+                ),
+                dtype=np.float64,
+            )
+            vmf_pdf: NDArrayF = self._vmf_pdf_many(
+                directions, params.mu[k], float(params.kappa[k])
+            )
+            comp_like[:, k] = float(params.pi[k]) * nak_pdf * vmf_pdf
 
-            # Component likelihoods
-            comp_like: NDArrayF = np.zeros(K, dtype=np.float64)
-            for k in range(K):
-                # Many pdfs are typed for arrays; pass 1-D array and extract scalar.
-                r_arr: NDArrayF = np.asarray([r], dtype=np.float64)
-                nak_pdf_arr: NDArrayF = np.asarray(
-                    NakagamiDistribution.pdf(r_arr, float(params.m[k]), float(params.Omega[k])),
-                    dtype=np.float64,
-                )
-                nakagami_pdf: float = float(nak_pdf_arr[0])
+        totals: NDArrayF = comp_like.sum(axis=1)
+        degenerate = totals <= 1e-15
 
-                vmf_pdf: float = self._vmf_pdf_single(a, params.mu[k], float(params.kappa[k]))
-                comp_like[k] = float(params.pi[k]) * nakagami_pdf * vmf_pdf
-
-            total_like: float = float(np.sum(comp_like))
-            if total_like > 1e-15:
-                responsibilities[i, :] = comp_like / total_like
-            else:
-                responsibilities[i, :] = 1.0 / float(K)
+        responsibilities: NDArrayF = np.empty((n, K), dtype=np.float64)
+        # Samples with negligible likelihood under every component fall back to
+        # a uniform assignment rather than dividing by ~0.
+        np.divide(
+            comp_like,
+            totals[:, None],
+            out=responsibilities,
+            where=~degenerate[:, None],
+        )
+        responsibilities[degenerate] = 1.0 / float(K)
 
         # Weighting by importance weights is done in M-step via weighted_resp
         return responsibilities
@@ -140,10 +147,10 @@ class PenalizedEMOptimizer:
         weights: NDArrayF,
         params: vMFNMParameters,
         beta: float,
-    ) -> Tuple[vMFNMParameters, int]:
+    ) -> tuple[vMFNMParameters, int]:
         """Penalized M-step with automatic component removal."""
-        n, d = data.shape
-        K = int(params.K)
+        _n, d = data.shape
+        int(params.K)
 
         # Weighted responsibilities
         weighted_resp: NDArrayF = (responsibilities * weights[:, np.newaxis]).astype(
@@ -226,8 +233,11 @@ class PenalizedEMOptimizer:
         # Normalize factor (total_weight/total_weight == 1), kept explicit for clarity
         norm_factor: float = 1.0
         for k in range(K):
-            penalty_term[k] = float(beta) * norm_factor * float(old_pi[k]) * (
-                float(np.log(max(float(old_pi[k]), 1e-15))) - float(entropy_current)
+            penalty_term[k] = (
+                float(beta)
+                * norm_factor
+                * float(old_pi[k])
+                * (float(np.log(max(float(old_pi[k]), 1e-15))) - float(entropy_current))
             )
 
         new_pi: NDArrayF = (pi_em + penalty_term).astype(np.float64, copy=False)
@@ -244,7 +254,7 @@ class PenalizedEMOptimizer:
 
     def _update_nakagami_parameters(
         self, radii: NDArrayF, responsibilities: NDArrayF
-    ) -> Tuple[float, float]:
+    ) -> tuple[float, float]:
         """Update Nakagami parameters using method of moments."""
         sum_resp: float = float(np.sum(responsibilities))
 
@@ -252,14 +262,14 @@ class PenalizedEMOptimizer:
             return 1.0, 1.0
 
         # Weighted moments
-        mean_r2: float = float(np.sum(responsibilities * (radii ** 2)) / sum_resp)
-        mean_r4: float = float(np.sum(responsibilities * (radii ** 4)) / sum_resp)
+        mean_r2: float = float(np.sum(responsibilities * (radii**2)) / sum_resp)
+        mean_r4: float = float(np.sum(responsibilities * (radii**4)) / sum_resp)
 
-        if mean_r4 <= mean_r2 ** 2:
+        if mean_r4 <= mean_r2**2:
             return 1.0, mean_r2
 
         # Method-of-moments estimators
-        m_est: float = float((mean_r2 ** 2) / (mean_r4 - mean_r2 ** 2))
+        m_est: float = float((mean_r2**2) / (mean_r4 - mean_r2**2))
         Omega_est: float = float(mean_r2)
 
         # Ensure valid parameters
@@ -270,7 +280,7 @@ class PenalizedEMOptimizer:
 
     def _update_vmf_parameters(
         self, directions: NDArrayF, responsibilities: NDArrayF
-    ) -> Tuple[NDArrayF, float]:
+    ) -> tuple[NDArrayF, float]:
         """Update von Mises-Fisher parameters."""
         d = int(directions.shape[1])
         sum_resp: float = float(np.sum(responsibilities))
@@ -305,55 +315,29 @@ class PenalizedEMOptimizer:
         if d == 2:
             # Circular case: approximations for kappa(R)
             if R < 0.53:
-                return float(2.0 * R + R ** 3 + 5.0 * (R ** 5) / 6.0)
+                return float(2.0 * R + R**3 + 5.0 * (R**5) / 6.0)
             elif R < 0.85:
                 return float(-0.4 + 1.39 * R + 0.43 / (1.0 - R))
             else:
-                denom = R ** 3 - 4.0 * R ** 2 + 3.0 * R
+                denom = R**3 - 4.0 * R**2 + 3.0 * R
                 if abs(denom) < 1e-12:
                     return 1_000.0
                 return float(1.0 / denom)
         else:
             # Higher dimensions: Banerjee et al. style approximation
-            return float(R * (d - R ** 2) / (1.0 - R ** 2))
+            return float(R * (d - R**2) / (1.0 - R**2))
 
     # -------------------------------------------------------------------------
     # Utilities
     # -------------------------------------------------------------------------
     def _vmf_pdf_single(self, x: NDArrayF, mu: NDArrayF, kappa: float) -> float:
         """von Mises–Fisher PDF for a single point w.r.t. surface area measure."""
-        d = int(x.shape[0])
+        x_arr: NDArrayF = np.asarray(x, dtype=np.float64).reshape(1, -1)
+        return float(self._vmf_pdf_many(x_arr, mu, kappa)[0])
 
-        if float(kappa) == 0.0:
-            # Uniform density on S^{d-1}: 1 / surface_area
-            surface_area: float = float(
-                2.0 * (math.pi ** (d / 2.0)) / float(gamma(d / 2.0))
-            )
-            return 1.0 / surface_area
-
-        nu: float = float(d / 2.0 - 1.0)
-
-        # Use exponentially-scaled Bessel to avoid overflow for large κ
-        ive_val: float = float(ive(nu, kappa))
-        if ive_val <= 0.0 or not np.isfinite(ive_val):
-            return 0.0
-
-        log_C = (
-            nu * float(np.log(kappa))
-            - (d / 2.0) * float(np.log(2.0 * math.pi))
-            - float(np.log(ive_val))
-            - float(kappa)
-        )
-        dot_val: float = float(np.dot(x, mu))
-        log_pdf = log_C + float(kappa) * dot_val
-
-        if not np.isfinite(log_pdf):
-            return 0.0
-        if log_pdf < -745.0:
-            return 0.0
-        if log_pdf > 700.0:
-            return float(np.exp(700.0))
-        return float(np.exp(log_pdf))
+    def _vmf_pdf_many(self, X: NDArrayF, mu: NDArrayF, kappa: float) -> NDArrayF:
+        """von Mises–Fisher PDF for a batch of unit rows w.r.t. surface area measure."""
+        return vmf_pdf_batch(X, mu, kappa)
 
     def _update_beta(self, params: vMFNMParameters, beta: float, K: int) -> float:
         """Update penalty parameter beta (simple adaptive heuristic)."""
@@ -368,7 +352,8 @@ class PenalizedEMOptimizer:
         # Heuristic terms
         # Encourage spreading when weights are peaky (max_pi large, min_pi small)
         term1: float = float(
-            (1.0 / float(K)) * np.sum(
+            (1.0 / float(K))
+            * np.sum(
                 np.exp(-eta * float(K) * np.abs(params.pi - float(np.mean(params.pi))))
             )
         )
@@ -384,7 +369,9 @@ class PenalizedEMOptimizer:
         """Compute weighted log-likelihood."""
         dist = vMFNMDistribution(params)
         pdf_vals: NDArrayF = np.asarray(dist.pdf(data), dtype=np.float64)
-        log_pdf: NDArrayF = np.log(np.maximum(pdf_vals, 1e-15)).astype(np.float64, copy=False)
+        log_pdf: NDArrayF = np.log(np.maximum(pdf_vals, 1e-15)).astype(
+            np.float64, copy=False
+        )
         return float(np.sum(weights * log_pdf))
 
     def _copy_parameters(self, params: vMFNMParameters) -> vMFNMParameters:

--- a/safe_ice/typing.py
+++ b/safe_ice/typing.py
@@ -1,0 +1,32 @@
+# safe_ice/typing.py
+"""Shared type aliases for the Safe-ICE public API.
+
+Keeping these in one place means the limit-state signature is written once and
+stays consistent across the core algorithm, the benchmark problems and the
+analysis helpers.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import numpy as np
+import numpy.typing as npt
+
+__all__ = ["LimitStateFunction", "NDArrayF", "RNGLike", "SeedLike"]
+
+#: The float64 ndarray used throughout the package.
+NDArrayF = npt.NDArray[np.float64]
+
+#: A limit-state function g(u): failure occurs where g(u) <= 0.
+#:
+#: Implementations receive an ``(n, d)`` batch of points and should return the
+#: matching ``(n,)`` array. Scalar-only functions are also accepted; callers
+#: fall back to evaluating row by row when a batch call does not work.
+LimitStateFunction = Callable[[NDArrayF], "float | NDArrayF"]
+
+#: Random generators accepted by the sampling helpers.
+RNGLike = np.random.Generator | np.random.RandomState
+
+#: Anything accepted by a ``random_state`` argument.
+SeedLike = int | np.random.Generator | None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,28 @@
+"""Shared pytest fixtures for the Safe-ICE test suite.
+
+Every test that needs randomness takes the :func:`rng` fixture rather than
+touching NumPy's global random state. Each test therefore gets its own
+generator seeded identically, which keeps failures reproducible and stops one
+test's draws from perturbing another's.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+#: Fixed seed for the per-test generator. Change it to shake out tests that
+#: only pass for one particular stream of random numbers.
+DEFAULT_SEED = 20240117
+
+
+@pytest.fixture
+def rng() -> np.random.Generator:
+    """A fresh, deterministically seeded NumPy random generator."""
+    return np.random.default_rng(DEFAULT_SEED)
+
+
+@pytest.fixture
+def seed() -> int:
+    """The seed used by :func:`rng`, for passing to ``random_state`` arguments."""
+    return DEFAULT_SEED

--- a/tests/test_numeric_helpers.py
+++ b/tests/test_numeric_helpers.py
@@ -1,0 +1,241 @@
+"""Regression tests for the vectorised numerical helpers.
+
+The mixture density and the EM E-step evaluate whole batches in a handful of
+NumPy passes. These tests pin the batched results to the scalar reference
+formulas so a future optimisation cannot silently change the numbers.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+from scipy.special import ive
+
+from safe_ice.core.parameters import vMFNMParameters
+from safe_ice.distributions._numeric import (
+    LOG_MAX,
+    RADIUS_FLOOR,
+    exp_clamped,
+    radii_and_directions,
+    sphere_surface_area,
+    vmf_pdf_batch,
+)
+from safe_ice.distributions.mixture import vMFNMDistribution
+from safe_ice.distributions.nakagami import NakagamiDistribution
+
+
+def reference_vmf_pdf(x, mu, kappa):
+    """Scalar von Mises-Fisher density, written directly from the definition."""
+    d = int(np.size(x))
+    if kappa <= 0.0:
+        return 1.0 / sphere_surface_area(d)
+    nu = d / 2.0 - 1.0
+    ive_val = float(ive(nu, kappa))
+    if ive_val <= 0.0 or not np.isfinite(ive_val):
+        return 0.0
+    log_norm = (
+        nu * math.log(kappa)
+        - (d / 2.0) * math.log(2.0 * math.pi)
+        - math.log(ive_val)
+        - kappa
+    )
+    log_pdf = log_norm + kappa * float(np.dot(x, mu))
+    if not np.isfinite(log_pdf):
+        return 0.0
+    if log_pdf < -745.0:
+        return 0.0
+    if log_pdf > 700.0:
+        return math.exp(700.0)
+    return math.exp(log_pdf)
+
+
+class TestRadiiAndDirections:
+    """Polar decomposition of a batch of points."""
+
+    def test_matches_per_row_computation(self, rng):
+        X = rng.standard_normal((50, 4)) * 3.0
+        radii, directions = radii_and_directions(X)
+
+        for i, row in enumerate(X):
+            assert radii[i] == pytest.approx(float(np.linalg.norm(row)), rel=1e-12)
+            assert directions[i] == pytest.approx(row / np.linalg.norm(row), rel=1e-12)
+
+    def test_directions_are_unit_vectors(self, rng):
+        X = rng.standard_normal((40, 6)) * 0.01
+        _, directions = radii_and_directions(X)
+        assert np.allclose(np.linalg.norm(directions, axis=1), 1.0)
+
+    def test_degenerate_rows_use_first_basis_vector(self):
+        X = np.zeros((3, 3))
+        X[1] = 1e-15  # below the floor
+        X[2, 0] = 1.0  # ordinary row
+        radii, directions = radii_and_directions(X)
+
+        assert radii[0] == RADIUS_FLOOR
+        assert radii[1] == RADIUS_FLOOR
+        assert np.array_equal(directions[0], [1.0, 0.0, 0.0])
+        assert np.array_equal(directions[1], [1.0, 0.0, 0.0])
+        assert radii[2] == pytest.approx(1.0)
+
+
+class TestExpClamped:
+    """Guard clauses around exponentiating log-densities."""
+
+    @pytest.mark.parametrize("bad", [np.inf, -np.inf, np.nan])
+    def test_non_finite_maps_to_zero(self, bad):
+        # +inf must yield 0 rather than saturating: the finiteness check comes first.
+        assert exp_clamped(np.array([bad])) == 0.0
+
+    def test_underflow_maps_to_zero(self):
+        assert exp_clamped(np.array([-800.0])) == 0.0
+
+    def test_saturates_instead_of_overflowing(self):
+        got = exp_clamped(np.array([5000.0]))
+        assert got == pytest.approx(math.exp(LOG_MAX))
+        assert np.isfinite(got).all()
+
+    def test_ordinary_values_pass_through(self, rng):
+        vals = rng.uniform(-700.0, 700.0, size=64)
+        assert exp_clamped(vals) == pytest.approx(np.exp(vals), rel=1e-12)
+
+
+class TestVmfPdfBatch:
+    """Batched vMF density against the scalar reference."""
+
+    @pytest.mark.parametrize("d", [2, 3, 5, 10])
+    @pytest.mark.parametrize("kappa", [0.0, 0.5, 7.5, 250.0])
+    def test_matches_reference(self, d, kappa, rng):
+        mu = rng.standard_normal(d)
+        mu /= np.linalg.norm(mu)
+        X = rng.standard_normal((25, d))
+        X /= np.linalg.norm(X, axis=1, keepdims=True)
+
+        got = vmf_pdf_batch(X, mu, kappa)
+        want = np.array([reference_vmf_pdf(x, mu, kappa) for x in X])
+        assert got == pytest.approx(want, rel=1e-12)
+
+    def test_zero_concentration_is_uniform(self, rng):
+        d = 4
+        X = rng.standard_normal((10, d))
+        X /= np.linalg.norm(X, axis=1, keepdims=True)
+        got = vmf_pdf_batch(X, np.eye(d)[0], 0.0)
+        assert got == pytest.approx(1.0 / sphere_surface_area(d))
+
+    @pytest.mark.parametrize("d", [2, 3, 7])
+    def test_integrates_to_one_over_the_sphere(self, d, rng):
+        # Uniform directions on S^{d-1} have density 1/area, so the mean of
+        # pdf/uniform_density estimates the integral over the sphere.
+        mu = np.eye(d)[0]
+        kappa = 3.0
+        X = rng.standard_normal((200_000, d))
+        X /= np.linalg.norm(X, axis=1, keepdims=True)
+        integral = np.mean(vmf_pdf_batch(X, mu, kappa)) * sphere_surface_area(d)
+        assert integral == pytest.approx(1.0, rel=0.02)
+
+
+class TestSphereSurfaceArea:
+    """Known closed-form values."""
+
+    def test_circle_and_sphere(self):
+        assert sphere_surface_area(2) == pytest.approx(2.0 * math.pi)
+        assert sphere_surface_area(3) == pytest.approx(4.0 * math.pi)
+
+
+class TestMixturePdfVectorisation:
+    """The batched mixture density must equal the per-sample formula."""
+
+    @pytest.mark.parametrize("d", [2, 3, 6])
+    @pytest.mark.parametrize("K", [1, 4])
+    def test_matches_per_sample_loop(self, d, K, rng):
+        pi = rng.dirichlet(np.ones(K))
+        params = vMFNMParameters(
+            pi=pi,
+            m=rng.uniform(0.5, 5.0, size=K),
+            Omega=rng.uniform(0.5, 10.0, size=K),
+            mu=rng.standard_normal((K, d)),
+            kappa=rng.uniform(0.0, 40.0, size=K),
+        )
+        dist = vMFNMDistribution(params)
+
+        X = rng.standard_normal((40, d)) * 2.0
+        got = dist.pdf(X)
+
+        # Reference: the original per-sample, per-component formulation.
+        want = np.zeros(X.shape[0])
+        for i, row in enumerate(X):
+            r = float(np.linalg.norm(row))
+            a = row / r if r > RADIUS_FLOOR else np.eye(d)[0]
+            r = max(r, RADIUS_FLOOR)
+            jacobian = r ** (d - 1)
+            total = 0.0
+            for k in range(K):
+                nak = float(
+                    NakagamiDistribution.pdf(
+                        r, float(params.m[k]), float(params.Omega[k])
+                    )
+                )
+                vmf = reference_vmf_pdf(a, params.mu[k], float(params.kappa[k]))
+                total += float(params.pi[k]) * nak * vmf / jacobian
+            want[i] = total
+
+        assert got == pytest.approx(want, rel=1e-10)
+
+    def test_single_row_input_is_accepted(self, rng):
+        d, K = 3, 2
+        params = vMFNMParameters(
+            pi=np.full(K, 1.0 / K),
+            m=np.full(K, 2.0),
+            Omega=np.full(K, 3.0),
+            mu=rng.standard_normal((K, d)),
+            kappa=np.full(K, 1.5),
+        )
+        dist = vMFNMDistribution(params)
+        row = rng.standard_normal(d)
+
+        assert dist.pdf(row) == pytest.approx(dist.pdf(row.reshape(1, -1)))
+
+
+class TestEStepVectorisation:
+    """Responsibilities must be a valid posterior for every sample."""
+
+    def test_rows_sum_to_one(self, rng):
+        from safe_ice.optimization.penalized_em import PenalizedEMOptimizer
+
+        d, K, n = 4, 3, 60
+        params = vMFNMParameters(
+            pi=rng.dirichlet(np.ones(K)),
+            m=rng.uniform(0.5, 4.0, size=K),
+            Omega=rng.uniform(0.5, 8.0, size=K),
+            mu=rng.standard_normal((K, d)),
+            kappa=rng.uniform(0.0, 20.0, size=K),
+        )
+        X = rng.standard_normal((n, d)) * 2.0
+        radii, directions = radii_and_directions(X)
+        weights = rng.uniform(0.0, 2.0, size=n)
+
+        resp = PenalizedEMOptimizer()._e_step(X, radii, directions, params, weights)
+
+        assert resp.shape == (n, K)
+        assert np.all(resp >= 0.0)
+        assert np.allclose(resp.sum(axis=1), 1.0)
+
+    def test_unreachable_samples_fall_back_to_uniform(self, rng):
+        from safe_ice.optimization.penalized_em import PenalizedEMOptimizer
+
+        d, K = 3, 4
+        params = vMFNMParameters(
+            pi=np.full(K, 1.0 / K),
+            m=np.full(K, 2.0),
+            Omega=np.full(K, 1.0),
+            mu=rng.standard_normal((K, d)),
+            kappa=np.full(K, 1.0),
+        )
+        # A radius this large has negligible density under every component.
+        X = np.full((2, d), 1e6)
+        radii, directions = radii_and_directions(X)
+        weights = np.ones(2)
+
+        resp = PenalizedEMOptimizer()._e_step(X, radii, directions, params, weights)
+        assert resp == pytest.approx(np.full((2, K), 1.0 / K))


### PR DESCRIPTION
The mixture PDF, the penalized-EM E-step and the heavy-tailed density each looped in Python over every (sample, component) pair, calling scalar PDFs. `NakagamiDistribution.pdf` alone was called 4.2 million times in a single two-iteration run.

Each now does one vectorised pass per component.

A 2-D problem at `N=1000, max_iterations=5` goes from **108.7s to 0.5s**. The `d=5` and `d=10` cases previously did not finish at all.

Results are unchanged to ~1e-13 relative. I captured baselines from the current implementation before changing anything and compared across 48 parameter combinations, plus 45 more for the heavy-tailed density. `tests/test_numeric_helpers.py` pins the batched code to the scalar reference formulas so this cannot drift.

First of 7 stacked PRs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Vectorizes mixture density evaluation, the heavy‑tailed component, and the penalized‑EM E‑step to remove per‑(sample, component) Python loops. A 2‑D run at N=1000, max_iterations=5 drops from 108.7s to 0.5s with results unchanged (~1e‑13 relative); logs now print "sigma"/"lambda" instead of Greek symbols.

- Introduces `safe_ice/distributions/_numeric.py` with `radii_and_directions`, `vmf_pdf_batch`, and `exp_clamped`; `mixture.pdf`, `optimization/penalized_em._e_step`, and the heavy‑tailed density in `core/safe_ice.py` now do one vectorized pass per component.
- Adds `tests/test_numeric_helpers.py` to pin batched results to scalar references (vMF normalization, edge cases for tiny radii and Bessel saturation) and `tests/conftest.py` for deterministic RNG.
- Backward compatibility: `sphere_surface_area` moved but re‑exported from `mixture`; public APIs are unchanged aside from typing clarifications; no migration required.
- Edge‑case handling retained: radii ≤1e‑12 map to e1 and clamp; responsibilities fall back to uniform when total likelihood ≤1e‑15; exponentiation saturates/zeros exactly as before.

<sup>Written for commit 0daf44f47139d1ad85059c6a61bb5bb84a73d18a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/adaptive-importance-sampling-ice/pull/61?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

