### PR TITLE
chore: fix all ruff findings and make mypy strict pass

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,34 +1,40 @@
+# Install with: pre-commit install
+# Run over everything with: pre-commit run --all-files
+# Refresh pinned versions with: pre-commit autoupdate
+
+default_language_version:
+  python: python3.12
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v6.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-yaml
+      - id: check-toml
       - id: check-added-large-files
       - id: check-merge-conflict
-      - id: check-toml
+      - id: check-case-conflict
       - id: debug-statements
+      - id: mixed-line-ending
+        args: [--fix=lf]
 
-  - repo: https://github.com/psf/black
-    rev: 23.12.1
-    hooks:
-      - id: black
-
-  - repo: https://github.com/pycqa/isort
-    rev: 5.13.2
-    hooks:
-      - id: isort
-
+  # Ruff replaces black, isort and flake8: one tool for lint and formatting.
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.11
+    rev: v0.14.14
     hooks:
-      - id: ruff
+      - id: ruff-check
         args: [--fix, --exit-non-zero-on-fix]
+      - id: ruff-format
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.8.0
+    rev: v1.19.1
     hooks:
       - id: mypy
-        additional_dependencies: [types-all]
-        args: [--config-file=pyproject.toml]
+        # mypy needs the real dependencies to check against, and `files` in
+        # pyproject.toml already scopes it to the package.
+        additional_dependencies:
+          - numpy>=1.26
+          - scipy>=1.11
+        pass_filenames: false

--- a/benchmarks/architecture_config.py
+++ b/benchmarks/architecture_config.py
@@ -3,14 +3,14 @@ Configuration for architecture diagram generation
 """
 
 # Modules to exclude from diagrams
-EXCLUDED_MODULES = ['migrations', 'tests', '__pycache__']
+EXCLUDED_MODULES = ["migrations", "tests", "__pycache__"]
 
 # Classes to highlight in diagrams
-IMPORTANT_CLASSES = ['User', 'Order', 'Product']
+IMPORTANT_CLASSES = ["User", "Order", "Product"]
 
 # Custom module groupings
 MODULE_GROUPS = {
-    'api': ['routes', 'controllers', 'endpoints'],
-    'core': ['models', 'schemas', 'services'],
-    'utils': ['helpers', 'validators', 'decorators']
+    "api": ["routes", "controllers", "endpoints"],
+    "core": ["models", "schemas", "services"],
+    "utils": ["helpers", "validators", "decorators"],
 }

--- a/examples/advanced_features.py
+++ b/examples/advanced_features.py
@@ -1,21 +1,31 @@
 """Demonstration of advanced Safe-ICE features."""
 
-import numpy as np
+import sys
+
 import matplotlib.pyplot as plt
+import numpy as np
+
+# This script prints mathematical notation. Windows consoles still default to a
+# legacy code page, where that would raise UnicodeEncodeError, so make sure
+# stdout can carry it.
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+
 from safe_ice import AdaptiveSafeICE
 from safe_ice.problems.advanced_problems import (
-    TimeVariantProblem,
-    SystemReliabilityProblem,
+    NetworkReliabilityProblem,
     StochasticProcessProblem,
-    NetworkReliabilityProblem
+    SystemReliabilityProblem,
+    TimeVariantProblem,
 )
 
 # Check for optional dependencies
 try:
     from safe_ice.analysis.interactive_visualization import (
         InteractiveVisualizer,
-        create_interactive_dashboard
+        create_interactive_dashboard,
     )
+
     INTERACTIVE_AVAILABLE = True
 except ImportError:
     INTERACTIVE_AVAILABLE = False
@@ -36,14 +46,14 @@ def demo_adaptive_safe_ice():
 
         # Multiple failure modes
         g1 = 3.5 - np.linalg.norm(u[:, :2], axis=1)
-        g2 = 2.5 + u[:, 0] - 0.1 * u[:, 1]**2
+        g2 = 2.5 + u[:, 0] - 0.1 * u[:, 1] ** 2
         g3 = 3.0 - np.abs(u[:, 0] + u[:, 1])
 
         return np.minimum(np.minimum(g1, g2), g3)
 
     # Test different dimensions
     for d in [2, 5, 10]:
-        print(f"\n{'='*70}")
+        print(f"\n{'=' * 70}")
         print(f"Dimension: {d}")
         print("-" * 70)
 
@@ -53,22 +63,24 @@ def demo_adaptive_safe_ice():
             dimension=d,
             N=None,  # Auto-computed based on dimension
             auto_tune=True,
-            adaptive_schedule=True
+            adaptive_schedule=True,
         )
 
-        print(f"Auto-tuned parameters:")
+        print("Auto-tuned parameters:")
         print(f"  N: {ice.N}")
         print(f"  K0: {ice.K0}")
         print(f"  delta_target: {ice.delta_target}")
         print(f"  delta_star: {ice.delta_star}")
 
         # Run algorithm
-        pf, results = ice.run(verbose=True)
+        _pf, _results = ice.run(verbose=True)
 
-        print(f"\nAdaptive metrics:")
+        print("\nAdaptive metrics:")
         if ice.beta_history:
             print(f"  Average β: {np.mean(ice.beta_history):.3f}")
-            print(f"  β range: [{min(ice.beta_history):.3f}, {max(ice.beta_history):.3f}]")
+            print(
+                f"  β range: [{min(ice.beta_history):.3f}, {max(ice.beta_history):.3f}]"
+            )
 
 
 def demo_time_variant_problem():
@@ -88,52 +100,44 @@ def demo_time_variant_problem():
     time_points = np.linspace(0, 20, 10)
 
     # Create time-variant problem
-    tv_problem = TimeVariantProblem(
-        limit_state_func=g_time,
-        time_points=time_points
-    )
+    tv_problem = TimeVariantProblem(limit_state_func=g_time, time_points=time_points)
 
     # Get series system (fails if fails at ANY time)
     g_series = tv_problem.get_series_system_limit_state()
 
     # Run Safe-ICE
-    ice = AdaptiveSafeICE(
-        limit_state_function=g_series,
-        dimension=2,
-        auto_tune=True
-    )
+    ice = AdaptiveSafeICE(limit_state_function=g_series, dimension=2, auto_tune=True)
 
     print(f"Analyzing series system over {len(time_points)} time points...")
-    pf, results = ice.run(verbose=False)
+    pf, _results = ice.run(verbose=False)
     print(f"Failure probability (series): {pf:.6e}")
 
     # Get parallel system (fails only if fails at ALL times)
     g_parallel = tv_problem.get_parallel_system_limit_state()
 
     ice_parallel = AdaptiveSafeICE(
-        limit_state_function=g_parallel,
-        dimension=2,
-        auto_tune=True
+        limit_state_function=g_parallel, dimension=2, auto_tune=True
     )
 
     pf_parallel, _ = ice_parallel.run(verbose=False)
     print(f"Failure probability (parallel): {pf_parallel:.6e}")
 
     # Cumulative damage
-    def damage_func(u, t):
+    def damage_func(u, t):  # noqa: ARG001 - `t` is part of the damage-model signature
         """Fatigue damage accumulation."""
-        stress = 2.0 + 0.5 * np.linalg.norm(u[:2]) if u.ndim > 1 else 2.0 + 0.5 * np.linalg.norm(u)
+        stress = (
+            2.0 + 0.5 * np.linalg.norm(u[:2])
+            if u.ndim > 1
+            else 2.0 + 0.5 * np.linalg.norm(u)
+        )
         return (stress / 10.0) ** 3  # Miner's rule
 
     g_damage = tv_problem.get_cumulative_damage_limit_state(
-        damage_func=damage_func,
-        threshold=1.0
+        damage_func=damage_func, threshold=1.0
     )
 
     ice_damage = AdaptiveSafeICE(
-        limit_state_function=g_damage,
-        dimension=2,
-        auto_tune=True
+        limit_state_function=g_damage, dimension=2, auto_tune=True
     )
 
     pf_damage, _ = ice_damage.run(verbose=False)
@@ -154,21 +158,18 @@ def demo_system_reliability():
         return 2.5 - np.abs(u[1] if u.ndim == 1 else u[:, 1]) if len(u) > 1 else 2.5
 
     def component3(u):
-        return 4.0 - np.linalg.norm(u[:2] if u.ndim == 2 else u, axis=-1 if u.ndim == 2 else None)
+        return 4.0 - np.linalg.norm(
+            u[:2] if u.ndim == 2 else u, axis=-1 if u.ndim == 2 else None
+        )
 
     components = [component1, component2, component3]
 
     # Define correlation matrix
-    correlation = np.array([
-        [1.0, 0.5, 0.3],
-        [0.5, 1.0, 0.4],
-        [0.3, 0.4, 1.0]
-    ])
+    correlation = np.array([[1.0, 0.5, 0.3], [0.5, 1.0, 0.4], [0.3, 0.4, 1.0]])
 
     # Create system problem
     sys_problem = SystemReliabilityProblem(
-        component_funcs=components,
-        correlation_matrix=correlation
+        component_funcs=components, correlation_matrix=correlation
     )
 
     # Analyze different system types
@@ -176,14 +177,12 @@ def demo_system_reliability():
         ("Series", sys_problem.get_series_system()),
         ("Parallel", sys_problem.get_parallel_system()),
         ("2-out-of-3", sys_problem.get_k_out_of_n_system(k=2)),
-        ("Correlated Series", sys_problem.get_correlated_system("series"))
+        ("Correlated Series", sys_problem.get_correlated_system("series")),
     ]
 
     for name, g_system in system_types:
         ice = AdaptiveSafeICE(
-            limit_state_function=g_system,
-            dimension=2,
-            auto_tune=True
+            limit_state_function=g_system, dimension=2, auto_tune=True
         )
 
         pf, _ = ice.run(verbose=False)
@@ -210,46 +209,43 @@ def demo_stochastic_process():
 
     # Create stochastic process problem
     sp_problem = StochasticProcessProblem(
-        mean_func=mean_func,
-        cov_func=cov_func,
-        mesh_points=mesh_points
+        mean_func=mean_func, cov_func=cov_func, mesh_points=mesh_points
     )
 
     # Get excursion limit state
     threshold = 5.0
     g_excursion = sp_problem.get_excursion_limit_state(
-        threshold=threshold,
-        n_kl_terms=10
+        threshold=threshold, n_kl_terms=10
     )
 
     # Run Safe-ICE
     ice = AdaptiveSafeICE(
         limit_state_function=g_excursion,
         dimension=10,  # Using 10 KL terms
-        auto_tune=True
+        auto_tune=True,
     )
 
     print(f"Analyzing excursion over threshold {threshold}...")
     print(f"Using {10} KL expansion terms")
-    pf, results = ice.run(verbose=False)
+    pf, _results = ice.run(verbose=False)
     print(f"Excursion probability: {pf:.6e}")
 
     # Visualize KL eigenvalues
     plt.figure(figsize=(10, 4))
     plt.subplot(1, 2, 1)
-    plt.semilogy(sp_problem.eigenvalues[:10], 'o-')
-    plt.xlabel('Mode')
-    plt.ylabel('Eigenvalue')
-    plt.title('KL Expansion Eigenvalues')
+    plt.semilogy(sp_problem.eigenvalues[:10], "o-")
+    plt.xlabel("Mode")
+    plt.ylabel("Eigenvalue")
+    plt.title("KL Expansion Eigenvalues")
     plt.grid(True)
 
     # Visualize eigenvectors
     plt.subplot(1, 2, 2)
     for i in range(min(3, len(sp_problem.eigenvectors[0]))):
-        plt.plot(mesh_points, sp_problem.eigenvectors[:, i], label=f'Mode {i+1}')
-    plt.xlabel('x')
-    plt.ylabel('Eigenfunction')
-    plt.title('KL Expansion Eigenfunctions')
+        plt.plot(mesh_points, sp_problem.eigenvectors[:, i], label=f"Mode {i + 1}")
+    plt.xlabel("x")
+    plt.ylabel("Eigenfunction")
+    plt.title("KL Expansion Eigenfunctions")
     plt.legend()
     plt.grid(True)
     plt.tight_layout()
@@ -270,37 +266,34 @@ def demo_network_reliability():
     #   | / \ |
     #   |/   \|
     #   3 --- 4
-    adjacency = np.array([
-        [0, 1, 1, 1, 0],  # Node 0 connections
-        [1, 0, 1, 0, 1],  # Node 1 connections
-        [1, 1, 0, 1, 1],  # Node 2 connections
-        [1, 0, 1, 0, 1],  # Node 3 connections
-        [0, 1, 1, 1, 0]   # Node 4 connections
-    ])
+    adjacency = np.array(
+        [
+            [0, 1, 1, 1, 0],  # Node 0 connections
+            [1, 0, 1, 0, 1],  # Node 1 connections
+            [1, 1, 0, 1, 1],  # Node 2 connections
+            [1, 0, 1, 0, 1],  # Node 3 connections
+            [0, 1, 1, 1, 0],  # Node 4 connections
+        ]
+    )
 
     # Create network problem
-    net_problem = NetworkReliabilityProblem(
-        adjacency_matrix=adjacency
-    )
+    net_problem = NetworkReliabilityProblem(adjacency_matrix=adjacency)
 
     # Get connectivity limit state (0 to 4)
-    g_connectivity = net_problem.get_connectivity_limit_state(
-        source=0,
-        target=4
-    )
+    g_connectivity = net_problem.get_connectivity_limit_state(source=0, target=4)
 
     # Run Safe-ICE
     ice = AdaptiveSafeICE(
         limit_state_function=g_connectivity,
         dimension=7,  # Number of edges
-        auto_tune=True
+        auto_tune=True,
     )
 
-    print(f"Analyzing network connectivity (0 → 4)...")
+    print("Analyzing network connectivity (0 → 4)...")
     print(f"Network has {net_problem.n_nodes} nodes and {net_problem.n_edges} edges")
-    pf, results = ice.run(verbose=False)
+    pf, _results = ice.run(verbose=False)
     print(f"Disconnection probability: {pf:.6e}")
-    print(f"Reliability: {1-pf:.6f}")
+    print(f"Reliability: {1 - pf:.6f}")
 
 
 def demo_interactive_visualization():
@@ -318,14 +311,11 @@ def demo_interactive_visualization():
         return 3.0 - np.linalg.norm(u, axis=-1)
 
     ice = AdaptiveSafeICE(
-        limit_state_function=g,
-        dimension=3,
-        N=1000,
-        max_iterations=10
+        limit_state_function=g, dimension=3, N=1000, max_iterations=10
     )
 
     print("Running Safe-ICE for visualization...")
-    pf, results = ice.run(verbose=False)
+    _pf, results = ice.run(verbose=False)
 
     # Create interactive visualizer
     viz = InteractiveVisualizer()
@@ -333,11 +323,11 @@ def demo_interactive_visualization():
     print("\nCreating interactive plots...")
 
     # 1. Interactive convergence plot
-    fig1 = viz.plot_convergence_interactive(results, show=False)
+    viz.plot_convergence_interactive(results, show=False)
     print("  ✓ Convergence plot created")
 
     # 2. 3D sample visualization
-    fig2 = viz.plot_sample_evolution_3d(results, show=False)
+    viz.plot_sample_evolution_3d(results, show=False)
     print("  ✓ 3D sample plot created")
 
     # 3. Comprehensive dashboard

--- a/examples/basic_usage.py
+++ b/examples/basic_usage.py
@@ -1,7 +1,16 @@
 """Basic usage example of Safe-ICE algorithm."""
 
-import numpy as np
+import sys
+
 import matplotlib.pyplot as plt
+import numpy as np
+
+# This script prints mathematical notation. Windows consoles still default to a
+# legacy code page, where that would raise UnicodeEncodeError, so make sure
+# stdout can carry it.
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+
 from safe_ice import SafeICE
 
 
@@ -28,10 +37,10 @@ def main():
     ice = SafeICE(
         limit_state_function=sphere_limit_state,
         dimension=2,
-        N=1000,               # Samples per iteration
-        max_iterations=10,    # Maximum iterations
-        delta_target=3.0,     # Target rarity parameter
-        delta_star=1.5        # Rarity increment threshold
+        N=1000,  # Samples per iteration
+        max_iterations=10,  # Maximum iterations
+        delta_target=3.0,  # Target rarity parameter
+        delta_star=1.5,  # Rarity increment threshold
     )
 
     print("\nRunning Safe-ICE algorithm...")
@@ -45,31 +54,31 @@ def main():
     print("RESULTS")
     print("=" * 60)
     print(f"Estimated failure probability: {pf:.6e}")
-    print(f"Analytical failure probability: 1.11e-2")
+    print("Analytical failure probability: 1.11e-2")
     print(f"Relative error: {abs(pf - 0.0111) / 0.0111:.2%}")
     print(f"\nTotal samples used: {len(results['final_samples'])}")
     print(f"Number of iterations: {len(results['iterations'])}")
 
     # Analyze convergence
-    metrics = results['convergence_metrics']
-    print(f"\nConvergence metrics:")
+    metrics = results["convergence_metrics"]
+    print("\nConvergence metrics:")
     print(f"  Final CV: {metrics['cv_values'][-1]:.4f}")
     print(f"  Final delta: {metrics['delta_values'][-1]:.4f}")
 
     # Component evolution
-    print(f"\nComponent evolution:")
-    for i, iter_data in enumerate(results['iterations']):
-        print(f"  Iteration {i+1}: K = {iter_data['K']} components")
+    print("\nComponent evolution:")
+    for i, iter_data in enumerate(results["iterations"]):
+        print(f"  Iteration {i + 1}: K = {iter_data['K']} components")
 
     # Visualize results for 2D problem
-    if results['final_samples'].shape[1] == 2:
+    if results["final_samples"].shape[1] == 2:
         visualize_2d_results(results, sphere_limit_state)
 
 
-def visualize_2d_results(results, limit_state_func):
+def visualize_2d_results(results, limit_state_func):  # noqa: ARG001 - kept for call-site symmetry
     """Visualize results for 2D problems."""
-    samples = results['final_samples']
-    g_values = results['final_g_values']
+    samples = results["final_samples"]
+    g_values = results["final_g_values"]
 
     # Separate failure and safe samples
     failure_mask = g_values <= 0
@@ -77,52 +86,64 @@ def visualize_2d_results(results, limit_state_func):
     failure_samples = samples[failure_mask]
 
     # Create figure
-    fig, axes = plt.subplots(1, 3, figsize=(15, 5))
+    _fig, axes = plt.subplots(1, 3, figsize=(15, 5))
 
     # Plot 1: Sample distribution
     ax = axes[0]
     if len(safe_samples) > 0:
-        ax.scatter(safe_samples[:, 0], safe_samples[:, 1],
-                  c='blue', alpha=0.5, s=10, label='Safe')
+        ax.scatter(
+            safe_samples[:, 0],
+            safe_samples[:, 1],
+            c="blue",
+            alpha=0.5,
+            s=10,
+            label="Safe",
+        )
     if len(failure_samples) > 0:
-        ax.scatter(failure_samples[:, 0], failure_samples[:, 1],
-                  c='red', alpha=0.8, s=20, label='Failure')
+        ax.scatter(
+            failure_samples[:, 0],
+            failure_samples[:, 1],
+            c="red",
+            alpha=0.8,
+            s=20,
+            label="Failure",
+        )
 
     # Add failure boundary
-    theta = np.linspace(0, 2*np.pi, 100)
+    theta = np.linspace(0, 2 * np.pi, 100)
     r = 3.0  # beta value
     x_boundary = r * np.cos(theta)
     y_boundary = r * np.sin(theta)
-    ax.plot(x_boundary, y_boundary, 'k-', linewidth=2, label='Failure boundary')
+    ax.plot(x_boundary, y_boundary, "k-", linewidth=2, label="Failure boundary")
 
-    ax.set_xlabel('u₁')
-    ax.set_ylabel('u₂')
-    ax.set_title('Sample Distribution')
+    ax.set_xlabel("u₁")
+    ax.set_ylabel("u₂")
+    ax.set_title("Sample Distribution")
     ax.legend()
     ax.grid(True, alpha=0.3)
-    ax.axis('equal')
+    ax.axis("equal")
     ax.set_xlim(-5, 5)
     ax.set_ylim(-5, 5)
 
     # Plot 2: Convergence
     ax = axes[1]
-    metrics = results['convergence_metrics']
-    iterations = range(1, len(metrics['cv_values']) + 1)
+    metrics = results["convergence_metrics"]
+    iterations = range(1, len(metrics["cv_values"]) + 1)
 
-    ax.plot(iterations, metrics['cv_values'], 'b-o', label='CV')
-    ax.set_xlabel('Iteration')
-    ax.set_ylabel('Coefficient of Variation')
-    ax.set_title('Convergence History')
+    ax.plot(iterations, metrics["cv_values"], "b-o", label="CV")
+    ax.set_xlabel("Iteration")
+    ax.set_ylabel("Coefficient of Variation")
+    ax.set_title("Convergence History")
     ax.grid(True, alpha=0.3)
     ax.legend()
 
     # Plot 3: G-values histogram
     ax = axes[2]
-    ax.hist(g_values, bins=50, alpha=0.7, color='skyblue', edgecolor='black')
-    ax.axvline(x=0, color='red', linestyle='--', linewidth=2, label='Failure threshold')
-    ax.set_xlabel('g(u)')
-    ax.set_ylabel('Frequency')
-    ax.set_title('Limit State Values Distribution')
+    ax.hist(g_values, bins=50, alpha=0.7, color="skyblue", edgecolor="black")
+    ax.axvline(x=0, color="red", linestyle="--", linewidth=2, label="Failure threshold")
+    ax.set_xlabel("g(u)")
+    ax.set_ylabel("Frequency")
+    ax.set_title("Limit State Values Distribution")
     ax.legend()
     ax.grid(True, alpha=0.3)
 
@@ -130,7 +151,9 @@ def visualize_2d_results(results, limit_state_func):
     plt.show()
 
     print("\nVisualization complete!")
-    print(f"Failure samples: {len(failure_samples)} / {len(samples)} = {len(failure_samples)/len(samples):.1%}")
+    print(
+        f"Failure samples: {len(failure_samples)} / {len(samples)} = {len(failure_samples) / len(samples):.1%}"
+    )
 
 
 if __name__ == "__main__":

--- a/examples/benchmark_comparison.py
+++ b/examples/benchmark_comparison.py
@@ -1,11 +1,13 @@
 """Compare Safe-ICE performance with standard Monte Carlo on benchmark problems."""
 
-import numpy as np
 import time
+
 import matplotlib.pyplot as plt
+import numpy as np
+
 from safe_ice import SafeICE
-from safe_ice.problems.benchmarks import BenchmarkProblems
 from safe_ice.analysis.performance import PerformanceEvaluator
+from safe_ice.problems.benchmarks import BenchmarkProblems
 
 
 def run_safe_ice(limit_state_func, dimension, n_samples, max_iterations):
@@ -14,7 +16,7 @@ def run_safe_ice(limit_state_func, dimension, n_samples, max_iterations):
         limit_state_function=limit_state_func,
         dimension=dimension,
         N=n_samples,
-        max_iterations=max_iterations
+        max_iterations=max_iterations,
     )
 
     start_time = time.time()
@@ -29,7 +31,7 @@ def run_monte_carlo(limit_state_func, dimension, n_samples):
     start_time = time.time()
 
     # Generate standard normal samples
-    u = np.random.randn(n_samples, dimension)
+    u = np.random.default_rng(0).standard_normal(n_samples, dimension)
 
     # Evaluate limit state function
     g_values = limit_state_func(u)
@@ -39,10 +41,7 @@ def run_monte_carlo(limit_state_func, dimension, n_samples):
     pf = n_failures / n_samples
 
     # Compute standard error
-    if n_failures > 0:
-        std_error = np.sqrt((1 - pf) / (n_failures))
-    else:
-        std_error = 0
+    std_error = np.sqrt((1 - pf) / n_failures) if n_failures > 0 else 0
 
     elapsed_time = time.time() - start_time
 
@@ -58,28 +57,28 @@ def main():
 
     # Initialize benchmark problems
     problems = BenchmarkProblems()
-    evaluator = PerformanceEvaluator()
+    PerformanceEvaluator()
 
     # Define test cases
     test_cases = [
         {
-            'name': 'Four-Mode Series System',
-            'func': problems.four_mode_series_system(),
-            'dimension': 2,
-            'ref_pf': 1.22e-5,
-            'n_samples_ice': 1000,
-            'n_samples_mc': 1000000,
-            'max_iterations': 15
+            "name": "Four-Mode Series System",
+            "func": problems.four_mode_series_system(),
+            "dimension": 2,
+            "ref_pf": 1.22e-5,
+            "n_samples_ice": 1000,
+            "n_samples_mc": 1000000,
+            "max_iterations": 15,
         },
         {
-            'name': 'Three-Mode Problem',
-            'func': problems.three_mode_problem(),
-            'dimension': 2,
-            'ref_pf': 2.3e-3,
-            'n_samples_ice': 500,
-            'n_samples_mc': 100000,
-            'max_iterations': 10
-        }
+            "name": "Three-Mode Problem",
+            "func": problems.three_mode_problem(),
+            "dimension": 2,
+            "ref_pf": 2.3e-3,
+            "n_samples_ice": 500,
+            "n_samples_mc": 100000,
+            "max_iterations": 10,
+        },
     ]
 
     results_comparison = []
@@ -94,38 +93,40 @@ def main():
         # Run Safe-ICE
         print(f"\nRunning Safe-ICE (N={test_case['n_samples_ice']})...")
         pf_ice, results_ice, time_ice = run_safe_ice(
-            test_case['func'],
-            test_case['dimension'],
-            test_case['n_samples_ice'],
-            test_case['max_iterations']
+            test_case["func"],
+            test_case["dimension"],
+            test_case["n_samples_ice"],
+            test_case["max_iterations"],
         )
 
-        total_samples_ice = len(results_ice['final_samples'])
-        cv_ice = results_ice['convergence_metrics']['cv_values'][-1]
+        total_samples_ice = len(results_ice["final_samples"])
+        cv_ice = results_ice["convergence_metrics"]["cv_values"][-1]
 
         print(f"  Pf estimate: {pf_ice:.6e}")
         print(f"  Total samples: {total_samples_ice}")
         print(f"  Final CV: {cv_ice:.4f}")
         print(f"  Time: {time_ice:.2f} seconds")
-        print(f"  Relative error: {abs(pf_ice - test_case['ref_pf']) / test_case['ref_pf']:.2%}")
+        print(
+            f"  Relative error: {abs(pf_ice - test_case['ref_pf']) / test_case['ref_pf']:.2%}"
+        )
 
         # Run Monte Carlo
         print(f"\nRunning Monte Carlo (N={test_case['n_samples_mc']})...")
         pf_mc, std_mc, time_mc = run_monte_carlo(
-            test_case['func'],
-            test_case['dimension'],
-            test_case['n_samples_mc']
+            test_case["func"], test_case["dimension"], test_case["n_samples_mc"]
         )
 
         print(f"  Pf estimate: {pf_mc:.6e}")
         print(f"  Standard error: {std_mc:.4f}")
         print(f"  Time: {time_mc:.2f} seconds")
         if pf_mc > 0:
-            print(f"  Relative error: {abs(pf_mc - test_case['ref_pf']) / test_case['ref_pf']:.2%}")
+            print(
+                f"  Relative error: {abs(pf_mc - test_case['ref_pf']) / test_case['ref_pf']:.2%}"
+            )
 
         # Compute efficiency metrics
-        efficiency_ratio = (test_case['n_samples_mc'] / total_samples_ice)
-        speedup = time_mc / time_ice if time_ice > 0 else float('inf')
+        efficiency_ratio = test_case["n_samples_mc"] / total_samples_ice
+        speedup = time_mc / time_ice if time_ice > 0 else float("inf")
 
         print(f"\n{'EFFICIENCY METRICS':^70}")
         print("-" * 70)
@@ -133,18 +134,20 @@ def main():
         print(f"  Computational speedup: {speedup:.1f}x")
 
         # Store results
-        results_comparison.append({
-            'problem': test_case['name'],
-            'pf_ice': pf_ice,
-            'pf_mc': pf_mc,
-            'pf_ref': test_case['ref_pf'],
-            'samples_ice': total_samples_ice,
-            'samples_mc': test_case['n_samples_mc'],
-            'time_ice': time_ice,
-            'time_mc': time_mc,
-            'efficiency': efficiency_ratio,
-            'speedup': speedup
-        })
+        results_comparison.append(
+            {
+                "problem": test_case["name"],
+                "pf_ice": pf_ice,
+                "pf_mc": pf_mc,
+                "pf_ref": test_case["ref_pf"],
+                "samples_ice": total_samples_ice,
+                "samples_mc": test_case["n_samples_mc"],
+                "time_ice": time_ice,
+                "time_mc": time_mc,
+                "efficiency": efficiency_ratio,
+                "speedup": speedup,
+            }
+        )
 
     # Visualize comparison
     visualize_comparison(results_comparison)
@@ -154,81 +157,103 @@ def visualize_comparison(results):
     """Create comparison plots."""
     n_problems = len(results)
 
-    fig, axes = plt.subplots(2, 2, figsize=(12, 10))
+    _fig, axes = plt.subplots(2, 2, figsize=(12, 10))
 
     # Plot 1: Failure probability estimates
     ax = axes[0, 0]
     x_pos = np.arange(n_problems)
     width = 0.25
 
-    pf_ice = [r['pf_ice'] for r in results]
-    pf_mc = [r['pf_mc'] for r in results]
-    pf_ref = [r['pf_ref'] for r in results]
+    pf_ice = [r["pf_ice"] for r in results]
+    pf_mc = [r["pf_mc"] for r in results]
+    pf_ref = [r["pf_ref"] for r in results]
 
-    ax.bar(x_pos - width, pf_ice, width, label='Safe-ICE', color='blue', alpha=0.7)
-    ax.bar(x_pos, pf_mc, width, label='Monte Carlo', color='red', alpha=0.7)
-    ax.bar(x_pos + width, pf_ref, width, label='Reference', color='green', alpha=0.7)
+    ax.bar(x_pos - width, pf_ice, width, label="Safe-ICE", color="blue", alpha=0.7)
+    ax.bar(x_pos, pf_mc, width, label="Monte Carlo", color="red", alpha=0.7)
+    ax.bar(x_pos + width, pf_ref, width, label="Reference", color="green", alpha=0.7)
 
-    ax.set_xlabel('Problem')
-    ax.set_ylabel('Failure Probability')
-    ax.set_title('Failure Probability Estimates')
+    ax.set_xlabel("Problem")
+    ax.set_ylabel("Failure Probability")
+    ax.set_title("Failure Probability Estimates")
     ax.set_xticks(x_pos)
-    ax.set_xticklabels([r['problem'] for r in results], rotation=45, ha='right')
-    ax.set_yscale('log')
+    ax.set_xticklabels([r["problem"] for r in results], rotation=45, ha="right")
+    ax.set_yscale("log")
     ax.legend()
     ax.grid(True, alpha=0.3)
 
     # Plot 2: Sample count comparison
     ax = axes[0, 1]
-    samples_ice = [r['samples_ice'] for r in results]
-    samples_mc = [r['samples_mc'] for r in results]
+    samples_ice = [r["samples_ice"] for r in results]
+    samples_mc = [r["samples_mc"] for r in results]
 
-    ax.bar(x_pos - width/2, samples_ice, width, label='Safe-ICE', color='blue', alpha=0.7)
-    ax.bar(x_pos + width/2, samples_mc, width, label='Monte Carlo', color='red', alpha=0.7)
+    ax.bar(
+        x_pos - width / 2, samples_ice, width, label="Safe-ICE", color="blue", alpha=0.7
+    )
+    ax.bar(
+        x_pos + width / 2,
+        samples_mc,
+        width,
+        label="Monte Carlo",
+        color="red",
+        alpha=0.7,
+    )
 
-    ax.set_xlabel('Problem')
-    ax.set_ylabel('Number of Samples')
-    ax.set_title('Sample Count Comparison')
+    ax.set_xlabel("Problem")
+    ax.set_ylabel("Number of Samples")
+    ax.set_title("Sample Count Comparison")
     ax.set_xticks(x_pos)
-    ax.set_xticklabels([r['problem'] for r in results], rotation=45, ha='right')
-    ax.set_yscale('log')
+    ax.set_xticklabels([r["problem"] for r in results], rotation=45, ha="right")
+    ax.set_yscale("log")
     ax.legend()
     ax.grid(True, alpha=0.3)
 
     # Plot 3: Computational time
     ax = axes[1, 0]
-    time_ice = [r['time_ice'] for r in results]
-    time_mc = [r['time_mc'] for r in results]
+    time_ice = [r["time_ice"] for r in results]
+    time_mc = [r["time_mc"] for r in results]
 
-    ax.bar(x_pos - width/2, time_ice, width, label='Safe-ICE', color='blue', alpha=0.7)
-    ax.bar(x_pos + width/2, time_mc, width, label='Monte Carlo', color='red', alpha=0.7)
+    ax.bar(
+        x_pos - width / 2, time_ice, width, label="Safe-ICE", color="blue", alpha=0.7
+    )
+    ax.bar(
+        x_pos + width / 2, time_mc, width, label="Monte Carlo", color="red", alpha=0.7
+    )
 
-    ax.set_xlabel('Problem')
-    ax.set_ylabel('Time (seconds)')
-    ax.set_title('Computational Time')
+    ax.set_xlabel("Problem")
+    ax.set_ylabel("Time (seconds)")
+    ax.set_title("Computational Time")
     ax.set_xticks(x_pos)
-    ax.set_xticklabels([r['problem'] for r in results], rotation=45, ha='right')
+    ax.set_xticklabels([r["problem"] for r in results], rotation=45, ha="right")
     ax.legend()
     ax.grid(True, alpha=0.3)
 
     # Plot 4: Efficiency metrics
     ax = axes[1, 1]
-    efficiency = [r['efficiency'] for r in results]
-    speedup = [r['speedup'] for r in results]
+    efficiency = [r["efficiency"] for r in results]
+    speedup = [r["speedup"] for r in results]
 
-    ax.bar(x_pos - width/2, efficiency, width, label='Sample Efficiency', color='green', alpha=0.7)
-    ax.bar(x_pos + width/2, speedup, width, label='Speedup', color='orange', alpha=0.7)
+    ax.bar(
+        x_pos - width / 2,
+        efficiency,
+        width,
+        label="Sample Efficiency",
+        color="green",
+        alpha=0.7,
+    )
+    ax.bar(
+        x_pos + width / 2, speedup, width, label="Speedup", color="orange", alpha=0.7
+    )
 
-    ax.set_xlabel('Problem')
-    ax.set_ylabel('Ratio')
-    ax.set_title('Efficiency Metrics (Higher is Better)')
+    ax.set_xlabel("Problem")
+    ax.set_ylabel("Ratio")
+    ax.set_title("Efficiency Metrics (Higher is Better)")
     ax.set_xticks(x_pos)
-    ax.set_xticklabels([r['problem'] for r in results], rotation=45, ha='right')
+    ax.set_xticklabels([r["problem"] for r in results], rotation=45, ha="right")
     ax.legend()
     ax.grid(True, alpha=0.3)
 
     # Add horizontal line at y=1
-    ax.axhline(y=1, color='black', linestyle='--', alpha=0.5)
+    ax.axhline(y=1, color="black", linestyle="--", alpha=0.5)
 
     plt.tight_layout()
     plt.show()

--- a/examples/high_dimensional.py
+++ b/examples/high_dimensional.py
@@ -1,24 +1,29 @@
 """Example of Safe-ICE for high-dimensional problems."""
 
-import numpy as np
+import time
+
 import matplotlib.pyplot as plt
+import numpy as np
+
 from safe_ice import SafeICE
 from safe_ice.problems.benchmarks import BenchmarkProblems
-import time
 
 
 def linear_limit_state_hd(dimension):
     """Create a linear limit state function in high dimensions."""
+
     def g(u):
         # Linear combination with decreasing weights
         weights = np.ones(dimension) / np.sqrt(dimension)
         beta = 3.0
         return beta - np.dot(u, weights)
+
     return g
 
 
 def nonlinear_limit_state_hd(dimension):
     """Create a nonlinear limit state function in high dimensions."""
+
     def g(u):
         # Nonlinear combination
         beta = 4.5
@@ -30,15 +35,18 @@ def nonlinear_limit_state_hd(dimension):
         else:
             term2 = 0.1 * np.sum(u[:-1] * u[1:])
         return beta - np.sqrt(term1) - term2
+
     return g
 
 
 def sphere_limit_state_hd(dimension):
     """Create a spherical limit state function in high dimensions."""
+
     def g(u):
         # Scaled sphere
         beta = np.sqrt(dimension) * 2.5
         return beta - np.linalg.norm(u, axis=-1)
+
     return g
 
 
@@ -64,10 +72,10 @@ def run_dimension_study():
         n_samples = min(1000 * d, 10000)  # Scale with dimension
         k0 = min(d * 5, 50)  # Initial components
 
-        print(f"Configuration:")
+        print("Configuration:")
         print(f"  Samples per iteration: {n_samples}")
         print(f"  Initial components: {k0}")
-        print(f"  Max iterations: 20")
+        print("  Max iterations: 20")
 
         # Initialize Safe-ICE
         ice = SafeICE(
@@ -77,7 +85,7 @@ def run_dimension_study():
             K0=k0,
             max_iterations=20,
             delta_target=3.0,
-            delta_star=1.5
+            delta_star=1.5,
         )
 
         # Run algorithm
@@ -88,17 +96,17 @@ def run_dimension_study():
 
         # Store results
         result = {
-            'dimension': d,
-            'pf': pf,
-            'time': elapsed_time,
-            'total_samples': len(ice_results['final_samples']),
-            'iterations': len(ice_results['iterations']),
-            'final_K': ice_results['iterations'][-1]['K'],
-            'cv': ice_results['convergence_metrics']['cv_values'][-1]
+            "dimension": d,
+            "pf": pf,
+            "time": elapsed_time,
+            "total_samples": len(ice_results["final_samples"]),
+            "iterations": len(ice_results["iterations"]),
+            "final_K": ice_results["iterations"][-1]["K"],
+            "cv": ice_results["convergence_metrics"]["cv_values"][-1],
         }
         results.append(result)
 
-        print(f"\nResults:")
+        print("\nResults:")
         print(f"  Failure probability: {pf:.6e}")
         print(f"  Total samples: {result['total_samples']}")
         print(f"  Iterations: {result['iterations']}")
@@ -125,11 +133,7 @@ def test_specific_problems():
 
     g = problems.nonlinear_oscillator()
     ice = SafeICE(
-        limit_state_function=g,
-        dimension=10,
-        N=3000,
-        K0=30,
-        max_iterations=15
+        limit_state_function=g, dimension=10, N=3000, K0=30, max_iterations=15
     )
 
     pf, results = ice.run(verbose=True)
@@ -143,11 +147,7 @@ def test_specific_problems():
 
         g = problems.two_mode_opposite_directions(dimension=d)
         ice = SafeICE(
-            limit_state_function=g,
-            dimension=d,
-            N=2000,
-            K0=20,
-            max_iterations=10
+            limit_state_function=g, dimension=d, N=2000, K0=20, max_iterations=10
         )
 
         pf, results = ice.run(verbose=False)
@@ -158,62 +158,62 @@ def test_specific_problems():
 def visualize_dimension_scaling(results):
     """Visualize how performance scales with dimension."""
 
-    dimensions = [r['dimension'] for r in results]
+    dimensions = [r["dimension"] for r in results]
 
-    fig, axes = plt.subplots(2, 3, figsize=(15, 10))
+    _fig, axes = plt.subplots(2, 3, figsize=(15, 10))
 
     # Plot 1: Failure probability vs dimension
     ax = axes[0, 0]
-    pf_values = [r['pf'] for r in results]
-    ax.semilogy(dimensions, pf_values, 'b-o')
-    ax.set_xlabel('Dimension')
-    ax.set_ylabel('Failure Probability')
-    ax.set_title('Failure Probability Scaling')
+    pf_values = [r["pf"] for r in results]
+    ax.semilogy(dimensions, pf_values, "b-o")
+    ax.set_xlabel("Dimension")
+    ax.set_ylabel("Failure Probability")
+    ax.set_title("Failure Probability Scaling")
     ax.grid(True, alpha=0.3)
 
     # Plot 2: Total samples vs dimension
     ax = axes[0, 1]
-    samples = [r['total_samples'] for r in results]
-    ax.plot(dimensions, samples, 'r-s')
-    ax.set_xlabel('Dimension')
-    ax.set_ylabel('Total Samples')
-    ax.set_title('Sample Requirement')
+    samples = [r["total_samples"] for r in results]
+    ax.plot(dimensions, samples, "r-s")
+    ax.set_xlabel("Dimension")
+    ax.set_ylabel("Total Samples")
+    ax.set_title("Sample Requirement")
     ax.grid(True, alpha=0.3)
 
     # Plot 3: Computational time vs dimension
     ax = axes[0, 2]
-    times = [r['time'] for r in results]
-    ax.plot(dimensions, times, 'g-^')
-    ax.set_xlabel('Dimension')
-    ax.set_ylabel('Time (seconds)')
-    ax.set_title('Computational Time')
+    times = [r["time"] for r in results]
+    ax.plot(dimensions, times, "g-^")
+    ax.set_xlabel("Dimension")
+    ax.set_ylabel("Time (seconds)")
+    ax.set_title("Computational Time")
     ax.grid(True, alpha=0.3)
 
     # Plot 4: Number of iterations vs dimension
     ax = axes[1, 0]
-    iterations = [r['iterations'] for r in results]
-    ax.plot(dimensions, iterations, 'm-d')
-    ax.set_xlabel('Dimension')
-    ax.set_ylabel('Iterations')
-    ax.set_title('Convergence Speed')
+    iterations = [r["iterations"] for r in results]
+    ax.plot(dimensions, iterations, "m-d")
+    ax.set_xlabel("Dimension")
+    ax.set_ylabel("Iterations")
+    ax.set_title("Convergence Speed")
     ax.grid(True, alpha=0.3)
 
     # Plot 5: Final components vs dimension
     ax = axes[1, 1]
-    final_K = [r['final_K'] for r in results]
-    ax.plot(dimensions, final_K, 'c-*')
-    ax.set_xlabel('Dimension')
-    ax.set_ylabel('Final K')
-    ax.set_title('Final Number of Components')
+    final_K = [r["final_K"] for r in results]
+    ax.plot(dimensions, final_K, "c-*")
+    ax.set_xlabel("Dimension")
+    ax.set_ylabel("Final K")
+    ax.set_title("Final Number of Components")
     ax.grid(True, alpha=0.3)
 
     # Plot 6: CV vs dimension
     ax = axes[1, 2]
-    cv_values = [r['cv'] for r in results]
-    ax.plot(dimensions, cv_values, 'y-p')
-    ax.set_xlabel('Dimension')
-    ax.set_ylabel('Coefficient of Variation')
-    ax.set_title('Estimation Accuracy')
+    cv_values = [r["cv"] for r in results]
+    ax.plot(dimensions, cv_values, "y-p")
+    ax.set_xlabel("Dimension")
+    ax.set_ylabel("Coefficient of Variation")
+    ax.set_title("Estimation Accuracy")
     ax.grid(True, alpha=0.3)
 
     plt.tight_layout()
@@ -223,11 +223,15 @@ def visualize_dimension_scaling(results):
     print("\n" + "=" * 70)
     print("DIMENSION SCALING SUMMARY")
     print("=" * 70)
-    print(f"{'Dim':<6} {'Pf':<12} {'Samples':<10} {'Time(s)':<10} {'K_final':<8} {'CV':<8}")
+    print(
+        f"{'Dim':<6} {'Pf':<12} {'Samples':<10} {'Time(s)':<10} {'K_final':<8} {'CV':<8}"
+    )
     print("-" * 70)
     for r in results:
-        print(f"{r['dimension']:<6} {r['pf']:<12.2e} {r['total_samples']:<10} "
-              f"{r['time']:<10.2f} {r['final_K']:<8} {r['cv']:<8.4f}")
+        print(
+            f"{r['dimension']:<6} {r['pf']:<12.2e} {r['total_samples']:<10} "
+            f"{r['time']:<10.2f} {r['final_K']:<8} {r['cv']:<8.4f}"
+        )
 
 
 def main():

--- a/examples/performance_benchmark.py
+++ b/examples/performance_benchmark.py
@@ -1,15 +1,19 @@
 """Performance benchmark comparing original and optimized Safe-ICE."""
 
-import numpy as np
 import time
-import matplotlib.pyplot as plt
-from safe_ice import SafeICE, OptimizedSafeICE
-from safe_ice.problems.benchmarks import BenchmarkProblems
-import psutil
 import tracemalloc
 
+import matplotlib.pyplot as plt
+import numpy as np
+import psutil
 
-def measure_performance(ice_class, limit_state_func, dimension, N, max_iterations, **kwargs):
+from safe_ice import OptimizedSafeICE, SafeICE
+from safe_ice.problems.benchmarks import BenchmarkProblems
+
+
+def measure_performance(
+    ice_class, limit_state_func, dimension, N, max_iterations, **kwargs
+):
     """Measure performance of a Safe-ICE implementation."""
 
     # Start memory tracking
@@ -23,7 +27,7 @@ def measure_performance(ice_class, limit_state_func, dimension, N, max_iteration
         dimension=dimension,
         N=N,
         max_iterations=max_iterations,
-        **kwargs
+        **kwargs,
     )
 
     # Run algorithm
@@ -36,18 +40,18 @@ def measure_performance(ice_class, limit_state_func, dimension, N, max_iteration
     mem_used = mem_after - mem_before
 
     # Get memory peak
-    current, peak = tracemalloc.get_traced_memory()
+    _current, peak = tracemalloc.get_traced_memory()
     tracemalloc.stop()
     peak_mb = peak / 1024 / 1024
 
     return {
-        'pf': pf,
-        'time': elapsed_time,
-        'memory_used': mem_used,
-        'memory_peak': peak_mb,
-        'total_samples': len(results['final_samples']),
-        'iterations': len(results['iterations']),
-        'final_K': results['final_parameters'].K
+        "pf": pf,
+        "time": elapsed_time,
+        "memory_used": mem_used,
+        "memory_peak": peak_mb,
+        "total_samples": len(results["final_samples"]),
+        "iterations": len(results["iterations"]),
+        "final_K": results["final_parameters"].K,
     }
 
 
@@ -63,40 +67,40 @@ def run_benchmark_suite():
     # Test configurations
     test_configs = [
         {
-            'name': 'Small 2D Problem',
-            'func': problems.four_mode_series_system(),
-            'dimension': 2,
-            'N': 500,
-            'max_iterations': 5
+            "name": "Small 2D Problem",
+            "func": problems.four_mode_series_system(),
+            "dimension": 2,
+            "N": 500,
+            "max_iterations": 5,
         },
         {
-            'name': 'Medium 2D Problem',
-            'func': problems.four_mode_series_system(),
-            'dimension': 2,
-            'N': 2000,
-            'max_iterations': 10
+            "name": "Medium 2D Problem",
+            "func": problems.four_mode_series_system(),
+            "dimension": 2,
+            "N": 2000,
+            "max_iterations": 10,
         },
         {
-            'name': 'Large 2D Problem',
-            'func': problems.four_mode_series_system(),
-            'dimension': 2,
-            'N': 5000,
-            'max_iterations': 15
+            "name": "Large 2D Problem",
+            "func": problems.four_mode_series_system(),
+            "dimension": 2,
+            "N": 5000,
+            "max_iterations": 15,
         },
         {
-            'name': '10D Problem',
-            'func': problems.nonlinear_oscillator(),
-            'dimension': 10,
-            'N': 2000,
-            'max_iterations': 10
+            "name": "10D Problem",
+            "func": problems.nonlinear_oscillator(),
+            "dimension": 10,
+            "N": 2000,
+            "max_iterations": 10,
         },
         {
-            'name': '20D Problem',
-            'func': problems.two_mode_opposite_directions(dimension=20),
-            'dimension': 20,
-            'N': 3000,
-            'max_iterations': 10
-        }
+            "name": "20D Problem",
+            "func": problems.two_mode_opposite_directions(dimension=20),
+            "dimension": 20,
+            "N": 3000,
+            "max_iterations": 10,
+        },
     ]
 
     results = []
@@ -104,7 +108,9 @@ def run_benchmark_suite():
     for config in test_configs:
         print(f"\n{'=' * 80}")
         print(f"Test: {config['name']}")
-        print(f"Dimension: {config['dimension']}, N: {config['N']}, Max iter: {config['max_iterations']}")
+        print(
+            f"Dimension: {config['dimension']}, N: {config['N']}, Max iter: {config['max_iterations']}"
+        )
         print("-" * 80)
 
         # Original SafeICE
@@ -112,10 +118,10 @@ def run_benchmark_suite():
         try:
             original_results = measure_performance(
                 SafeICE,
-                config['func'],
-                config['dimension'],
-                config['N'],
-                config['max_iterations']
+                config["func"],
+                config["dimension"],
+                config["N"],
+                config["max_iterations"],
             )
             print(f"  Time: {original_results['time']:.2f}s")
             print(f"  Memory: {original_results['memory_peak']:.1f} MB")
@@ -129,12 +135,12 @@ def run_benchmark_suite():
         try:
             optimized_cached = measure_performance(
                 OptimizedSafeICE,
-                config['func'],
-                config['dimension'],
-                config['N'],
-                config['max_iterations'],
+                config["func"],
+                config["dimension"],
+                config["N"],
+                config["max_iterations"],
                 enable_caching=True,
-                enable_parallel=False
+                enable_parallel=False,
             )
             print(f"  Time: {optimized_cached['time']:.2f}s")
             print(f"  Memory: {optimized_cached['memory_peak']:.1f} MB")
@@ -148,13 +154,13 @@ def run_benchmark_suite():
         try:
             optimized_full = measure_performance(
                 OptimizedSafeICE,
-                config['func'],
-                config['dimension'],
-                config['N'],
-                config['max_iterations'],
+                config["func"],
+                config["dimension"],
+                config["N"],
+                config["max_iterations"],
                 enable_caching=True,
                 enable_parallel=False,
-                batch_size=1000
+                batch_size=1000,
             )
             print(f"  Time: {optimized_full['time']:.2f}s")
             print(f"  Memory: {optimized_full['memory_peak']:.1f} MB")
@@ -165,23 +171,29 @@ def run_benchmark_suite():
 
         # Calculate speedups
         if original_results and optimized_cached:
-            speedup_cached = original_results['time'] / optimized_cached['time']
-            memory_ratio_cached = optimized_cached['memory_peak'] / original_results['memory_peak']
+            speedup_cached = original_results["time"] / optimized_cached["time"]
+            memory_ratio_cached = (
+                optimized_cached["memory_peak"] / original_results["memory_peak"]
+            )
             print(f"\nSpeedup (cached): {speedup_cached:.2f}x")
             print(f"Memory ratio (cached): {memory_ratio_cached:.2f}x")
 
         if original_results and optimized_full:
-            speedup_full = original_results['time'] / optimized_full['time']
-            memory_ratio_full = optimized_full['memory_peak'] / original_results['memory_peak']
+            speedup_full = original_results["time"] / optimized_full["time"]
+            memory_ratio_full = (
+                optimized_full["memory_peak"] / original_results["memory_peak"]
+            )
             print(f"Speedup (full): {speedup_full:.2f}x")
             print(f"Memory ratio (full): {memory_ratio_full:.2f}x")
 
-        results.append({
-            'config': config,
-            'original': original_results,
-            'optimized_cached': optimized_cached,
-            'optimized_full': optimized_full
-        })
+        results.append(
+            {
+                "config": config,
+                "original": original_results,
+                "optimized_cached": optimized_cached,
+                "optimized_full": optimized_full,
+            }
+        )
 
     return results
 
@@ -190,53 +202,74 @@ def plot_performance_results(results):
     """Create performance comparison plots."""
 
     # Extract valid results
-    valid_results = [r for r in results if r['original'] is not None]
+    valid_results = [r for r in results if r["original"] is not None]
     if not valid_results:
         print("No valid results to plot")
         return
 
     n_tests = len(valid_results)
-    test_names = [r['config']['name'] for r in valid_results]
+    test_names = [r["config"]["name"] for r in valid_results]
 
-    fig, axes = plt.subplots(2, 2, figsize=(14, 10))
+    _fig, axes = plt.subplots(2, 2, figsize=(14, 10))
 
     # Plot 1: Execution Time Comparison
     ax = axes[0, 0]
     x_pos = np.arange(n_tests)
     width = 0.25
 
-    times_original = [r['original']['time'] if r['original'] else 0 for r in valid_results]
-    times_cached = [r['optimized_cached']['time'] if r['optimized_cached'] else 0 for r in valid_results]
-    times_full = [r['optimized_full']['time'] if r['optimized_full'] else 0 for r in valid_results]
+    times_original = [
+        r["original"]["time"] if r["original"] else 0 for r in valid_results
+    ]
+    times_cached = [
+        r["optimized_cached"]["time"] if r["optimized_cached"] else 0
+        for r in valid_results
+    ]
+    times_full = [
+        r["optimized_full"]["time"] if r["optimized_full"] else 0 for r in valid_results
+    ]
 
-    ax.bar(x_pos - width, times_original, width, label='Original', color='blue', alpha=0.7)
-    ax.bar(x_pos, times_cached, width, label='Opt. (cache)', color='green', alpha=0.7)
-    ax.bar(x_pos + width, times_full, width, label='Opt. (full)', color='red', alpha=0.7)
+    ax.bar(
+        x_pos - width, times_original, width, label="Original", color="blue", alpha=0.7
+    )
+    ax.bar(x_pos, times_cached, width, label="Opt. (cache)", color="green", alpha=0.7)
+    ax.bar(
+        x_pos + width, times_full, width, label="Opt. (full)", color="red", alpha=0.7
+    )
 
-    ax.set_xlabel('Test Configuration')
-    ax.set_ylabel('Time (seconds)')
-    ax.set_title('Execution Time Comparison')
+    ax.set_xlabel("Test Configuration")
+    ax.set_ylabel("Time (seconds)")
+    ax.set_title("Execution Time Comparison")
     ax.set_xticks(x_pos)
-    ax.set_xticklabels(test_names, rotation=45, ha='right')
+    ax.set_xticklabels(test_names, rotation=45, ha="right")
     ax.legend()
     ax.grid(True, alpha=0.3)
 
     # Plot 2: Memory Usage Comparison
     ax = axes[0, 1]
 
-    mem_original = [r['original']['memory_peak'] if r['original'] else 0 for r in valid_results]
-    mem_cached = [r['optimized_cached']['memory_peak'] if r['optimized_cached'] else 0 for r in valid_results]
-    mem_full = [r['optimized_full']['memory_peak'] if r['optimized_full'] else 0 for r in valid_results]
+    mem_original = [
+        r["original"]["memory_peak"] if r["original"] else 0 for r in valid_results
+    ]
+    mem_cached = [
+        r["optimized_cached"]["memory_peak"] if r["optimized_cached"] else 0
+        for r in valid_results
+    ]
+    mem_full = [
+        r["optimized_full"]["memory_peak"] if r["optimized_full"] else 0
+        for r in valid_results
+    ]
 
-    ax.bar(x_pos - width, mem_original, width, label='Original', color='blue', alpha=0.7)
-    ax.bar(x_pos, mem_cached, width, label='Opt. (cache)', color='green', alpha=0.7)
-    ax.bar(x_pos + width, mem_full, width, label='Opt. (full)', color='red', alpha=0.7)
+    ax.bar(
+        x_pos - width, mem_original, width, label="Original", color="blue", alpha=0.7
+    )
+    ax.bar(x_pos, mem_cached, width, label="Opt. (cache)", color="green", alpha=0.7)
+    ax.bar(x_pos + width, mem_full, width, label="Opt. (full)", color="red", alpha=0.7)
 
-    ax.set_xlabel('Test Configuration')
-    ax.set_ylabel('Peak Memory (MB)')
-    ax.set_title('Memory Usage Comparison')
+    ax.set_xlabel("Test Configuration")
+    ax.set_ylabel("Peak Memory (MB)")
+    ax.set_title("Memory Usage Comparison")
     ax.set_xticks(x_pos)
-    ax.set_xticklabels(test_names, rotation=45, ha='right')
+    ax.set_xticklabels(test_names, rotation=45, ha="right")
     ax.legend()
     ax.grid(True, alpha=0.3)
 
@@ -247,45 +280,66 @@ def plot_performance_results(results):
     speedups_full = []
 
     for r in valid_results:
-        if r['original'] and r['optimized_cached']:
-            speedups_cached.append(r['original']['time'] / r['optimized_cached']['time'])
+        if r["original"] and r["optimized_cached"]:
+            speedups_cached.append(
+                r["original"]["time"] / r["optimized_cached"]["time"]
+            )
         else:
             speedups_cached.append(0)
 
-        if r['original'] and r['optimized_full']:
-            speedups_full.append(r['original']['time'] / r['optimized_full']['time'])
+        if r["original"] and r["optimized_full"]:
+            speedups_full.append(r["original"]["time"] / r["optimized_full"]["time"])
         else:
             speedups_full.append(0)
 
-    ax.bar(x_pos - width/2, speedups_cached, width, label='Cache Only', color='green', alpha=0.7)
-    ax.bar(x_pos + width/2, speedups_full, width, label='Full Opt.', color='red', alpha=0.7)
+    ax.bar(
+        x_pos - width / 2,
+        speedups_cached,
+        width,
+        label="Cache Only",
+        color="green",
+        alpha=0.7,
+    )
+    ax.bar(
+        x_pos + width / 2,
+        speedups_full,
+        width,
+        label="Full Opt.",
+        color="red",
+        alpha=0.7,
+    )
 
-    ax.axhline(y=1, color='black', linestyle='--', alpha=0.5)
-    ax.set_xlabel('Test Configuration')
-    ax.set_ylabel('Speedup Factor')
-    ax.set_title('Performance Speedup (Higher is Better)')
+    ax.axhline(y=1, color="black", linestyle="--", alpha=0.5)
+    ax.set_xlabel("Test Configuration")
+    ax.set_ylabel("Speedup Factor")
+    ax.set_title("Performance Speedup (Higher is Better)")
     ax.set_xticks(x_pos)
-    ax.set_xticklabels(test_names, rotation=45, ha='right')
+    ax.set_xticklabels(test_names, rotation=45, ha="right")
     ax.legend()
     ax.grid(True, alpha=0.3)
 
     # Plot 4: Accuracy Comparison
     ax = axes[1, 1]
 
-    pf_original = [r['original']['pf'] if r['original'] else 0 for r in valid_results]
-    pf_cached = [r['optimized_cached']['pf'] if r['optimized_cached'] else 0 for r in valid_results]
-    pf_full = [r['optimized_full']['pf'] if r['optimized_full'] else 0 for r in valid_results]
+    pf_original = [r["original"]["pf"] if r["original"] else 0 for r in valid_results]
+    pf_cached = [
+        r["optimized_cached"]["pf"] if r["optimized_cached"] else 0
+        for r in valid_results
+    ]
+    pf_full = [
+        r["optimized_full"]["pf"] if r["optimized_full"] else 0 for r in valid_results
+    ]
 
-    ax.bar(x_pos - width, pf_original, width, label='Original', color='blue', alpha=0.7)
-    ax.bar(x_pos, pf_cached, width, label='Opt. (cache)', color='green', alpha=0.7)
-    ax.bar(x_pos + width, pf_full, width, label='Opt. (full)', color='red', alpha=0.7)
+    ax.bar(x_pos - width, pf_original, width, label="Original", color="blue", alpha=0.7)
+    ax.bar(x_pos, pf_cached, width, label="Opt. (cache)", color="green", alpha=0.7)
+    ax.bar(x_pos + width, pf_full, width, label="Opt. (full)", color="red", alpha=0.7)
 
-    ax.set_xlabel('Test Configuration')
-    ax.set_ylabel('Failure Probability')
-    ax.set_title('Accuracy Comparison')
+    ax.set_xlabel("Test Configuration")
+    ax.set_ylabel("Failure Probability")
+    ax.set_title("Accuracy Comparison")
     ax.set_xticks(x_pos)
-    ax.set_xticklabels(test_names, rotation=45, ha='right')
-    ax.set_yscale('log')
+    ax.set_xticklabels(test_names, rotation=45, ha="right")
+    ax.set_yscale("log")
     ax.legend()
     ax.grid(True, alpha=0.3)
 
@@ -299,7 +353,7 @@ def plot_performance_results(results):
     print(f"{'Test':<25} {'Speedup (Cache)':<20} {'Speedup (Full)':<20}")
     print("-" * 80)
 
-    for i, r in enumerate(valid_results):
+    for i, _r in enumerate(valid_results):
         speedup_cache = speedups_cached[i] if i < len(speedups_cached) else 0
         speedup_full = speedups_full[i] if i < len(speedups_full) else 0
         print(f"{test_names[i]:<25} {speedup_cache:<20.2f}x {speedup_full:<20.2f}x")
@@ -310,7 +364,8 @@ def main():
 
     # Check if numba is available for additional optimizations
     try:
-        import numba
+        import numba  # noqa: F401 - availability probe
+
         print("Numba available for JIT compilation")
     except ImportError:
         print("Numba not available - some optimizations disabled")
@@ -329,7 +384,9 @@ def main():
     print("\nRecommendations based on benchmarks:")
     print("- For small problems (N < 1000): Use original SafeICE")
     print("- For medium problems (1000 < N < 5000): Use OptimizedSafeICE with caching")
-    print("- For large problems (N > 5000): Use OptimizedSafeICE with full optimization")
+    print(
+        "- For large problems (N > 5000): Use OptimizedSafeICE with full optimization"
+    )
     print("- For high dimensions (d > 20): Always use OptimizedSafeICE")
 
 

--- a/quickstart.py
+++ b/quickstart.py
@@ -1,12 +1,20 @@
 #!/usr/bin/env python
 """Quick start script for Safe-ICE - Run this to verify installation and see basic usage."""
 
-import numpy as np
 import sys
 import time
 
+import numpy as np
+
+# This script prints mathematical notation. Windows consoles still default to a
+# legacy code page, where that would raise UnicodeEncodeError, so make sure
+# stdout can carry it.
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+
 try:
     from safe_ice import AdaptiveSafeICE, __version__
+
     print(f"✓ Safe-ICE version {__version__} successfully imported!")
 except ImportError as e:
     print(f"✗ Error importing Safe-ICE: {e}")
@@ -19,9 +27,9 @@ except ImportError as e:
 
 def simple_example():
     """Run a simple 2D example."""
-    print("\n" + "="*60)
+    print("\n" + "=" * 60)
     print("SAFE-ICE QUICK START EXAMPLE")
-    print("="*60)
+    print("=" * 60)
 
     # Define a simple limit state function
     def limit_state(u):
@@ -33,11 +41,7 @@ def simple_example():
     print("\nInitializing Adaptive Safe-ICE...")
 
     # Use AdaptiveSafeICE for automatic parameter tuning
-    ice = AdaptiveSafeICE(
-        limit_state_function=limit_state,
-        dimension=2,
-        auto_tune=True
-    )
+    ice = AdaptiveSafeICE(limit_state_function=limit_state, dimension=2, auto_tune=True)
 
     print(f"  Auto-tuned N: {ice.N} samples per iteration")
     print(f"  Auto-tuned K0: {ice.K0} initial components")
@@ -51,13 +55,13 @@ def simple_example():
     elapsed_time = time.time() - start_time
 
     # Display results
-    print("\n" + "="*60)
+    print("\n" + "=" * 60)
     print("RESULTS")
-    print("="*60)
+    print("=" * 60)
     print(f"Estimated failure probability: {pf:.6e}")
-    print(f"Analytical failure probability: 1.11e-2")
+    print("Analytical failure probability: 1.11e-2")
     print(f"Relative error: {abs(pf - 0.0111) / 0.0111:.2%}")
-    print(f"\nAlgorithm statistics:")
+    print("\nAlgorithm statistics:")
     print(f"  Total samples: {len(results['final_samples'])}")
     print(f"  Iterations: {len(results['iterations'])}")
     print(f"  Execution time: {elapsed_time:.2f} seconds")
@@ -68,9 +72,9 @@ def simple_example():
 
 def check_optional_features():
     """Check which optional features are available."""
-    print("\n" + "="*60)
+    print("\n" + "=" * 60)
     print("CHECKING OPTIONAL FEATURES")
-    print("="*60)
+    print("=" * 60)
 
     features = {
         "Plotly (interactive visualization)": "plotly",
@@ -101,9 +105,9 @@ def check_optional_features():
 
 def show_advanced_usage():
     """Show advanced usage examples."""
-    print("\n" + "="*60)
+    print("\n" + "=" * 60)
     print("ADVANCED USAGE EXAMPLES")
-    print("="*60)
+    print("=" * 60)
 
     print("\n1. Original SafeICE (full control):")
     print("""
@@ -180,10 +184,11 @@ def main():
 
     # Run simple example
     try:
-        pf, results = simple_example()
+        _pf, _results = simple_example()
     except Exception as e:
         print(f"\n✗ Error running example: {e}")
         import traceback
+
         traceback.print_exc()
         sys.exit(1)
 
@@ -193,9 +198,9 @@ def main():
     # Show advanced usage
     show_advanced_usage()
 
-    print("\n" + "="*60)
+    print("\n" + "=" * 60)
     print("NEXT STEPS")
-    print("="*60)
+    print("=" * 60)
     print("\n1. Run more examples:")
     print("   python examples/basic_usage.py")
     print("   python examples/benchmark_comparison.py")
@@ -213,9 +218,9 @@ def main():
     print("   jupyter lab")
     print("   # Then import safe_ice")
 
-    print("\n" + "="*60)
+    print("\n" + "=" * 60)
     print("Quick start completed successfully!")
-    print("="*60)
+    print("=" * 60)
 
 
 if __name__ == "__main__":

--- a/safe_ice/analysis/__init__.py
+++ b/safe_ice/analysis/__init__.py
@@ -1,7 +1,6 @@
-
 """Analysis and visualization tools for Safe-ICE."""
 
 from .performance import PerformanceEvaluator
 from .visualization import AdvancedAnalysis
 
-__all__ = ["PerformanceEvaluator", "AdvancedAnalysis"]
+__all__ = ["AdvancedAnalysis", "PerformanceEvaluator"]

--- a/safe_ice/analysis/visualization.py
+++ b/safe_ice/analysis/visualization.py
@@ -1,21 +1,24 @@
 """Visualization and advanced analysis tools for Safe-ICE."""
+
 from __future__ import annotations
 
-from typing import Any, Callable, Dict, Optional, Tuple, cast
-import numpy as np
-import numpy.typing as npt
+from typing import Any
+
 import matplotlib.pyplot as plt
+import numpy as np
+
+from ..typing import LimitStateFunction
 
 
 class AdvancedAnalysis:
     """Advanced analysis tools for Safe-ICE results"""
 
     @staticmethod
-    def analyze_component_evolution(results: Dict[str, Any]) -> None:
+    def analyze_component_evolution(results: dict[str, Any]) -> None:
         """Analyze how mixture components evolve during optimization"""
         history = results["history"]
 
-        fig, axes = plt.subplots(2, 2, figsize=(12, 8))
+        _fig, axes = plt.subplots(2, 2, figsize=(12, 8))
 
         # Component count evolution
         axes[0, 0].plot(history["components"], "b-o")
@@ -52,7 +55,7 @@ class AdvancedAnalysis:
 
     @staticmethod
     def analyze_sample_distribution(
-        results: Dict[str, Any], problem_func: Callable
+        results: dict[str, Any], problem_func: LimitStateFunction
     ) -> None:
         """Analyze final sample distribution (for 2D problems)"""
         if results["final_samples"].shape[1] != 2:
@@ -66,7 +69,7 @@ class AdvancedAnalysis:
         failure_samples = samples[g_values <= 0]
         safe_samples = samples[g_values > 0]
 
-        fig, axes = plt.subplots(1, 2, figsize=(12, 5))
+        _fig, axes = plt.subplots(1, 2, figsize=(12, 5))
 
         # Sample scatter plot
         axes[0].scatter(
@@ -123,7 +126,7 @@ class AdvancedAnalysis:
 
         # Statistics
         failure_rate = len(failure_samples) / len(samples)
-        print(f"Final sample statistics:")
+        print("Final sample statistics:")
         print(f"  Total samples: {len(samples)}")
         print(f"  Failure samples: {len(failure_samples)} ({failure_rate:.1%})")
         print(f"  G-function range: [{np.min(g_values):.3f}, {np.max(g_values):.3f}]")

--- a/safe_ice/cli.py
+++ b/safe_ice/cli.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import argparse
 import sys
-from typing import Optional, List
-import numpy as np
+from collections.abc import Callable
+
+from . import __version__
+from .typing import LimitStateFunction
 
 
 def run_demo() -> None:
@@ -13,9 +15,9 @@ def run_demo() -> None:
     from safe_ice import SafeICE
     from safe_ice.problems.benchmarks import BenchmarkProblems
 
-    print("\n" + "="*60)
+    print("\n" + "=" * 60)
     print("Safe-ICE Algorithm Demonstration")
-    print("="*60)
+    print("=" * 60)
 
     # Create a simple test problem
     problems = BenchmarkProblems()
@@ -35,27 +37,27 @@ def run_demo() -> None:
         N=1000,
         max_iterations=10,
         delta_target=3.0,
-        delta_star=1.5
+        delta_star=1.5,
     )
 
     try:
         pf, results = ice.run(verbose=True)
 
-        print("\n" + "="*60)
+        print("\n" + "=" * 60)
         print("Results:")
         print(f"  Estimated failure probability: {pf:.6e}")
         print(f"  Number of samples generated: {len(results['final_samples'])}")
-        print(f"  Reference probability: ~1.22e-5")
-        print("="*60)
+        print("  Reference probability: ~1.22e-5")
+        print("=" * 60)
 
     except Exception as e:
         print(f"\nError during demonstration: {e}")
         print("Please check your installation and try again.")
 
 
-def run_benchmark(problem_name: Optional[str] = None,
-                  n_samples: int = 1000,
-                  max_iterations: int = 20) -> None:
+def run_benchmark(
+    problem_name: str | None = None, n_samples: int = 1000, max_iterations: int = 20
+) -> None:
     """Run a benchmark problem."""
     from safe_ice import SafeICE
     from safe_ice.problems.benchmarks import BenchmarkProblems
@@ -63,14 +65,14 @@ def run_benchmark(problem_name: Optional[str] = None,
     problems = BenchmarkProblems()
 
     # Available problems
-    available = {
+    available: dict[str, tuple[Callable[[], LimitStateFunction], int, float | None]] = {
         "four-mode": (problems.four_mode_series_system, 2, 1.22e-5),
         "three-mode": (problems.three_mode_problem, 2, 2.3e-3),
         "oscillator": (problems.nonlinear_oscillator, 10, None),
     }
 
     if problem_name is None or problem_name not in available:
-        print(f"\nAvailable benchmark problems:")
+        print("\nAvailable benchmark problems:")
         for name in available:
             print(f"  - {name}")
         if problem_name is not None:
@@ -93,19 +95,19 @@ def run_benchmark(problem_name: Optional[str] = None,
         N=n_samples,
         max_iterations=max_iterations,
         delta_target=3.0,
-        delta_star=1.5
+        delta_star=1.5,
     )
 
-    pf, results = ice.run(verbose=True)
+    pf, _results = ice.run(verbose=True)
 
-    print(f"\nResults:")
+    print("\nResults:")
     print(f"  Estimated failure probability: {pf:.6e}")
     if ref_prob:
         rel_error = abs(pf - ref_prob) / ref_prob
         print(f"  Relative error: {rel_error:.2%}")
 
 
-def analyze_results(input_file: Optional[str] = None) -> None:
+def analyze_results(input_file: str | None = None) -> None:  # noqa: ARG001 - placeholder for the unimplemented subcommand
     """Analyze and visualize results."""
     print("\nResult analysis functionality coming soon!")
     print("For now, please use the Python API directly:")
@@ -114,7 +116,7 @@ def analyze_results(input_file: Optional[str] = None) -> None:
     print("  # ... load your results and analyze")
 
 
-def main(args: Optional[List[str]] = None) -> int:
+def main(args: list[str] | None = None) -> int:
     """Main entry point for the Safe-ICE CLI."""
     parser = argparse.ArgumentParser(
         prog="safe-ice",
@@ -128,52 +130,40 @@ Examples:
   safe-ice --help                  Show this help message
 
 For more information, visit: https://github.com/your-username/safe-ice
-        """
+        """,
     )
 
     parser.add_argument(
-        "--version",
-        action="version",
-        version="safe-ice 0.1.0"
+        "--version", action="version", version=f"safe-ice {__version__}"
     )
 
     # Create subparsers for different commands
     subparsers = parser.add_subparsers(dest="command", help="Available commands")
 
     # Demo command
-    demo_parser = subparsers.add_parser("demo", help="Run a simple demonstration")
+    subparsers.add_parser("demo", help="Run a simple demonstration")
 
     # Benchmark command
     benchmark_parser = subparsers.add_parser("benchmark", help="Run benchmark problems")
     benchmark_parser.add_argument(
-        "problem",
-        nargs="?",
-        help="Problem name (four-mode, three-mode, oscillator)"
+        "problem", nargs="?", help="Problem name (four-mode, three-mode, oscillator)"
     )
     benchmark_parser.add_argument(
         "--samples",
         type=int,
         default=1000,
-        help="Number of samples per iteration (default: 1000)"
+        help="Number of samples per iteration (default: 1000)",
     )
     benchmark_parser.add_argument(
-        "--iterations",
-        type=int,
-        default=20,
-        help="Maximum iterations (default: 20)"
+        "--iterations", type=int, default=20, help="Maximum iterations (default: 20)"
     )
     benchmark_parser.add_argument(
-        "--list",
-        action="store_true",
-        help="List available benchmark problems"
+        "--list", action="store_true", help="List available benchmark problems"
     )
 
     # Analyze command
     analyze_parser = subparsers.add_parser("analyze", help="Analyze results")
-    analyze_parser.add_argument(
-        "--input",
-        help="Input file with results"
-    )
+    analyze_parser.add_argument("--input", help="Input file with results")
 
     # Parse arguments
     parsed_args = parser.parse_args(args)
@@ -185,7 +175,9 @@ For more information, visit: https://github.com/your-username/safe-ice
         if parsed_args.list:
             run_benchmark(None, parsed_args.samples, parsed_args.iterations)
         else:
-            run_benchmark(parsed_args.problem, parsed_args.samples, parsed_args.iterations)
+            run_benchmark(
+                parsed_args.problem, parsed_args.samples, parsed_args.iterations
+            )
     elif parsed_args.command == "analyze":
         analyze_results(parsed_args.input)
     else:

--- a/safe_ice/core/__init__.py
+++ b/safe_ice/core/__init__.py
@@ -1,9 +1,8 @@
-
 """Core Safe-ICE algorithm and parameters."""
 
+from .adaptive_safe_ice import AdaptiveSafeICE
 from .parameters import vMFNMParameters
 from .safe_ice import SafeICE
 from .safe_ice_optimized import OptimizedSafeICE
-from .adaptive_safe_ice import AdaptiveSafeICE
 
-__all__ = ["vMFNMParameters", "SafeICE", "OptimizedSafeICE", "AdaptiveSafeICE"]
+__all__ = ["AdaptiveSafeICE", "OptimizedSafeICE", "SafeICE", "vMFNMParameters"]

--- a/safe_ice/core/adaptive_safe_ice.py
+++ b/safe_ice/core/adaptive_safe_ice.py
@@ -2,17 +2,16 @@
 
 from __future__ import annotations
 
-import math
-import warnings
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any
+
 import numpy as np
 import numpy.typing as npt
-from scipy.stats import chi2
 from scipy.optimize import minimize_scalar
 
+from ..optimization.penalized_em import PenalizedEMOptimizer
+from ..typing import LimitStateFunction
 from .parameters import vMFNMParameters
 from .safe_ice_optimized import OptimizedSafeICE
-from ..optimization.penalized_em import PenalizedEMOptimizer
 
 NDArrayF = npt.NDArray[np.float64]
 
@@ -30,14 +29,14 @@ class AdaptiveSafeICE(OptimizedSafeICE):
 
     def __init__(
         self,
-        limit_state_function: Callable[[NDArrayF], float],
+        limit_state_function: LimitStateFunction,
         dimension: int,
-        N: Optional[int] = None,
+        N: int | None = None,
         max_iterations: int = 30,
         auto_tune: bool = True,
         adaptive_schedule: bool = True,
-        random_state: Optional[int | np.random.Generator] = None,
-        **kwargs
+        random_state: int | np.random.Generator | None = None,
+        **kwargs: Any,
     ) -> None:
         """
         Initialize Adaptive Safe-ICE.
@@ -66,15 +65,15 @@ class AdaptiveSafeICE(OptimizedSafeICE):
             N = self._compute_adaptive_sample_size(dimension)
 
         # Auto-compute K0 based on dimension
-        if 'K0' not in kwargs:
-            kwargs['K0'] = self._compute_adaptive_k0(dimension)
+        if "K0" not in kwargs:
+            kwargs["K0"] = self._compute_adaptive_k0(dimension)
 
         # Auto-compute delta parameters based on dimension
-        if 'delta_target' not in kwargs:
-            kwargs['delta_target'] = self._compute_adaptive_delta_target(dimension)
+        if "delta_target" not in kwargs:
+            kwargs["delta_target"] = self._compute_adaptive_delta_target(dimension)
 
-        if 'delta_star' not in kwargs:
-            kwargs['delta_star'] = self._compute_adaptive_delta_star(dimension)
+        if "delta_star" not in kwargs:
+            kwargs["delta_star"] = self._compute_adaptive_delta_star(dimension)
 
         # Initialize parent class
         super().__init__(
@@ -83,16 +82,16 @@ class AdaptiveSafeICE(OptimizedSafeICE):
             N=N,
             max_iterations=max_iterations,
             random_state=random_state,
-            **kwargs
+            **kwargs,
         )
 
         self.auto_tune = auto_tune
         self.adaptive_schedule = adaptive_schedule
 
         # Adaptive parameters
-        self.beta_history: List[float] = []
-        self.learning_rate_history: List[float] = []
-        self.convergence_history: List[Dict[str, float]] = []
+        self.beta_history: list[float] = []
+        self.learning_rate_history: list[float] = []
+        self.convergence_history: list[dict[str, float]] = []
 
     def _compute_adaptive_sample_size(self, d: int) -> int:
         """
@@ -212,7 +211,7 @@ class AdaptiveSafeICE(OptimizedSafeICE):
         samples: NDArrayF,
         weights: NDArrayF,
         params: vMFNMParameters,
-        iteration: int
+        iteration: int,
     ) -> float:
         """
         Auto-tune penalty coefficient β.
@@ -233,18 +232,17 @@ class AdaptiveSafeICE(OptimizedSafeICE):
         float
             Optimal beta value.
         """
+
         # Objective function for beta tuning
         def objective(beta: float) -> float:
             """Objective: Balance between likelihood and sparsity."""
             optimizer = PenalizedEMOptimizer(max_em_iterations=20)
 
             try:
-                new_params, _ = optimizer.fit(
-                    samples, weights, params, beta_init=beta
-                )
+                new_params, _ = optimizer.fit(samples, weights, params, beta_init=beta)
 
                 # Compute effective sample size
-                ess = np.sum(weights)**2 / np.sum(weights**2)
+                ess = np.sum(weights) ** 2 / np.sum(weights**2)
 
                 # Penalty for too many or too few components
                 K = new_params.K
@@ -255,7 +253,7 @@ class AdaptiveSafeICE(OptimizedSafeICE):
                 return -ess / len(samples) + 0.1 * K_penalty
 
             except Exception:
-                return float('inf')
+                return float("inf")
 
         # Search for optimal beta
         if iteration == 0:
@@ -267,10 +265,7 @@ class AdaptiveSafeICE(OptimizedSafeICE):
             beta_range = (max(0.1, prev_beta * 0.5), min(10.0, prev_beta * 2.0))
 
         result = minimize_scalar(
-            objective,
-            bounds=beta_range,
-            method='bounded',
-            options={'maxiter': 10}
+            objective, bounds=beta_range, method="bounded", options={"maxiter": 10}
         )
 
         optimal_beta = result.x if result.success else 1.0
@@ -279,10 +274,7 @@ class AdaptiveSafeICE(OptimizedSafeICE):
         return optimal_beta
 
     def _adaptive_annealing_schedule(
-        self,
-        sigma: float,
-        iteration: int,
-        convergence_rate: float
+        self, sigma: float, iteration: int, convergence_rate: float
     ) -> float:
         """
         Adaptive annealing schedule based on convergence.
@@ -324,14 +316,11 @@ class AdaptiveSafeICE(OptimizedSafeICE):
         decay = np.exp(-iteration / 10)
         lambda_val = base_lambda * (1 - 0.3 * (1 - decay))
 
-        return max(0.5, min(0.95, lambda_val))
+        return float(max(0.5, min(0.95, lambda_val)))
 
     def _compute_convergence_metrics(
-        self,
-        weights: NDArrayF,
-        g_values: NDArrayF,
-        iteration: int
-    ) -> Dict[str, float]:
+        self, weights: NDArrayF, g_values: NDArrayF, iteration: int
+    ) -> dict[str, float]:
         """
         Compute comprehensive convergence metrics.
 
@@ -353,24 +342,24 @@ class AdaptiveSafeICE(OptimizedSafeICE):
         cv = self._compute_cv(weights)
 
         # Effective sample size
-        ess = np.sum(weights)**2 / np.sum(weights**2) if np.sum(weights) > 0 else 0
+        ess = np.sum(weights) ** 2 / np.sum(weights**2) if np.sum(weights) > 0 else 0
 
         # Failure sample ratio
         failure_ratio = np.sum(g_values <= 0) / len(g_values)
 
         # Convergence rate (if we have history)
         if self.convergence_history:
-            prev_cv = self.convergence_history[-1]['cv']
+            prev_cv = self.convergence_history[-1]["cv"]
             cv_change = abs(cv - prev_cv) / max(prev_cv, 1e-10)
         else:
             cv_change = 1.0
 
         metrics = {
-            'cv': cv,
-            'ess': ess,
-            'failure_ratio': failure_ratio,
-            'cv_change': cv_change,
-            'iteration': iteration
+            "cv": cv,
+            "ess": ess,
+            "failure_ratio": failure_ratio,
+            "cv_change": cv_change,
+            "iteration": iteration,
         }
 
         self.convergence_history.append(metrics)
@@ -378,9 +367,7 @@ class AdaptiveSafeICE(OptimizedSafeICE):
         return metrics
 
     def _adaptive_stopping_criterion(
-        self,
-        metrics: Dict[str, float],
-        iteration: int
+        self, metrics: dict[str, float], iteration: int
     ) -> bool:
         """
         Adaptive stopping criterion based on multiple metrics.
@@ -406,32 +393,29 @@ class AdaptiveSafeICE(OptimizedSafeICE):
             return True
 
         # Check CV convergence
-        cv_converged = metrics['cv'] < 0.05
+        cv_converged = metrics["cv"] < 0.05
 
         # Check CV stability (small changes)
         if len(self.convergence_history) >= 3:
-            recent_cvs = [m['cv'] for m in self.convergence_history[-3:]]
-            cv_stable = np.std(recent_cvs) < 0.01
+            recent_cvs = [m["cv"] for m in self.convergence_history[-3:]]
+            cv_stable = bool(np.std(recent_cvs) < 0.01)
         else:
             cv_stable = False
 
         # Check ESS
-        ess_sufficient = metrics['ess'] > 0.5 * self.N
+        ess_sufficient = metrics["ess"] > 0.5 * self.N
 
         # Adaptive criterion
         if cv_converged and cv_stable:
             return True
 
-        if iteration > 10 and cv_stable and ess_sufficient:
-            return True
-
-        return False
+        return bool(iteration > 10 and cv_stable and ess_sufficient)
 
     def run(
         self,
-        initial_params: Optional[vMFNMParameters] = None,
+        initial_params: vMFNMParameters | None = None,
         verbose: bool = False,
-    ) -> Tuple[float, Dict[str, Any]]:
+    ) -> tuple[float, dict[str, Any]]:
         """
         Run Adaptive Safe-ICE algorithm.
 
@@ -461,10 +445,10 @@ class AdaptiveSafeICE(OptimizedSafeICE):
         delta_prev = 0.0
 
         # Storage
-        all_samples: List[NDArrayF] = []
-        all_g_values: List[NDArrayF] = []
-        all_weights: List[NDArrayF] = []
-        iterations_data: List[Dict[str, Any]] = []
+        all_samples: list[NDArrayF] = []
+        all_g_values: list[NDArrayF] = []
+        all_weights: list[NDArrayF] = []
+        iterations_data: list[dict[str, Any]] = []
 
         if verbose:
             print("=" * 50)
@@ -489,28 +473,27 @@ class AdaptiveSafeICE(OptimizedSafeICE):
                 self._precompute_omega_in(phi_t)
 
             # Compute convergence rate for adaptive schedule
-            if t > 0:
-                conv_rate = self.convergence_history[-1]['cv_change']
-            else:
-                conv_rate = 1.0
+            conv_rate = self.convergence_history[-1]["cv_change"] if t > 0 else 1.0
 
             # Adaptive annealing
             lambda_t = self._adaptive_annealing_schedule(sigma, t, conv_rate)
 
             # Generate samples
             if verbose:
-                print(f"  Generating {self.N} samples (λ={lambda_t:.3f})...")
+                print(f"  Generating {self.N} samples (lambda={lambda_t:.3f})...")
             samples_t = self._generate_safe_mixture_samples_batched(phi_t, lambda_t)
 
             # Evaluate limit state
             g_values_t = self._evaluate_limit_state_vectorized(samples_t)
 
             # Update delta adaptively
-            if t > 0 and self.convergence_history[-1]['failure_ratio'] < 0.01:
+            if t > 0 and self.convergence_history[-1]["failure_ratio"] < 0.01:
                 # Few failures - increase delta more aggressively
                 delta_increment = self.delta_star * 1.5
             else:
-                delta_increment = self.delta_star if delta_prev >= self.delta_star else 0.0
+                delta_increment = (
+                    self.delta_star if delta_prev >= self.delta_star else 0.0
+                )
 
             delta_t = min(self.delta_target, delta_prev + delta_increment)
             delta_prev = delta_t
@@ -534,14 +517,16 @@ class AdaptiveSafeICE(OptimizedSafeICE):
             all_g_values.append(g_values_t)
             all_weights.append(weights_t)
 
-            iterations_data.append({
-                "iteration": t + 1,
-                "K": phi_t.K,
-                "delta": delta_t,
-                "lambda": lambda_t,
-                "metrics": metrics,
-                "sigma": sigma,
-            })
+            iterations_data.append(
+                {
+                    "iteration": t + 1,
+                    "K": phi_t.K,
+                    "delta": delta_t,
+                    "lambda": lambda_t,
+                    "metrics": metrics,
+                    "sigma": sigma,
+                }
+            )
 
             # Check adaptive stopping
             if self._adaptive_stopping_criterion(metrics, t):
@@ -567,7 +552,7 @@ class AdaptiveSafeICE(OptimizedSafeICE):
                         elites_samples, elites_weights, phi_t, t
                     )
                     if verbose:
-                        print(f"  Auto-tuned β: {beta:.3f}")
+                        print(f"  Auto-tuned beta: {beta:.3f}")
                 else:
                     beta = 1.0
 
@@ -591,7 +576,7 @@ class AdaptiveSafeICE(OptimizedSafeICE):
 
                 if verbose:
                     print(f"  Updated K: {K_old} -> {K_new}")
-                    print(f"  Updated σ: {sigma:.4f}")
+                    print(f"  Updated sigma: {sigma:.4f}")
 
         # Combine results
         final_samples = np.vstack(all_samples)
@@ -610,8 +595,8 @@ class AdaptiveSafeICE(OptimizedSafeICE):
             "iterations": iterations_data,
             "convergence_metrics": {
                 "history": self.convergence_history,
-                "cv_values": [m['cv'] for m in self.convergence_history],
-                "ess_values": [m['ess'] for m in self.convergence_history],
+                "cv_values": [m["cv"] for m in self.convergence_history],
+                "ess_values": [m["ess"] for m in self.convergence_history],
             },
             "adaptive_metrics": {
                 "beta_history": self.beta_history,
@@ -627,7 +612,11 @@ class AdaptiveSafeICE(OptimizedSafeICE):
             print(f"Failure Probability: {pf_estimate:.6e}")
             print(f"Total Iterations: {t + 1}")
             print(f"Final Components: {phi_t.K}")
-            print(f"Average β: {np.mean(self.beta_history):.3f}" if self.beta_history else "")
+            print(
+                f"Average beta: {np.mean(self.beta_history):.3f}"
+                if self.beta_history
+                else ""
+            )
 
         return float(pf_estimate), results
 
@@ -666,7 +655,7 @@ class AdaptiveSafeICE(OptimizedSafeICE):
 
         if d == 2:
             # Uniform angles in 2D
-            angles = np.linspace(0, 2*np.pi, K, endpoint=False)
+            angles = np.linspace(0, 2 * np.pi, K, endpoint=False)
             mu[:, 0] = np.cos(angles)
             mu[:, 1] = np.sin(angles)
         else:

--- a/safe_ice/core/parameters.py
+++ b/safe_ice/core/parameters.py
@@ -8,6 +8,7 @@ We use explicit NumPy typing so mypy knows array shapes/dtypes and to avoid
 from __future__ import annotations
 
 from dataclasses import dataclass
+
 import numpy as np
 import numpy.typing as npt
 
@@ -33,11 +34,11 @@ class vMFNMParameters:
         vMF concentration parameters (shape: (K,)), kappa >= 0.
     """
 
-    pi: NDArrayF          # (K,)
-    m: NDArrayF           # (K,)
-    Omega: NDArrayF       # (K,)
-    mu: NDArrayF          # (K, d)
-    kappa: NDArrayF       # (K,)
+    pi: NDArrayF  # (K,)
+    m: NDArrayF  # (K,)
+    Omega: NDArrayF  # (K,)
+    mu: NDArrayF  # (K, d)
+    kappa: NDArrayF  # (K,)
 
     def __init__(
         self,

--- a/safe_ice/core/safe_ice_optimized.py
+++ b/safe_ice/core/safe_ice_optimized.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import math
-import warnings
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from collections.abc import Callable
+from typing import Any
 
 import numpy as np
 import numpy.typing as npt
@@ -14,19 +14,23 @@ try:
     from numba import jit, prange
 except ImportError:
     # Optional acceleration: keep API compatible when numba is unavailable.
-    def jit(*args: Any, **kwargs: Any) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    def jit(
+        *args: Any, **kwargs: Any
+    ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
         def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
             return func
 
         return decorator
 
-    def prange(*args: Any, **kwargs: Any) -> range:  # type: ignore[misc]
+    def prange(*args: Any, **kwargs: Any) -> range:
         return range(*args)
 
-from .parameters import vMFNMParameters
+
 from ..distributions.nakagami import InverseNakagamiDistribution, NakagamiDistribution
 from ..distributions.vmf import VonMisesFisherSampler
 from ..optimization.penalized_em import PenalizedEMOptimizer
+from ..typing import LimitStateFunction
+from .parameters import vMFNMParameters
 
 # Type alias for NumPy float arrays
 NDArrayF = npt.NDArray[np.float64]
@@ -45,7 +49,7 @@ class OptimizedSafeICE:
 
     def __init__(
         self,
-        limit_state_function: Callable[[NDArrayF], float],
+        limit_state_function: LimitStateFunction,
         dimension: int,
         K0: int = 20,
         delta_target: float = 4.0,
@@ -56,8 +60,8 @@ class OptimizedSafeICE:
         em_max_iter: int = 100,
         enable_caching: bool = True,
         enable_parallel: bool = True,
-        batch_size: Optional[int] = None,
-        random_state: Optional[int | np.random.Generator] = None,
+        batch_size: int | None = None,
+        random_state: int | np.random.Generator | None = None,
     ) -> None:
         """
         Initialize Optimized Safe-ICE.
@@ -113,20 +117,20 @@ class OptimizedSafeICE:
         self.batch_size = batch_size or min(N, 10000)
 
         # Caches
-        self._omega_in_cache: Optional[Dict[int, float]] = None
-        self._pdf_cache: Optional[Dict[Tuple[float, ...], float]] = None
+        self._omega_in_cache: dict[int, float] | None = None
+        self._pdf_cache: dict[tuple[float, ...], float] | None = None
 
         # Pre-compute constants
-        self.m_IN = max(1, int(math.ceil(math.sqrt(self.d))))
+        self.m_IN = max(1, math.ceil(math.sqrt(self.d)))
 
         # Statistics tracking
-        self.history: List[Dict[str, Any]] = []
+        self.history: list[dict[str, Any]] = []
 
     def run(
         self,
-        initial_params: Optional[vMFNMParameters] = None,
+        initial_params: vMFNMParameters | None = None,
         verbose: bool = False,
-    ) -> Tuple[float, Dict[str, Any]]:
+    ) -> tuple[float, dict[str, Any]]:
         """
         Run optimized Safe-ICE algorithm.
 
@@ -156,12 +160,12 @@ class OptimizedSafeICE:
         phi_t = phi_0
 
         # Storage for all samples and weights
-        all_samples: List[NDArrayF] = []
-        all_g_values: List[NDArrayF] = []
-        all_weights: List[NDArrayF] = []
-        iterations_data: List[Dict[str, Any]] = []
-        cv_values: List[float] = []
-        delta_values: List[float] = []
+        all_samples: list[NDArrayF] = []
+        all_g_values: list[NDArrayF] = []
+        all_weights: list[NDArrayF] = []
+        iterations_data: list[dict[str, Any]] = []
+        cv_values: list[float] = []
+        delta_values: list[float] = []
 
         if verbose:
             print("=" * 50)
@@ -203,7 +207,7 @@ class OptimizedSafeICE:
 
             # Step 5: Compute importance weights
             if verbose:
-                print(f"  Computing importance weights...")
+                print("  Computing importance weights...")
             weights_t = self._compute_importance_weights_vectorized(
                 samples_t, g_values_t, phi_t, lambda_t, delta_t, sigma
             )
@@ -224,15 +228,17 @@ class OptimizedSafeICE:
             all_weights.append(weights_t)
 
             # Store iteration data
-            iterations_data.append({
-                "iteration": t + 1,
-                "K": phi_t.K,
-                "delta": delta_t,
-                "lambda": lambda_t,
-                "cv": cv_weights,
-                "sigma": sigma,
-                "n_failures": np.sum(g_values_t <= 0),
-            })
+            iterations_data.append(
+                {
+                    "iteration": t + 1,
+                    "K": phi_t.K,
+                    "delta": delta_t,
+                    "lambda": lambda_t,
+                    "cv": cv_weights,
+                    "sigma": sigma,
+                    "n_failures": np.sum(g_values_t <= 0),
+                }
+            )
 
             # Step 7: Update parameters (if not last iteration)
             if t < self.max_iterations - 1:
@@ -248,11 +254,11 @@ class OptimizedSafeICE:
 
                 # Penalized EM optimization
                 if verbose:
-                    print(f"  Running Penalized EM...")
-                optimizer = PenalizedEMOptimizer(
-                    max_em_iterations=self.em_max_iter
+                    print("  Running Penalized EM...")
+                optimizer = PenalizedEMOptimizer(max_em_iterations=self.em_max_iter)
+                phi_t, _ = optimizer.fit(
+                    elites_samples, elites_weights, phi_t, beta_init=1.0
                 )
-                phi_t, _ = optimizer.fit(elites_samples, elites_weights, phi_t, beta_init=1.0)
 
                 # Adapt sigma based on component evolution
                 K_new = phi_t.K
@@ -277,7 +283,11 @@ class OptimizedSafeICE:
         # Compute failure probability
         failure_indicator = (final_g_values <= 0).astype(float)
         pf_estimate = np.sum(failure_indicator * final_weights) / np.sum(final_weights)
-        cv_w_star = self._compute_cv(final_weights[final_g_values <= 0]) if np.any(final_g_values <= 0) else 0.0
+        cv_w_star = (
+            self._compute_cv(final_weights[final_g_values <= 0])
+            if np.any(final_g_values <= 0)
+            else 0.0
+        )
 
         # Prepare results
         results = {
@@ -326,7 +336,9 @@ class OptimizedSafeICE:
         """Get cached Omega_IN value or compute if not cached."""
         if self.enable_caching and self._omega_in_cache and k in self._omega_in_cache:
             return self._omega_in_cache[k]
-        return self._calculate_matched_omega_inverse_nakagami(m_k, omega_k, float(self.m_IN))
+        return self._calculate_matched_omega_inverse_nakagami(
+            m_k, omega_k, float(self.m_IN)
+        )
 
     # -------------------------------------------------------------------------
     # Vectorized Operations
@@ -371,13 +383,17 @@ class OptimizedSafeICE:
 
             # Sample radii (vectorized)
             radii = NakagamiDistribution.sample(
-                float(params.m[k]), float(params.Omega[k]), n_k,
+                float(params.m[k]),
+                float(params.Omega[k]),
+                n_k,
                 rng=self._rng,
             )
 
             # Sample directions (already vectorized in VonMisesFisherSampler)
             directions = VonMisesFisherSampler.sample(
-                params.mu[k], float(params.kappa[k]), n_k,
+                params.mu[k],
+                float(params.kappa[k]),
+                n_k,
                 rng=self._rng,
             )
 
@@ -386,7 +402,9 @@ class OptimizedSafeICE:
 
         return samples
 
-    def _sample_heavy_tailed_batch(self, params: vMFNMParameters, n_samples: int) -> NDArrayF:
+    def _sample_heavy_tailed_batch(
+        self, params: vMFNMParameters, n_samples: int
+    ) -> NDArrayF:
         """Sample batch from heavy-tailed distribution (vectorized)."""
         samples = np.zeros((n_samples, self.d), dtype=np.float64)
 
@@ -407,13 +425,17 @@ class OptimizedSafeICE:
 
             # Sample radii from inverse Nakagami
             radii = InverseNakagamiDistribution.sample(
-                float(self.m_IN), omega_in, n_k,
+                float(self.m_IN),
+                omega_in,
+                n_k,
                 rng=self._rng,
             )
 
             # Sample directions
             directions = VonMisesFisherSampler.sample(
-                params.mu[k], float(params.kappa[k]), n_k,
+                params.mu[k],
+                float(params.kappa[k]),
+                n_k,
                 rng=self._rng,
             )
 
@@ -428,7 +450,7 @@ class OptimizedSafeICE:
 
         if n_samples <= self.batch_size:
             # Evaluate all at once
-            return self.g(samples)
+            return np.asarray(self.g(samples), dtype=np.float64)
         else:
             # Process in batches to manage memory
             g_values = np.zeros(n_samples, dtype=np.float64)
@@ -465,7 +487,9 @@ class OptimizedSafeICE:
                 )
 
         # Standard normal density (vectorized)
-        phi_u = np.exp(-0.5 * np.sum(samples**2, axis=1)) / ((2 * np.pi) ** (self.d / 2))
+        phi_u = np.exp(-0.5 * np.sum(samples**2, axis=1)) / (
+            (2 * np.pi) ** (self.d / 2)
+        )
 
         # Importance weights with regularization
         weights = np.zeros(n_samples, dtype=np.float64)
@@ -483,10 +507,10 @@ class OptimizedSafeICE:
         samples: NDArrayF,
         params: vMFNMParameters,
         lambda_val: float,
-        sigma: float
+        sigma: float,
     ) -> NDArrayF:
         """Evaluate safe mixture density (vectorized)."""
-        n_samples = samples.shape[0]
+        samples.shape[0]
 
         # Compute both components
         q_light = self._evaluate_vmfnm_density_vectorized(samples, params, sigma)
@@ -607,15 +631,18 @@ class OptimizedSafeICE:
     def _compute_cv(self, weights: NDArrayF) -> float:
         """Compute coefficient of variation of weights."""
         if len(weights) == 0 or np.sum(weights) == 0:
-            return float('inf')
+            return float("inf")
         mean_w = np.mean(weights)
         if mean_w == 0:
-            return float('inf')
+            return float("inf")
         std_w = np.std(weights)
         return float(std_w / mean_w)
 
     def _calculate_matched_omega_inverse_nakagami(
-        self, m: float, Omega: float, m_IN: float
+        self,
+        m: float,  # noqa: ARG002 - overrides the base signature
+        Omega: float,
+        m_IN: float,
     ) -> float:
         """Calculate Omega_IN for mode matching."""
         chi2_pdf_val = chi2.pdf(Omega * self.sigma0**2, df=self.d)
@@ -632,7 +659,9 @@ class OptimizedSafeICE:
 
         # General formula
         d = self.d
-        return kappa**(d/2 - 1) / ((2*np.pi)**(d/2) * iv(d/2 - 1, kappa))
+        return float(
+            kappa ** (d / 2 - 1) / ((2 * np.pi) ** (d / 2) * iv(d / 2 - 1, kappa))
+        )
 
 
 # Optional: Numba-accelerated functions for critical loops
@@ -647,7 +676,7 @@ def compute_radii_parallel(samples: NDArrayF) -> NDArrayF:
 
 
 @jit(nopython=True, parallel=True)
-def evaluate_limit_state_parallel(samples: NDArrayF, g_func) -> NDArrayF:
+def evaluate_limit_state_parallel(samples: NDArrayF, g_func: Any) -> NDArrayF:
     """Evaluate limit state in parallel (if g_func is Numba-compatible)."""
     n_samples = samples.shape[0]
     g_values = np.zeros(n_samples, dtype=np.float64)

--- a/safe_ice/distributions/__init__.py
+++ b/safe_ice/distributions/__init__.py
@@ -1,12 +1,12 @@
 """Distribution implementations for Safe-ICE."""
 
-from .vmf import VonMisesFisherSampler
-from .nakagami import NakagamiDistribution, InverseNakagamiDistribution
 from .mixture import vMFNMDistribution
+from .nakagami import InverseNakagamiDistribution, NakagamiDistribution
+from .vmf import VonMisesFisherSampler
 
 __all__ = [
-    "VonMisesFisherSampler",
-    "NakagamiDistribution",
     "InverseNakagamiDistribution",
+    "NakagamiDistribution",
+    "VonMisesFisherSampler",
     "vMFNMDistribution",
 ]

--- a/safe_ice/distributions/nakagami.py
+++ b/safe_ice/distributions/nakagami.py
@@ -12,11 +12,13 @@ We expose precise typing with @overload so mypy understands both cases.
 
 from __future__ import annotations
 
-from typing import overload
+from typing import Any, overload
 
 import numpy as np
 import numpy.typing as npt
-from scipy.special import gamma, gammainc, loggamma  # normalized lower incomplete gamma
+from scipy.special import gammainc, loggamma  # normalized lower incomplete gamma
+
+from ..typing import RNGLike
 
 NDArrayF = npt.NDArray[np.float64]
 
@@ -73,17 +75,19 @@ class NakagamiDistribution:
                 std = np.sqrt(variance)
 
                 # Use normal PDF approximation
-                pdf_values = (1.0 / (std * np.sqrt(2 * np.pi))) * np.exp(-0.5 * ((xm - mode) / std) ** 2)
+                pdf_values = (1.0 / (std * np.sqrt(2 * np.pi))) * np.exp(
+                    -0.5 * ((xm - mode) / std) ** 2
+                )
                 out[mask] = pdf_values
             else:
                 # Standard log-space computation for reasonable m values
                 log_pdf = (
-                    np.log(2.0) +
-                    m * np.log(m) -
-                    loggamma(m) -
-                    m * np.log(Omega) +
-                    (2.0 * m - 1.0) * np.log(xm) -
-                    m * (xm ** 2) / Omega
+                    np.log(2.0)
+                    + m * np.log(m)
+                    - loggamma(m)
+                    - m * np.log(Omega)
+                    + (2.0 * m - 1.0) * np.log(xm)
+                    - m * (xm**2) / Omega
                 )
 
                 # Convert back from log-space, handling potential underflow
@@ -132,6 +136,7 @@ class NakagamiDistribution:
 
                     # Normal CDF
                     from scipy.stats import norm
+
                     out[mask] = norm.cdf(r_arr[mask], loc=mode, scale=std)
                 else:
                     # Handle potential overflow in z
@@ -151,7 +156,7 @@ class NakagamiDistribution:
     # -------------------- Sample --------------------
     @staticmethod
     def sample(
-        m: float, Omega: float, n: int = 1, rng: object = None
+        m: float, Omega: float, n: int = 1, rng: RNGLike | None = None
     ) -> NDArrayF:
         """Draw `n` Nakagami samples as sqrt of a Gamma(m, Omega/m).
 
@@ -160,7 +165,7 @@ class NakagamiDistribution:
         rng : numpy random generator, optional
             If *None*, the global ``np.random`` state is used.
         """
-        _rng = rng if rng is not None else np.random
+        _rng: Any = rng if rng is not None else np.random
         m = float(m)
         Omega = float(Omega)
         n = int(n)
@@ -170,12 +175,10 @@ class NakagamiDistribution:
             variance = Omega * (1 - 1 / (4 * m)) / m if m > 0.25 else Omega
             std = np.sqrt(variance)
             samples = _rng.normal(mean, std, n)
-            return np.abs(samples).astype(np.float64, copy=False)
+            return np.asarray(np.abs(samples), dtype=np.float64)
 
-        x = _rng.gamma(
-            shape=m, scale=(Omega / m), size=n
-        ).astype(np.float64, copy=False)
-        return np.sqrt(x).astype(np.float64, copy=False)
+        x = np.asarray(_rng.gamma(shape=m, scale=(Omega / m), size=n), dtype=np.float64)
+        return np.asarray(np.sqrt(x), dtype=np.float64)
 
 
 # =============================================================================
@@ -219,7 +222,7 @@ class InverseNakagamiDistribution:
         fr = NakagamiDistribution.pdf(r_inv, m, Omega)  # returns ndarray here
 
         # Compute final PDF
-        pdf_values = fr * (1.0 / (ym ** 2))
+        pdf_values = fr * (1.0 / (ym**2))
         # Handle any numerical issues
         pdf_values = np.where(np.isfinite(pdf_values), pdf_values, 0.0)
         out[mask] = pdf_values
@@ -257,7 +260,7 @@ class InverseNakagamiDistribution:
     # -------------------- Sample --------------------
     @staticmethod
     def sample(
-        m: float, Omega: float, n: int = 1, rng: object = None
+        m: float, Omega: float, n: int = 1, rng: RNGLike | None = None
     ) -> NDArrayF:
         """Draw `n` samples via Y = 1/R, R ~ Nakagami(m, Omega).
 

--- a/safe_ice/distributions/nakagami_stable.py
+++ b/safe_ice/distributions/nakagami_stable.py
@@ -19,7 +19,7 @@ from typing import overload
 
 import numpy as np
 import numpy.typing as npt
-from scipy.special import gamma, gammainc, loggamma  # normalized lower incomplete gamma
+from scipy.special import gammainc, loggamma  # normalized lower incomplete gamma
 
 NDArrayF = npt.NDArray[np.float64]
 
@@ -68,12 +68,12 @@ class NakagamiDistribution:
         # log(pdf) = log(2) + m*log(m) - loggamma(m) - m*log(Omega) + (2m-1)*log(xm) - m*xm^2/Omega
         try:
             log_pdf = (
-                np.log(2.0) +
-                m * np.log(m) -
-                loggamma(m) -
-                m * np.log(Omega) +
-                (2.0 * m - 1.0) * np.log(xm) -
-                m * (xm ** 2) / Omega
+                np.log(2.0)
+                + m * np.log(m)
+                - loggamma(m)
+                - m * np.log(Omega)
+                + (2.0 * m - 1.0) * np.log(xm)
+                - m * (xm**2) / Omega
             )
 
             # Convert back from log-space, handling potential underflow
@@ -121,12 +121,12 @@ class NakagamiDistribution:
 
         # Compute log PDF
         log_pdf = (
-            np.log(2.0) +
-            m * np.log(m) -
-            loggamma(m) -
-            m * np.log(Omega) +
-            (2.0 * m - 1.0) * np.log(xm) -
-            m * (xm ** 2) / Omega
+            np.log(2.0)
+            + m * np.log(m)
+            - loggamma(m)
+            - m * np.log(Omega)
+            + (2.0 * m - 1.0) * np.log(xm)
+            - m * (xm**2) / Omega
         )
 
         out[mask] = log_pdf
@@ -191,7 +191,9 @@ class NakagamiDistribution:
 
         # Standard approach for reasonable m values
         # X ~ Gamma(shape=m, scale=Omega/m)  (NumPy parameterizes by shape & scale)
-        x = np.random.gamma(shape=m, scale=(Omega / m), size=n).astype(np.float64, copy=False)
+        x = np.random.gamma(shape=m, scale=(Omega / m), size=n).astype(
+            np.float64, copy=False
+        )
         return np.sqrt(x).astype(np.float64, copy=False)
 
 

--- a/safe_ice/distributions/vmf.py
+++ b/safe_ice/distributions/vmf.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import math
-from typing import Optional, Union
 
 import numpy as np
 import numpy.typing as npt
@@ -12,11 +11,11 @@ import numpy.typing as npt
 NDArrayF = npt.NDArray[np.float64]
 
 # Type alias accepted for the ``rng`` parameter.
-RNGLike = Union[np.random.Generator, np.random.RandomState]
+RNGLike = np.random.Generator | np.random.RandomState
 
 
 def _default_rng(
-    rng: Optional[RNGLike] = None,
+    rng: RNGLike | None = None,
 ) -> RNGLike:
     """Return *rng* if given, else the legacy ``np.random`` module."""
     return rng if rng is not None else np.random  # type: ignore[return-value]
@@ -30,7 +29,7 @@ class VonMisesFisherSampler:
         mu: npt.ArrayLike,
         kappa: float,
         n_samples: int = 1,
-        rng: Optional[RNGLike] = None,
+        rng: RNGLike | None = None,
     ) -> NDArrayF:
         """
         Sample from a vMF_d(mu, kappa).
@@ -62,9 +61,9 @@ class VonMisesFisherSampler:
                 dtype=np.float64,
             )
             # normalize each row
-            norms: NDArrayF = np.linalg.norm(
-                samples, axis=1, keepdims=True
-            ).astype(np.float64, copy=False)
+            norms: NDArrayF = np.linalg.norm(samples, axis=1, keepdims=True).astype(
+                np.float64, copy=False
+            )
             eps: float = float(np.finfo(np.float64).tiny)
             norms = np.maximum(norms, eps)
             return (samples / norms).astype(np.float64, copy=False)
@@ -82,24 +81,19 @@ class VonMisesFisherSampler:
         if kappa >= 30.0:
             noise_scale = 0.2 / math.sqrt(float(kappa))
             raw: NDArrayF = np.asarray(
-                mu_unit
-                + _rng.normal(0.0, noise_scale, size=(n_samples, d)),
+                mu_unit + _rng.normal(0.0, noise_scale, size=(n_samples, d)),
                 dtype=np.float64,
             )
-            norms_h: NDArrayF = np.linalg.norm(
-                raw, axis=1, keepdims=True
-            ).astype(np.float64, copy=False)
+            norms_h: NDArrayF = np.linalg.norm(raw, axis=1, keepdims=True).astype(
+                np.float64, copy=False
+            )
             eps_h: float = float(np.finfo(np.float64).tiny)
-            return (
-                raw / np.maximum(norms_h, eps_h)
-            ).astype(np.float64, copy=False)
+            return np.asarray(raw / np.maximum(norms_h, eps_h), dtype=np.float64)
 
         # General case d >= 3
         out: NDArrayF = np.zeros((n_samples, d), dtype=np.float64)
         for i in range(n_samples):
-            w: float = VonMisesFisherSampler._sample_w_wood(
-                float(kappa), d, _rng
-            )
+            w: float = VonMisesFisherSampler._sample_w_wood(float(kappa), d, _rng)
 
             # v ~ Unif(S^{d-2}) in R^{d-1}
             v_raw: NDArrayF = np.asarray(
@@ -108,9 +102,7 @@ class VonMisesFisherSampler:
             )
             v_norm: float = float(np.linalg.norm(v_raw))
             if v_norm > 0.0:
-                v: NDArrayF = (v_raw / v_norm).astype(
-                    np.float64, copy=False
-                )
+                v: NDArrayF = (v_raw / v_norm).astype(np.float64, copy=False)
             else:
                 v = np.zeros(d - 1, dtype=np.float64)
                 v[0] = 1.0
@@ -126,9 +118,7 @@ class VonMisesFisherSampler:
             ).astype(np.float64, copy=False)
 
             # Rotate e_d -> mu via Householder and apply to xy
-            out[i, :] = VonMisesFisherSampler._householder_rotation(
-                xy, mu_unit
-            )
+            out[i, :] = VonMisesFisherSampler._householder_rotation(xy, mu_unit)
 
         return out
 
@@ -148,18 +138,15 @@ class VonMisesFisherSampler:
         )
         mu_angle: float = float(np.arctan2(mu[1], mu[0]))
         angles = (angles + mu_angle).astype(np.float64, copy=False)
-        return np.column_stack(
-            [np.cos(angles), np.sin(angles)]
-        ).astype(np.float64, copy=False)
+        return np.column_stack([np.cos(angles), np.sin(angles)]).astype(
+            np.float64, copy=False
+        )
 
     @staticmethod
-    def _sample_w_wood(
-        kappa: float, d: int, rng: RNGLike
-    ) -> float:
+    def _sample_w_wood(kappa: float, d: int, rng: RNGLike) -> float:
         """Sample the last coordinate w using Wood (1994) rejection sampler."""
         b: float = (d - 1.0) / (
-            2.0 * kappa
-            + math.sqrt(4.0 * kappa * kappa + (d - 1.0) ** 2)
+            2.0 * kappa + math.sqrt(4.0 * kappa * kappa + (d - 1.0) ** 2)
         )
         x0: float = (1.0 - b) / (1.0 + b)
         c: float = kappa * x0 + (d - 1.0) * math.log(1.0 - x0 * x0)
@@ -172,16 +159,12 @@ class VonMisesFisherSampler:
             w: float = (1.0 - (1.0 + b) * z) / (1.0 - (1.0 - b) * z)
             u: float = float(rng.uniform(0.0, 1.0))
 
-            test_val: float = (
-                kappa * w + (d - 1.0) * math.log(1.0 - x0 * w) - c
-            )
+            test_val: float = kappa * w + (d - 1.0) * math.log(1.0 - x0 * w) - c
             if test_val >= math.log(u):
                 return w
 
     @staticmethod
-    def _householder_rotation(
-        x: npt.ArrayLike, mu: npt.ArrayLike
-    ) -> NDArrayF:
+    def _householder_rotation(x: npt.ArrayLike, mu: npt.ArrayLike) -> NDArrayF:
         """Apply Householder reflection that maps e_d to mu."""
         x_arr: NDArrayF = np.asarray(x, dtype=np.float64).reshape(-1)
         mu_arr: NDArrayF = np.asarray(mu, dtype=np.float64).reshape(-1)

--- a/safe_ice/problems/__init__.py
+++ b/safe_ice/problems/__init__.py
@@ -1,4 +1,3 @@
-
 """Benchmark problems for Safe-ICE testing."""
 
 from .benchmarks import BenchmarkProblems

--- a/safe_ice/problems/advanced_problems.py
+++ b/safe_ice/problems/advanced_problems.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
+from functools import partial
+
 import numpy as np
-from typing import Callable, List, Optional, Tuple, Union
 import numpy.typing as npt
-from scipy.stats import norm, multivariate_normal
 from scipy.linalg import cholesky
+
+from ..typing import LimitStateFunction
 
 NDArrayF = npt.NDArray[np.float64]
 
@@ -22,7 +25,7 @@ class TimeVariantProblem:
         self,
         limit_state_func: Callable[[NDArrayF, float], float],
         time_points: NDArrayF,
-        correlation_func: Optional[Callable[[float, float], float]] = None
+        correlation_func: Callable[[float, float], float] | None = None,
     ):
         """
         Initialize time-variant problem.
@@ -48,7 +51,7 @@ class TimeVariantProblem:
     def _default_correlation(self, t1: float, t2: float) -> float:
         """Default exponential correlation function."""
         correlation_length = 1.0
-        return np.exp(-abs(t1 - t2) / correlation_length)
+        return float(np.exp(-abs(t1 - t2) / correlation_length))
 
     def _build_correlation_matrix(self) -> NDArrayF:
         """Build correlation matrix for time points."""
@@ -58,8 +61,7 @@ class TimeVariantProblem:
         for i in range(n):
             for j in range(n):
                 R[i, j] = self.correlation_func(
-                    self.time_points[i],
-                    self.time_points[j]
+                    self.time_points[i], self.time_points[j]
                 )
 
         # Ensure positive definiteness
@@ -69,7 +71,7 @@ class TimeVariantProblem:
 
         return R
 
-    def get_series_system_limit_state(self) -> Callable:
+    def get_series_system_limit_state(self) -> LimitStateFunction:
         """
         Get limit state function for series system over time.
 
@@ -80,6 +82,7 @@ class TimeVariantProblem:
         callable
             Combined limit state function.
         """
+
         def g_series(u: NDArrayF) -> NDArrayF:
             """Series system: min_t g(u, t)."""
             if u.ndim == 1:
@@ -90,9 +93,7 @@ class TimeVariantProblem:
 
             for i in range(n_samples):
                 # Evaluate at all time points
-                g_t = np.array([
-                    self.g_base(u[i], t) for t in self.time_points
-                ])
+                g_t = np.array([self.g_base(u[i], t) for t in self.time_points])
                 # Series system: take minimum
                 g_values[i] = np.min(g_t)
 
@@ -100,7 +101,7 @@ class TimeVariantProblem:
 
         return g_series
 
-    def get_parallel_system_limit_state(self) -> Callable:
+    def get_parallel_system_limit_state(self) -> LimitStateFunction:
         """
         Get limit state function for parallel system over time.
 
@@ -111,6 +112,7 @@ class TimeVariantProblem:
         callable
             Combined limit state function.
         """
+
         def g_parallel(u: NDArrayF) -> NDArrayF:
             """Parallel system: max_t g(u, t)."""
             if u.ndim == 1:
@@ -121,9 +123,7 @@ class TimeVariantProblem:
 
             for i in range(n_samples):
                 # Evaluate at all time points
-                g_t = np.array([
-                    self.g_base(u[i], t) for t in self.time_points
-                ])
+                g_t = np.array([self.g_base(u[i], t) for t in self.time_points])
                 # Parallel system: take maximum
                 g_values[i] = np.max(g_t)
 
@@ -132,10 +132,8 @@ class TimeVariantProblem:
         return g_parallel
 
     def get_cumulative_damage_limit_state(
-        self,
-        damage_func: Callable[[NDArrayF, float], float],
-        threshold: float = 1.0
-    ) -> Callable:
+        self, damage_func: Callable[[NDArrayF, float], float], threshold: float = 1.0
+    ) -> LimitStateFunction:
         """
         Get limit state function for cumulative damage.
 
@@ -151,6 +149,7 @@ class TimeVariantProblem:
         callable
             Cumulative damage limit state function.
         """
+
         def g_damage(u: NDArrayF) -> NDArrayF:
             """Cumulative damage: threshold - sum_t d(u, t)*dt."""
             if u.ndim == 1:
@@ -189,8 +188,8 @@ class SystemReliabilityProblem:
 
     def __init__(
         self,
-        component_funcs: List[Callable],
-        correlation_matrix: Optional[NDArrayF] = None
+        component_funcs: list[LimitStateFunction],
+        correlation_matrix: NDArrayF | None = None,
     ):
         """
         Initialize system reliability problem.
@@ -208,12 +207,15 @@ class SystemReliabilityProblem:
         if correlation_matrix is not None:
             self.correlation_matrix = np.asarray(correlation_matrix)
             # Validate correlation matrix
-            assert self.correlation_matrix.shape == (self.n_components, self.n_components)
+            assert self.correlation_matrix.shape == (
+                self.n_components,
+                self.n_components,
+            )
             assert np.allclose(self.correlation_matrix, self.correlation_matrix.T)
         else:
             self.correlation_matrix = np.eye(self.n_components)
 
-    def get_series_system(self) -> Callable:
+    def get_series_system(self) -> LimitStateFunction:
         """
         Get series system limit state function.
 
@@ -224,6 +226,7 @@ class SystemReliabilityProblem:
         callable
             Series system limit state function.
         """
+
         def g_series(u: NDArrayF) -> NDArrayF:
             """Series system: min_i g_i(u)."""
             if u.ndim == 1:
@@ -234,9 +237,7 @@ class SystemReliabilityProblem:
 
             for i in range(n_samples):
                 # Evaluate all components
-                g_components = np.array([
-                    func(u[i]) for func in self.component_funcs
-                ])
+                g_components = np.array([func(u[i]) for func in self.component_funcs])
                 # Series: minimum
                 g_values[i] = np.min(g_components)
 
@@ -244,7 +245,7 @@ class SystemReliabilityProblem:
 
         return g_series
 
-    def get_parallel_system(self) -> Callable:
+    def get_parallel_system(self) -> LimitStateFunction:
         """
         Get parallel system limit state function.
 
@@ -255,6 +256,7 @@ class SystemReliabilityProblem:
         callable
             Parallel system limit state function.
         """
+
         def g_parallel(u: NDArrayF) -> NDArrayF:
             """Parallel system: max_i g_i(u)."""
             if u.ndim == 1:
@@ -265,9 +267,7 @@ class SystemReliabilityProblem:
 
             for i in range(n_samples):
                 # Evaluate all components
-                g_components = np.array([
-                    func(u[i]) for func in self.component_funcs
-                ])
+                g_components = np.array([func(u[i]) for func in self.component_funcs])
                 # Parallel: maximum
                 g_values[i] = np.max(g_components)
 
@@ -275,7 +275,7 @@ class SystemReliabilityProblem:
 
         return g_parallel
 
-    def get_k_out_of_n_system(self, k: int) -> Callable:
+    def get_k_out_of_n_system(self, k: int) -> LimitStateFunction:
         """
         Get k-out-of-n system limit state function.
 
@@ -291,6 +291,7 @@ class SystemReliabilityProblem:
         callable
             k-out-of-n system limit state function.
         """
+
         def g_k_out_of_n(u: NDArrayF) -> NDArrayF:
             """k-out-of-n system."""
             if u.ndim == 1:
@@ -301,9 +302,7 @@ class SystemReliabilityProblem:
 
             for i in range(n_samples):
                 # Evaluate all components
-                g_components = np.array([
-                    func(u[i]) for func in self.component_funcs
-                ])
+                g_components = np.array([func(u[i]) for func in self.component_funcs])
 
                 # Sort components
                 g_sorted = np.sort(g_components)
@@ -315,10 +314,7 @@ class SystemReliabilityProblem:
 
         return g_k_out_of_n
 
-    def get_correlated_system(
-        self,
-        system_type: str = "series"
-    ) -> Callable:
+    def get_correlated_system(self, system_type: str = "series") -> LimitStateFunction:
         """
         Get system with correlated components.
 
@@ -353,7 +349,7 @@ class SystemReliabilityProblem:
                 # Generate correlated inputs
                 if d >= self.n_components:
                     # Use first n_components dimensions
-                    z = u[i, :self.n_components]
+                    z = u[i, : self.n_components]
                 else:
                     # Extend with zeros
                     z = np.zeros(self.n_components)
@@ -363,10 +359,12 @@ class SystemReliabilityProblem:
                 u_corr = L @ z
 
                 # Evaluate components with correlated inputs
-                g_components = np.array([
-                    self.component_funcs[j](u_corr[j:j+1])
-                    for j in range(self.n_components)
-                ])
+                g_components = np.array(
+                    [
+                        self.component_funcs[j](u_corr[j : j + 1])
+                        for j in range(self.n_components)
+                    ]
+                )
 
                 # Apply system logic
                 if system_type == "series":
@@ -395,7 +393,7 @@ class StochasticProcessProblem:
         self,
         mean_func: Callable[[float], float],
         cov_func: Callable[[float, float], float],
-        mesh_points: NDArrayF
+        mesh_points: NDArrayF,
     ):
         """
         Initialize stochastic process problem.
@@ -426,14 +424,13 @@ class StochasticProcessProblem:
 
         for i in range(self.n_points):
             for j in range(self.n_points):
-                C[i, j] = self.cov_func(
-                    self.mesh_points[i],
-                    self.mesh_points[j]
-                )
+                C[i, j] = self.cov_func(self.mesh_points[i], self.mesh_points[j])
 
         return C
 
-    def _compute_kl_expansion(self, n_terms: Optional[int] = None) -> Tuple[NDArrayF, NDArrayF]:
+    def _compute_kl_expansion(
+        self, n_terms: int | None = None
+    ) -> tuple[NDArrayF, NDArrayF]:
         """Compute Karhunen-Loève expansion."""
         # Eigendecomposition
         eigvals, eigvecs = np.linalg.eigh(self.cov_matrix)
@@ -456,9 +453,7 @@ class StochasticProcessProblem:
         return eigvals, eigvecs
 
     def generate_random_field(
-        self,
-        xi: NDArrayF,
-        n_kl_terms: Optional[int] = None
+        self, xi: NDArrayF, n_kl_terms: int | None = None
     ) -> NDArrayF:
         """
         Generate random field realization using KL expansion.
@@ -476,9 +471,7 @@ class StochasticProcessProblem:
             Random field values at mesh points.
         """
         # Mean field
-        mean_field = np.array([
-            self.mean_func(x) for x in self.mesh_points
-        ])
+        mean_field = np.array([self.mean_func(x) for x in self.mesh_points])
 
         # Determine number of terms
         if n_kl_terms is None:
@@ -494,10 +487,8 @@ class StochasticProcessProblem:
         return field
 
     def get_excursion_limit_state(
-        self,
-        threshold: float,
-        n_kl_terms: Optional[int] = None
-    ) -> Callable:
+        self, threshold: float, n_kl_terms: int | None = None
+    ) -> LimitStateFunction:
         """
         Get limit state function for excursion over threshold.
 
@@ -513,6 +504,7 @@ class StochasticProcessProblem:
         callable
             Excursion limit state function.
         """
+
         def g_excursion(u: NDArrayF) -> NDArrayF:
             """Excursion: threshold - max(field)."""
             if u.ndim == 1:
@@ -543,8 +535,8 @@ class NetworkReliabilityProblem:
     def __init__(
         self,
         adjacency_matrix: NDArrayF,
-        edge_reliability_funcs: Optional[List[Callable]] = None
-    ):
+        edge_reliability_funcs: list[LimitStateFunction] | None = None,
+    ) -> None:
         """
         Initialize network reliability problem.
 
@@ -565,12 +557,12 @@ class NetworkReliabilityProblem:
             self.edge_funcs = edge_reliability_funcs
         else:
             # Default: all edges have same reliability
-            self.edge_funcs = [
-                lambda u, i=i: 3.0 - u[i] if i < len(u) else 3.0
-                for i in range(self.n_edges)
-            ]
+            def _edge_func(u: NDArrayF, i: int = 0) -> float:
+                return float(3.0 - u[i]) if i < len(u) else 3.0
 
-    def _extract_edges(self) -> List[Tuple[int, int]]:
+            self.edge_funcs = [partial(_edge_func, i=i) for i in range(self.n_edges)]
+
+    def _extract_edges(self) -> list[tuple[int, int]]:
         """Extract edge list from adjacency matrix."""
         edges = []
         for i in range(self.n_nodes):
@@ -580,10 +572,8 @@ class NetworkReliabilityProblem:
         return edges
 
     def get_connectivity_limit_state(
-        self,
-        source: int,
-        target: int
-    ) -> Callable:
+        self, source: int, target: int
+    ) -> LimitStateFunction:
         """
         Get limit state function for s-t connectivity.
 
@@ -599,6 +589,7 @@ class NetworkReliabilityProblem:
         callable
             Connectivity limit state function.
         """
+
         def g_connectivity(u: NDArrayF) -> NDArrayF:
             """Connectivity: 1 if connected, -1 if disconnected."""
             if u.ndim == 1:
@@ -621,9 +612,7 @@ class NetworkReliabilityProblem:
                         operational[node2, node1] = 1
 
                 # Check connectivity using BFS
-                connected = self._check_connectivity(
-                    operational, source, target
-                )
+                connected = self._check_connectivity(operational, source, target)
 
                 g_values[i] = 1.0 if connected else -1.0
 
@@ -631,12 +620,7 @@ class NetworkReliabilityProblem:
 
         return g_connectivity
 
-    def _check_connectivity(
-        self,
-        adj: NDArrayF,
-        source: int,
-        target: int
-    ) -> bool:
+    def _check_connectivity(self, adj: NDArrayF, source: int, target: int) -> bool:
         """Check if source and target are connected."""
         visited = np.zeros(self.n_nodes, dtype=bool)
         queue = [source]

--- a/safe_ice/problems/benchmarks.py
+++ b/safe_ice/problems/benchmarks.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from typing import Callable
+from collections.abc import Callable
 
 import numpy as np
 import numpy.typing as npt
@@ -46,7 +46,7 @@ class BenchmarkProblems:
             g_min = np.minimum(np.minimum(g1, g2), np.minimum(g3, g4)) + z
             if is_single:
                 return float(g_min[0])
-            return g_min.astype(np.float64, copy=False)
+            return np.asarray(g_min, dtype=np.float64)
 
         return limit_state_function
 
@@ -71,7 +71,7 @@ class BenchmarkProblems:
             g_min = np.minimum(g1, g2)
             if is_single:
                 return float(g_min[0])
-            return g_min.astype(np.float64, copy=False)
+            return np.asarray(g_min, dtype=np.float64)
 
         return limit_state_function
 
@@ -85,10 +85,9 @@ class BenchmarkProblems:
             u: npt.ArrayLike,
         ) -> float | npt.NDArray[np.float64]:
             # Parameters from the paper (kept as floats)
-            m = 6e4        # mass
-            k = 5e6        # stiffness
-            alpha = 0.1    # force partition
-            S = 0.005      # white-noise intensity
+            k = 5e6  # stiffness
+            alpha = 0.1  # force partition
+            S = 0.005  # white-noise intensity
 
             # Frequency discretization
             d_eff = max(int(d), 2)
@@ -118,7 +117,7 @@ class BenchmarkProblems:
 
             if is_single:
                 return float(g_values[0])
-            return g_values.astype(np.float64, copy=False)
+            return np.asarray(g_values, dtype=np.float64)
 
         return limit_state_function
 
@@ -152,7 +151,7 @@ class BenchmarkProblems:
             g_min = np.minimum(g1, g2)
             if is_single:
                 return float(g_min[0])
-            return g_min.astype(np.float64, copy=False)
+            return np.asarray(g_min, dtype=np.float64)
 
         return limit_state_function
 
@@ -174,6 +173,6 @@ class BenchmarkProblems:
 
             if is_single:
                 return float(g_values[0])
-            return g_values.astype(np.float64, copy=False)
+            return np.asarray(g_values, dtype=np.float64)
 
         return limit_state_function

--- a/safe_ice/problems/heat_transfer.py
+++ b/safe_ice/problems/heat_transfer.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from typing import Callable
+from collections.abc import Callable
 
 import numpy as np
 import numpy.typing as npt
@@ -93,9 +93,9 @@ class HeatTransferProblem:
 
         # --- Vectorized, type-stable column normalization ---
         # Norms as a (1, n_terms) array (keepdims=True prevents scalar return)
-        norms: NDArrayF = np.linalg.norm(
-            self.eigenvecs, axis=0, keepdims=True
-        ).astype(np.float64, copy=False)
+        norms: NDArrayF = np.linalg.norm(self.eigenvecs, axis=0, keepdims=True).astype(
+            np.float64, copy=False
+        )
 
         # Avoid division by zero in a vectorized, typed-safe way
         eps = np.finfo(np.float64).tiny  # strictly positive float64
@@ -119,7 +119,7 @@ class HeatTransferProblem:
         b_kappa = np.sqrt(np.log(1.0 + (sigma_kappa**2) / (mu_kappa**2)))
 
         # KL expansion coefficients
-        xi_vec: NDArrayF = np.asarray(xi, dtype=np.float64)[: self.n_terms]
+        np.asarray(xi, dtype=np.float64)[: self.n_terms]
         # KL expansion coefficients: turn the triple product into a matvec
         # shapes: eigenvecs (n_points, n_terms) @ coeffs (n_terms,) -> (n_points,)
         coeffs: NDArrayF = np.multiply(
@@ -146,7 +146,7 @@ class HeatTransferProblem:
 
         # Heat source region A = (0.2, 0.3) × (0.2, 0.3)
         x_indices = np.where((self.X >= 0.2) & (self.X <= 0.3))
-        y_indices = np.where((self.Y >= 0.2) & (self.Y <= 0.3))
+        np.where((self.Y >= 0.2) & (self.Y <= 0.3))
         source_mask: NDArrayB = np.zeros_like(T, dtype=bool)
         source_mask[x_indices[0], x_indices[1]] = True  # rectangular mask
 

--- a/safe_ice/utils/__init__.py
+++ b/safe_ice/utils/__init__.py
@@ -1,21 +1,21 @@
 """Utility functions for Safe-ICE."""
 
 from .performance import (
+    MemoryEfficientSampling,
+    OptimizationUtils,
+    ParallelProcessor,
     PerformanceCache,
     VectorizedOperations,
-    MemoryEfficientSampling,
-    ParallelProcessor,
-    OptimizationUtils,
     optimize_safe_ice_iteration,
-    profile_performance
+    profile_performance,
 )
 
 __all__ = [
+    "MemoryEfficientSampling",
+    "OptimizationUtils",
+    "ParallelProcessor",
     "PerformanceCache",
     "VectorizedOperations",
-    "MemoryEfficientSampling",
-    "ParallelProcessor",
-    "OptimizationUtils",
     "optimize_safe_ice_iteration",
-    "profile_performance"
+    "profile_performance",
 ]

--- a/safe_ice/utils/performance.py
+++ b/safe_ice/utils/performance.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
-import numpy as np
-from typing import Dict, Tuple, Optional, Any
-from functools import lru_cache
 import warnings
+from collections.abc import Callable, Sequence
+from functools import lru_cache
+from typing import Any
+
+import numpy as np
 
 
 class PerformanceCache:
@@ -21,18 +23,22 @@ class PerformanceCache:
             Maximum number of items to cache.
         """
         self.max_size = max_size
-        self._omega_in_cache: Dict[Tuple[float, float, float], float] = {}
-        self._vmf_norm_cache: Dict[Tuple[float, int], float] = {}
-        self._chi2_pdf_cache: Dict[Tuple[float, int], float] = {}
+        self._omega_in_cache: dict[tuple[float, float, float], float] = {}
+        self._vmf_norm_cache: dict[tuple[float, int], float] = {}
+        self._chi2_pdf_cache: dict[tuple[float, int], float] = {}
 
-    def clear(self):
+    def clear(self) -> None:
         """Clear all caches."""
         self._omega_in_cache.clear()
         self._vmf_norm_cache.clear()
         self._chi2_pdf_cache.clear()
 
     def get_omega_in(
-        self, m: float, omega: float, m_in: float, compute_func=None
+        self,
+        m: float,
+        omega: float,
+        m_in: float,
+        compute_func: Callable[[float, float, float], float] | None = None,
     ) -> float:
         """
         Get cached Omega_IN value or compute if not cached.
@@ -64,7 +70,10 @@ class PerformanceCache:
         return self._omega_in_cache[key]
 
     def get_vmf_normalization(
-        self, kappa: float, d: int, compute_func=None
+        self,
+        kappa: float,
+        d: int,
+        compute_func: Callable[[float, int], float] | None = None,
     ) -> float:
         """
         Get cached vMF normalization constant.
@@ -111,10 +120,12 @@ class VectorizedOperations:
         np.ndarray
             Radii array of shape (n_samples,).
         """
-        return np.linalg.norm(samples, axis=1)
+        return np.asarray(np.linalg.norm(samples, axis=1))
 
     @staticmethod
-    def normalize_directions_batch(samples: np.ndarray, radii: Optional[np.ndarray] = None) -> Tuple[np.ndarray, np.ndarray]:
+    def normalize_directions_batch(
+        samples: np.ndarray, radii: np.ndarray | None = None
+    ) -> tuple[np.ndarray, np.ndarray]:
         """
         Normalize samples to unit directions (vectorized).
 
@@ -147,10 +158,7 @@ class VectorizedOperations:
 
     @staticmethod
     def evaluate_vmf_density_batch(
-        directions: np.ndarray,
-        mu: np.ndarray,
-        kappa: float,
-        normalization: float
+        directions: np.ndarray, mu: np.ndarray, kappa: float, normalization: float
     ) -> np.ndarray:
         """
         Evaluate vMF density for batch of directions (vectorized).
@@ -173,13 +181,13 @@ class VectorizedOperations:
         """
         # Vectorized dot product
         dot_products = np.dot(directions, mu)
-        return normalization * np.exp(kappa * dot_products)
+        return np.asarray(normalization * np.exp(kappa * dot_products))
 
     @staticmethod
     def evaluate_mixture_density_batch(
-        samples: np.ndarray,
+        samples: np.ndarray,  # noqa: ARG004 - kept so batch helpers share one signature
         component_densities: np.ndarray,
-        weights: np.ndarray
+        weights: np.ndarray,
     ) -> np.ndarray:
         """
         Evaluate mixture density for batch (vectorized).
@@ -199,7 +207,7 @@ class VectorizedOperations:
             Mixture density values of shape (n_samples,).
         """
         # Weighted sum across components
-        return np.dot(component_densities, weights)
+        return np.asarray(np.dot(component_densities, weights))
 
 
 class MemoryEfficientSampling:
@@ -207,10 +215,10 @@ class MemoryEfficientSampling:
 
     @staticmethod
     def generate_samples_in_batches(
-        sample_func,
+        sample_func: Callable[..., np.ndarray],
         n_total: int,
         batch_size: int = 10000,
-        **kwargs
+        **kwargs: Any,
     ) -> np.ndarray:
         """
         Generate samples in batches to manage memory.
@@ -243,9 +251,9 @@ class MemoryEfficientSampling:
 
     @staticmethod
     def evaluate_function_in_batches(
-        func,
+        func: Callable[[np.ndarray], np.ndarray],
         data: np.ndarray,
-        batch_size: int = 10000
+        batch_size: int = 10000,
     ) -> np.ndarray:
         """
         Evaluate function on data in batches.
@@ -282,7 +290,9 @@ class ParallelProcessor:
     """Simple parallel processing utilities (without numba dependency)."""
 
     @staticmethod
-    def parallel_map(func, data_list, n_jobs: int = -1):
+    def parallel_map(
+        func: Callable[[Any], Any], data_list: Sequence[Any], n_jobs: int = -1
+    ) -> list[Any]:
         """
         Apply function to list in parallel using multiprocessing.
 
@@ -311,7 +321,9 @@ class ParallelProcessor:
             return results
 
         except Exception as e:
-            warnings.warn(f"Parallel processing failed: {e}. Using sequential.")
+            warnings.warn(
+                f"Parallel processing failed: {e}. Using sequential.", stacklevel=2
+            )
             return [func(item) for item in data_list]
 
 
@@ -319,7 +331,7 @@ class OptimizationUtils:
     """Utility functions for performance optimization."""
 
     @staticmethod
-    def preallocate_arrays(shapes: Dict[str, Tuple[int, ...]]) -> Dict[str, np.ndarray]:
+    def preallocate_arrays(shapes: dict[str, tuple[int, ...]]) -> dict[str, np.ndarray]:
         """
         Preallocate arrays to avoid repeated allocations.
 
@@ -339,16 +351,17 @@ class OptimizationUtils:
         return arrays
 
     @staticmethod
-    def check_memory_usage():
+    def check_memory_usage() -> dict[str, float] | None:
         """Check current memory usage."""
         try:
             import psutil
+
             process = psutil.Process()
             mem_info = process.memory_info()
             return {
-                'rss_mb': mem_info.rss / 1024 / 1024,
-                'vms_mb': mem_info.vms / 1024 / 1024,
-                'available_mb': psutil.virtual_memory().available / 1024 / 1024
+                "rss_mb": mem_info.rss / 1024 / 1024,
+                "vms_mb": mem_info.vms / 1024 / 1024,
+                "available_mb": psutil.virtual_memory().available / 1024 / 1024,
             }
         except ImportError:
             return None
@@ -372,6 +385,7 @@ class OptimizationUtils:
             PDF value.
         """
         from scipy.stats import chi2
+
         return float(chi2.pdf(x, df))
 
     @staticmethod
@@ -393,15 +407,16 @@ class OptimizationUtils:
             Bessel function value.
         """
         from scipy.special import iv
+
         return float(iv(nu, z))
 
 
 def optimize_safe_ice_iteration(
     samples: np.ndarray,
-    g_values: np.ndarray,
-    params: Any,
-    cache: Optional[PerformanceCache] = None
-) -> Dict[str, Any]:
+    g_values: np.ndarray,  # noqa: ARG001 - part of the iteration signature
+    params: Any,  # noqa: ARG001 - part of the iteration signature
+    cache: PerformanceCache | None = None,
+) -> dict[str, Any]:
     """
     Optimized iteration step for Safe-ICE.
 
@@ -433,20 +448,20 @@ def optimize_safe_ice_iteration(
 
     # Return optimized results
     return {
-        'directions': directions,
-        'radii': radii,
-        'cache_hits': cache._omega_in_cache if cache else 0
+        "directions": directions,
+        "radii": radii,
+        "cache_hits": cache._omega_in_cache if cache else 0,
     }
 
 
 # Performance monitoring decorator
-def profile_performance(func):
+def profile_performance(func: Callable[..., Any]) -> Callable[..., Any]:
     """Decorator to profile function performance."""
     import functools
     import time
 
     @functools.wraps(func)
-    def wrapper(*args, **kwargs):
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
         start_time = time.time()
         start_memory = OptimizationUtils.check_memory_usage()
 
@@ -456,8 +471,10 @@ def profile_performance(func):
         end_memory = OptimizationUtils.check_memory_usage()
 
         if start_memory and end_memory:
-            memory_delta = end_memory['rss_mb'] - start_memory['rss_mb']
-            print(f"{func.__name__}: {elapsed_time:.2f}s, Δmem: {memory_delta:.1f}MB")
+            memory_delta = end_memory["rss_mb"] - start_memory["rss_mb"]
+            print(
+                f"{func.__name__}: {elapsed_time:.2f}s, delta_mem: {memory_delta:.1f}MB"
+            )
         else:
             print(f"{func.__name__}: {elapsed_time:.2f}s")
 

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -5,7 +5,6 @@ import argparse
 import re
 import sys
 from pathlib import Path
-from typing import Optional, Tuple
 
 
 def get_current_version(root_dir: Path) -> str:
@@ -20,10 +19,10 @@ def get_current_version(root_dir: Path) -> str:
     return match.group(1)
 
 
-def parse_version(version: str) -> Tuple[int, int, int, Optional[str]]:
+def parse_version(version: str) -> tuple[int, int, int, str | None]:
     """Parse version string into components."""
     # Match versions like 0.1.0, 0.1.0rc1, 0.1.0-beta.1
-    match = re.match(r'^(\d+)\.(\d+)\.(\d+)(?:[-.]?(.+))?$', version)
+    match = re.match(r"^(\d+)\.(\d+)\.(\d+)(?:[-.]?(.+))?$", version)
     if not match:
         raise ValueError(f"Invalid version format: {version}")
 
@@ -33,7 +32,9 @@ def parse_version(version: str) -> Tuple[int, int, int, Optional[str]]:
     return major, minor, patch, suffix
 
 
-def format_version(major: int, minor: int, patch: int, suffix: Optional[str] = None) -> str:
+def format_version(
+    major: int, minor: int, patch: int, suffix: str | None = None
+) -> str:
     """Format version components into string."""
     version = f"{major}.{minor}.{patch}"
     if suffix:
@@ -41,7 +42,7 @@ def format_version(major: int, minor: int, patch: int, suffix: Optional[str] = N
     return version
 
 
-def bump_version(current: str, bump_type: str, suffix: Optional[str] = None) -> str:
+def bump_version(current: str, bump_type: str, suffix: str | None = None) -> str:
     """Bump version based on bump type."""
     major, minor, patch, current_suffix = parse_version(current)
 
@@ -58,13 +59,13 @@ def bump_version(current: str, bump_type: str, suffix: Optional[str] = None) -> 
         if current_suffix:
             # Increment prerelease version
             if "rc" in current_suffix:
-                num = int(re.search(r'rc(\d+)', current_suffix).group(1))
+                num = int(re.search(r"rc(\d+)", current_suffix).group(1))
                 suffix = f"rc{num + 1}"
             elif "beta" in current_suffix:
-                num = int(re.search(r'beta(\d+)', current_suffix).group(1))
+                num = int(re.search(r"beta(\d+)", current_suffix).group(1))
                 suffix = f"beta{num + 1}"
             elif "alpha" in current_suffix:
-                num = int(re.search(r'alpha(\d+)', current_suffix).group(1))
+                num = int(re.search(r"alpha(\d+)", current_suffix).group(1))
                 suffix = f"alpha{num + 1}"
             else:
                 suffix = current_suffix
@@ -77,7 +78,11 @@ def bump_version(current: str, bump_type: str, suffix: Optional[str] = None) -> 
     return format_version(major, minor, patch, suffix)
 
 
-def update_file_version(file_path: Path, old_version: str, new_version: str) -> bool:
+def update_file_version(
+    file_path: Path,
+    old_version: str,  # noqa: ARG001 - kept so callers can log the transition
+    new_version: str,
+) -> bool:
     """Update version in a file."""
     if not file_path.exists():
         return False
@@ -111,16 +116,15 @@ def main():
     parser.add_argument(
         "bump_type",
         choices=["major", "minor", "patch", "prerelease"],
-        help="Type of version bump"
+        help="Type of version bump",
     )
     parser.add_argument(
-        "--suffix",
-        help="Suffix for prerelease versions (e.g., rc1, beta1, alpha1)"
+        "--suffix", help="Suffix for prerelease versions (e.g., rc1, beta1, alpha1)"
     )
     parser.add_argument(
         "--dry-run",
         action="store_true",
-        help="Show what would be changed without making changes"
+        help="Show what would be changed without making changes",
     )
 
     args = parser.parse_args()
@@ -177,10 +181,10 @@ def main():
     if not args.dry_run:
         print(f"\nSuccessfully updated {len(updated_files)} files")
         print("\nNext steps:")
-        print(f"1. Review the changes: git diff")
+        print("1. Review the changes: git diff")
         print(f"2. Commit the changes: git commit -am 'Bump version to {new_version}'")
         print(f"3. Create a tag: git tag v{new_version}")
-        print(f"4. Push changes: git push && git push --tags")
+        print("4. Push changes: git push && git push --tags")
 
     return 0
 


### PR DESCRIPTION
Ruff reported **236 problems** across the package. CI only ever ran a syntax-error subset of the rules (`--select E9,F63,F7,F82`), so none of them surfaced. mypy was configured as `strict` but was not run anywhere, and reported **56 errors**.

Both are clean now.

- Ruff replaces black, isort and flake8, for both linting and formatting. One tool, config in `pyproject.toml`.
- Type annotations modernised, with shared aliases in `safe_ice/typing.py`.
- Library output no longer prints Greek letters. `run(verbose=True)` — the README's main example — raised `UnicodeEncodeError` on a default Windows console. Example scripts set their own stdout encoding for the same reason.
- pre-commit was pinned to 2023 releases and pulled in `types-all`, which no longer exists.

Large diff, but mechanical. The only behaviour change is the encoding fix.

Tests and docs still have findings; they are cleaned in the next two PRs, which is why CI enforcement lands last.

Stacked on #63.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleans up linting and type hints across the library and fixes Windows console encoding in verbose output. Previously CI only ran syntax checks and `run(verbose=True)` could raise `UnicodeEncodeError`; now `ruff` and `mypy --strict` pass and verbose output avoids Greek glyphs.

- Adopted `ruff` for linting and formatting, replacing `black`, `isort`, and `flake8`; type aliases added (e.g., `LimitStateFunction`, `RNGLike`) and applied across modules; `pre-commit` hooks updated and `types-all` removed.
- The only behavior change is output encoding: examples reconfigure stdout to UTF-8 when possible, and library verbose output uses ASCII-safe symbols.

**Migration**
- Use `ruff` instead of `black`, `isort`, and `flake8`. Run `pre-commit install` and `pre-commit autoupdate`.
- `pre-commit` now defaults to Python 3.12; install Python 3.12 or override `default_language_version` locally.
- No API changes for consumers; check that local scripts relying on Greek symbols render as expected.

<sup>Written for commit c57b57a65aead65ee7d5dbcc6d7e7b254ac3348c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/adaptive-importance-sampling-ice/pull/64?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

