### PR TITLE
test: make the suite deterministic and quick

### DIFF
--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import numpy as np
 import pytest
-from typing import Callable
 
 from safe_ice.problems.benchmarks import BenchmarkProblems
 from safe_ice.problems.heat_transfer import HeatTransferProblem
@@ -37,7 +36,7 @@ class TestBenchmarkProblemsStructure:
         diff = abs(g(u1) - g(u2))
         assert diff < 0.5  # Reasonable continuity
 
-    def test_three_mode_problem_properties(self):
+    def test_three_mode_problem_properties(self, rng):
         """Test properties of three-mode problem."""
         g = self.problems.three_mode_problem()
 
@@ -46,40 +45,40 @@ class TestBenchmarkProblemsStructure:
         result_single = g(u_single)
         assert isinstance(result_single, (float, np.floating))
 
-        u_batch = np.random.randn(10, 2)
+        u_batch = rng.standard_normal((10, 2))
         result_batch = g(u_batch)
         assert result_batch.shape == (10,)
 
-    def test_two_mode_opposite_directions(self):
+    def test_two_mode_opposite_directions(self, rng):
         """Test two-mode opposite directions problem."""
         # Test different dimensions
         for d in [2, 5, 10]:
             g = self.problems.two_mode_opposite_directions(dimension=d)
 
-            u_test = np.random.randn(5, d)
+            u_test = rng.standard_normal((5, d))
             results = g(u_test)
 
             assert results.shape == (5,)
             assert not np.any(np.isnan(results))
             assert not np.any(np.isinf(results))
 
-    def test_nonlinear_oscillator(self):
+    def test_nonlinear_oscillator(self, rng):
         """Test nonlinear oscillator problem."""
         g = self.problems.nonlinear_oscillator()
 
         # Should work with 10D input
-        u_test = np.random.randn(10, 10)
+        u_test = rng.standard_normal((10, 10))
         results = g(u_test)
 
         assert results.shape == (10,)
         assert not np.any(np.isnan(results))
 
-    def test_nakagami_ratio_problem(self):
+    def test_nakagami_ratio_problem(self, rng):
         """Test Nakagami ratio problem."""
         g = self.problems.nakagami_ratio_problem()
 
         # Test with 2D input (two Nakagami variables)
-        u_test = np.random.randn(20, 2)
+        u_test = rng.standard_normal((20, 2))
         results = g(u_test)
 
         assert results.shape == (20,)
@@ -165,6 +164,7 @@ class TestBenchmarkProblemsBehavior:
         assert np.sum(np.sign(differences) == dominant_sign) > len(differences) / 2
 
 
+@pytest.mark.slow
 class TestHeatTransferProblem:
     """Test heat transfer problem with KL expansion."""
 
@@ -180,10 +180,7 @@ class TestHeatTransferProblem:
     def test_initialization_custom(self):
         """Test custom initialization of heat transfer problem."""
         problem = HeatTransferProblem(
-            n_terms=5,
-            correlation_length=1.0,
-            field_std=0.5,
-            threshold=150.0
+            n_terms=5, correlation_length=1.0, field_std=0.5, threshold=150.0
         )
 
         assert problem.n_terms == 5
@@ -205,13 +202,13 @@ class TestHeatTransferProblem:
         # Check eigenvectors
         assert problem.eigenvectors.shape == (50, 5)  # 50 grid points, 5 terms
 
-    def test_limit_state_function(self):
+    def test_limit_state_function(self, rng):
         """Test heat transfer limit state function."""
         problem = HeatTransferProblem(n_terms=5)
         g = problem.get_limit_state_function()
 
         # Test with random input
-        u_test = np.random.randn(10, 5)
+        u_test = rng.standard_normal((10, 5))
         results = g(u_test)
 
         assert results.shape == (10,)
@@ -234,12 +231,12 @@ class TestHeatTransferProblem:
         assert np.isfinite(result_nonzero)
 
     @pytest.mark.parametrize("n_terms", [5, 10, 20])
-    def test_different_truncations(self, n_terms):
+    def test_different_truncations(self, n_terms, rng):
         """Test heat transfer problem with different KL truncations."""
         problem = HeatTransferProblem(n_terms=n_terms)
         g = problem.get_limit_state_function()
 
-        u_test = np.random.randn(5, n_terms)
+        u_test = rng.standard_normal((5, n_terms))
         results = g(u_test)
 
         assert results.shape == (5,)
@@ -273,28 +270,27 @@ class TestHeatTransferProblem:
 class TestBenchmarkComparison:
     """Test comparison between different benchmark problems."""
 
-    def test_relative_difficulty(self):
+    def test_relative_difficulty(self, seed):
         """Test that SafeICE produces finite probability estimates."""
         from safe_ice import SafeICE
 
-        np.random.seed(42)
         problems = BenchmarkProblems()
 
         # Four-mode series
         g1 = problems.four_mode_series_system()
-        ice1 = SafeICE(g1, dimension=2, N=1000, max_iterations=5)
+        ice1 = SafeICE(g1, dimension=2, N=1000, max_iterations=5, random_state=seed)
         pf1, _ = ice1.run(verbose=False)
 
         # Three-mode
         g2 = problems.three_mode_problem()
-        ice2 = SafeICE(g2, dimension=2, N=1000, max_iterations=5)
+        ice2 = SafeICE(g2, dimension=2, N=1000, max_iterations=5, random_state=seed)
         pf2, _ = ice2.run(verbose=False)
 
         # Both estimates must be non-negative finite values
         assert np.isfinite(pf1) and pf1 >= 0
         assert np.isfinite(pf2) and pf2 >= 0
 
-    def test_dimension_scaling(self):
+    def test_dimension_scaling(self, seed):
         """Test how failure probability scales with dimension."""
         problems = BenchmarkProblems()
 
@@ -306,11 +302,13 @@ class TestBenchmarkComparison:
             g = problems.two_mode_opposite_directions(dimension=d)
 
             from safe_ice import SafeICE
+
             ice = SafeICE(
                 limit_state_function=g,
                 dimension=d,
                 N=1000,
-                max_iterations=5
+                max_iterations=5,
+                random_state=seed,
             )
             pf, _ = ice.run(verbose=False)
             pf_values.append(pf)
@@ -343,13 +341,13 @@ class TestBenchmarkRobustness:
         result_mixed = g(u_mixed)
         assert np.isfinite(result_mixed)
 
-    def test_vectorization_consistency(self):
+    def test_vectorization_consistency(self, rng):
         """Test that vectorized evaluation is consistent with single evaluation."""
         problems = BenchmarkProblems()
         g = problems.four_mode_series_system()
 
         # Generate test points
-        test_points = np.random.randn(5, 2)
+        test_points = rng.standard_normal((5, 2))
 
         # Evaluate individually
         individual_results = np.array([g(u) for u in test_points])
@@ -360,7 +358,7 @@ class TestBenchmarkRobustness:
         # Should give same results
         np.testing.assert_allclose(individual_results, batch_results, rtol=1e-10)
 
-    def test_numerical_stability(self):
+    def test_numerical_stability(self, rng):
         """Test numerical stability of limit state functions."""
         problems = BenchmarkProblems()
 
@@ -369,16 +367,16 @@ class TestBenchmarkRobustness:
             problems.four_mode_series_system(),
             problems.three_mode_problem(),
             problems.nonlinear_oscillator(),
-            problems.nakagami_ratio_problem()
+            problems.nakagami_ratio_problem(),
         ]
 
         for g in test_functions:
             # Test with various scales of input
             for scale in [1e-3, 1.0, 1e3]:
                 if g == problems.nonlinear_oscillator():
-                    u_test = np.random.randn(10, 10) * scale
+                    u_test = rng.standard_normal((10, 10)) * scale
                 else:
-                    u_test = np.random.randn(10, 2) * scale
+                    u_test = rng.standard_normal((10, 2)) * scale
 
                 results = g(u_test)
 

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -3,76 +3,74 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 import numpy as np
 import numpy.typing as npt
 import pytest
-from scipy.stats import kstest, chi2  # noqa: F401  (may be used in future tests)
+from scipy.stats import chi2, kstest  # noqa: F401  (may be used in future tests)
 
-from safe_ice.distributions.vmf import VonMisesFisherSampler
-from safe_ice.distributions.nakagami import (
-    NakagamiDistribution,
-    InverseNakagamiDistribution,
-)
-from safe_ice.distributions.mixture import vMFNMDistribution
 from safe_ice.core.parameters import vMFNMParameters
+from safe_ice.distributions.mixture import vMFNMDistribution
+from safe_ice.distributions.nakagami import (
+    InverseNakagamiDistribution,
+    NakagamiDistribution,
+)
+from safe_ice.distributions.vmf import VonMisesFisherSampler
 
 
 class TestVonMisesFisherSampler:
     """Tests for von Mises-Fisher distribution sampler."""
 
-    def test_sample_shape(self) -> None:
+    def test_sample_shape(self, rng) -> None:
         """Test that samples have correct shape."""
         mu: npt.NDArray[np.float64] = np.array([1.0, 0.0, 0.0], dtype=np.float64)
         kappa: float = 2.0
         n_samples: int = 100
 
-        samples = VonMisesFisherSampler.sample(mu, kappa, n_samples)
+        samples = VonMisesFisherSampler.sample(mu, kappa, n_samples, rng=rng)
         assert samples.shape == (n_samples, 3)
 
-    def test_samples_are_unit_vectors(self) -> None:
+    def test_samples_are_unit_vectors(self, rng) -> None:
         """Test that all samples are unit vectors."""
         mu: npt.NDArray[np.float64] = np.array([1.0, 0.0], dtype=np.float64)
         kappa: float = 5.0
         n_samples: int = 50
 
-        samples = VonMisesFisherSampler.sample(mu, kappa, n_samples)
+        samples = VonMisesFisherSampler.sample(mu, kappa, n_samples, rng=rng)
         norms = np.linalg.norm(samples, axis=1)
 
         np.testing.assert_allclose(norms, 1.0, rtol=1e-10)
 
-    def test_zero_kappa_uniform(self) -> None:
+    def test_zero_kappa_uniform(self, rng) -> None:
         """Test that kappa=0 gives uniform distribution."""
         mu: npt.NDArray[np.float64] = np.array([1.0, 0.0], dtype=np.float64)
         kappa: float = 0.0
         n_samples: int = 1000
 
-        samples = VonMisesFisherSampler.sample(mu, kappa, n_samples)
+        samples = VonMisesFisherSampler.sample(mu, kappa, n_samples, rng=rng)
 
         # Check mean direction is close to zero
         mean_direction = np.mean(samples, axis=0)
         assert np.linalg.norm(mean_direction) < 0.2
 
-    def test_high_kappa_concentration(self) -> None:
+    def test_high_kappa_concentration(self, rng) -> None:
         """Test that high kappa concentrates around mean."""
         mu: npt.NDArray[np.float64] = np.array([1.0, 0.0, 0.0], dtype=np.float64)
         kappa: float = 50.0
         n_samples: int = 100
 
-        samples = VonMisesFisherSampler.sample(mu, kappa, n_samples)
+        samples = VonMisesFisherSampler.sample(mu, kappa, n_samples, rng=rng)
 
         # All samples should be close to mu
         dot_products = np.dot(samples, mu)
         assert np.all(dot_products > 0.9)
 
-    def test_circular_vmf(self) -> None:
+    def test_circular_vmf(self, rng) -> None:
         """Test 2D circular case."""
         mu: npt.NDArray[np.float64] = np.array([1.0, 0.0], dtype=np.float64)
         kappa: float = 3.0
         n_samples: int = 200
 
-        samples = VonMisesFisherSampler.sample(mu, kappa, n_samples)
+        samples = VonMisesFisherSampler.sample(mu, kappa, n_samples, rng=rng)
 
         assert samples.shape == (n_samples, 2)
         norms = np.linalg.norm(samples, axis=1)
@@ -99,22 +97,22 @@ class TestNakagamiDistribution:
 
         assert pdf_value == 0.0
 
-    def test_sample_shape(self) -> None:
+    def test_sample_shape(self, rng) -> None:
         """Test sample shape."""
         m, Omega = 1.5, 2.0
         n_samples = 100
 
-        samples = NakagamiDistribution.sample(m, Omega, n_samples)
+        samples = NakagamiDistribution.sample(m, Omega, n_samples, rng=rng)
 
         assert samples.shape == (n_samples,)
         assert np.all(samples > 0)
 
-    def test_sample_mean_approximation(self) -> None:
+    def test_sample_mean_approximation(self, rng) -> None:
         """Test that sample mean approximates theoretical mean."""
         m, Omega = 2.0, 1.0
         n_samples = 10000
 
-        samples = NakagamiDistribution.sample(m, Omega, n_samples)
+        samples = NakagamiDistribution.sample(m, Omega, n_samples, rng=rng)
         sample_mean = float(np.mean(samples))
 
         # Theoretical mean: E[R] = (Gamma(m + 0.5) / Gamma(m)) * sqrt(Omega / m)
@@ -149,22 +147,22 @@ class TestInverseNakagamiDistribution:
 
         assert np.all(pdf_values >= 0)
 
-    def test_sample_positive(self) -> None:
+    def test_sample_positive(self, rng) -> None:
         """Test that all samples are positive."""
         m, Omega = 1.5, 2.0
         n_samples = 100
 
-        samples = InverseNakagamiDistribution.sample(m, Omega, n_samples)
+        samples = InverseNakagamiDistribution.sample(m, Omega, n_samples, rng=rng)
 
         assert samples.shape == (n_samples,)
         assert np.all(samples > 0)
 
-    def test_heavy_tail_property(self) -> None:
+    def test_heavy_tail_property(self, rng) -> None:
         """Test that distribution has heavy tails."""
         m, Omega = 2.0, 1.0
         n_samples = 10000
 
-        samples = InverseNakagamiDistribution.sample(m, Omega, n_samples)
+        samples = InverseNakagamiDistribution.sample(m, Omega, n_samples, rng=rng)
 
         # Heavy-tailed: should have some very large values
         assert float(np.max(samples)) > 5.0
@@ -178,8 +176,6 @@ class TestvMFNMDistribution:
     @pytest.fixture
     def simple_params_2d(self) -> vMFNMParameters:
         """Simple 2D vMFNM parameters."""
-        K = 2
-        d = 2
         return vMFNMParameters(
             pi=np.array([0.6, 0.4], dtype=np.float64),
             m=np.array([2.0, 1.5], dtype=np.float64),
@@ -195,40 +191,42 @@ class TestvMFNMDistribution:
         assert dist.params.K == 2
         assert dist.params.d == 2
 
-    def test_pdf_positive(self, simple_params_2d: vMFNMParameters) -> None:
+    def test_pdf_positive(self, simple_params_2d: vMFNMParameters, rng) -> None:
         """Test that PDF is non-negative."""
         dist = vMFNMDistribution(simple_params_2d)
 
-        x = np.random.randn(10, 2)
+        x = rng.standard_normal((10, 2))
         pdf_values = dist.pdf(x)
 
         assert np.all(pdf_values >= 0)
 
-    def test_sample_shape(self, simple_params_2d: vMFNMParameters) -> None:
+    def test_sample_shape(self, simple_params_2d: vMFNMParameters, rng) -> None:
         """Test sample shape."""
         dist = vMFNMDistribution(simple_params_2d)
         n_samples = 100
 
-        samples = dist.sample(n_samples)
+        samples = dist.sample(n_samples, rng=rng)
 
         assert samples.shape == (n_samples, 2)
 
-    def test_sample_pdf_consistency(self, simple_params_2d: vMFNMParameters) -> None:
+    def test_sample_pdf_consistency(
+        self, simple_params_2d: vMFNMParameters, rng
+    ) -> None:
         """Test that samples have reasonable PDF values."""
         dist = vMFNMDistribution(simple_params_2d)
         n_samples = 50
 
-        samples = dist.sample(n_samples)
+        samples = dist.sample(n_samples, rng=rng)
         pdf_values = dist.pdf(samples)
 
         # All PDF values should be positive
         assert np.all(pdf_values > 0)
 
-    def test_log_likelihood(self, simple_params_2d: vMFNMParameters) -> None:
+    def test_log_likelihood(self, simple_params_2d: vMFNMParameters, rng) -> None:
         """Test log-likelihood computation."""
         dist = vMFNMDistribution(simple_params_2d)
 
-        samples = dist.sample(100)
+        samples = dist.sample(100, rng=rng)
         log_likelihood = float(dist.log_likelihood(samples))
 
         # Should be finite and negative
@@ -236,19 +234,19 @@ class TestvMFNMDistribution:
         assert log_likelihood < 0
 
     @pytest.mark.parametrize("dimension", [2, 5, 10])
-    def test_different_dimensions(self, dimension: int) -> None:
+    def test_different_dimensions(self, dimension: int, rng) -> None:
         """Test distribution works in different dimensions."""
         K = 3
         params = vMFNMParameters(
             pi=(np.ones(K, dtype=np.float64) / K),
-            m=np.random.uniform(1, 3, K).astype(np.float64),
-            Omega=np.random.uniform(0.5, 2, K).astype(np.float64),
-            mu=np.random.randn(K, dimension).astype(np.float64),
-            kappa=np.random.uniform(0.5, 3, K).astype(np.float64),
+            m=rng.uniform(1, 3, K).astype(np.float64),
+            Omega=rng.uniform(0.5, 2, K).astype(np.float64),
+            mu=rng.standard_normal((K, dimension)).astype(np.float64),
+            kappa=rng.uniform(0.5, 3, K).astype(np.float64),
         )
 
         dist = vMFNMDistribution(params)
-        samples = dist.sample(50)
+        samples = dist.sample(50, rng=rng)
 
         assert samples.shape == (50, dimension)
 
@@ -256,7 +254,7 @@ class TestvMFNMDistribution:
 class TestIntegration:
     """Integration tests for distributions."""
 
-    def test_vmfnm_mixture_normalization(self) -> None:
+    def test_vmfnm_mixture_normalization(self, rng) -> None:
         """Test that vMFNM PDF approximately integrates to 1."""
         # This is a Monte Carlo integration test
         params = vMFNMParameters(
@@ -272,7 +270,7 @@ class TestIntegration:
         # Generate many samples from a wide proposal N(0, 9I)
         n_samples = 100000
         proposal_std = 3.0
-        samples = (np.random.randn(n_samples, 2) * proposal_std).astype(
+        samples = (rng.standard_normal((n_samples, 2)) * proposal_std).astype(
             np.float64
         )
 
@@ -280,10 +278,9 @@ class TestIntegration:
         # proposal density q(x) = N(0, σ²I).
         pdf_values = dist.pdf(samples)
         d = 2
-        proposal_var = proposal_std ** 2
-        proposal_pdf = (
-            (1.0 / (2.0 * np.pi * proposal_var) ** (d / 2.0))
-            * np.exp(-0.5 * np.sum(samples ** 2, axis=1) / proposal_var)
+        proposal_var = proposal_std**2
+        proposal_pdf = (1.0 / (2.0 * np.pi * proposal_var) ** (d / 2.0)) * np.exp(
+            -0.5 * np.sum(samples**2, axis=1) / proposal_var
         )
 
         integral_estimate = float(np.mean(pdf_values / proposal_pdf))
@@ -293,7 +290,7 @@ class TestIntegration:
         assert 0.5 < integral_estimate < 2.0
 
     @pytest.mark.slow
-    def test_vmfnm_sampling_consistency(self) -> None:
+    def test_vmfnm_sampling_consistency(self, rng) -> None:
         """Test sampling and PDF evaluation are consistent."""
         params = vMFNMParameters(
             pi=np.array([0.5, 0.5], dtype=np.float64),
@@ -306,7 +303,7 @@ class TestIntegration:
         dist = vMFNMDistribution(params)
 
         # Generate samples
-        samples = dist.sample(5000)
+        samples = dist.sample(5000, rng=rng)
 
         # Samples should roughly follow the distribution
         # Test: mean of samples should be near zero (symmetric mixture)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2,21 +2,20 @@
 
 from __future__ import annotations
 
-import numpy as np
-import pytest
-from typing import Callable, Tuple
 import time
 
+import numpy as np
+import pytest
+
 from safe_ice import SafeICE
-from safe_ice.core.parameters import vMFNMParameters
-from safe_ice.problems.benchmarks import BenchmarkProblems
 from safe_ice.analysis.performance import PerformanceEvaluator
+from safe_ice.problems.benchmarks import BenchmarkProblems
 
 
 class TestEndToEndWorkflow:
     """Test complete end-to-end workflows."""
 
-    def test_complete_workflow_with_benchmarks(self):
+    def test_complete_workflow_with_benchmarks(self, seed):
         """Test complete workflow from initialization to analysis."""
         # 1. Create problem
         problems = BenchmarkProblems()
@@ -27,7 +26,8 @@ class TestEndToEndWorkflow:
             limit_state_function=g,
             dimension=2,
             N=300,
-            max_iterations=5
+            max_iterations=5,
+            random_state=seed,
         )
 
         # 3. Run algorithm
@@ -49,8 +49,9 @@ class TestEndToEndWorkflow:
         # 6. Verify probability estimate is non-negative and finite
         assert np.isfinite(pf) and pf >= 0
 
-    def test_workflow_with_custom_limit_state(self):
+    def test_workflow_with_custom_limit_state(self, seed):
         """Test workflow with user-defined limit state function."""
+
         # Custom limit state function
         def custom_limit_state(u: np.ndarray) -> np.ndarray:
             """Custom nonlinear limit state function."""
@@ -58,7 +59,7 @@ class TestEndToEndWorkflow:
                 u = u.reshape(1, -1)
 
             # Nonlinear combination
-            term1 = 3.5 - 0.1 * (u[:, 0] - u[:, 1])**2
+            term1 = 3.5 - 0.1 * (u[:, 0] - u[:, 1]) ** 2
             term2 = (u[:, 0] + u[:, 1]) / np.sqrt(2)
             return term1 - term2
 
@@ -67,7 +68,8 @@ class TestEndToEndWorkflow:
             limit_state_function=custom_limit_state,
             dimension=2,
             N=500,
-            max_iterations=10
+            max_iterations=10,
+            random_state=seed,
         )
 
         pf, results = ice.run(verbose=False)
@@ -85,13 +87,12 @@ class TestEndToEndWorkflow:
         pf_values = []
 
         for seed in [42, 123, 456]:
-            np.random.seed(seed)
-
             ice = SafeICE(
                 limit_state_function=g,
                 dimension=2,
                 N=1000,
                 max_iterations=10,
+                random_state=seed,
             )
 
             pf, _ = ice.run(verbose=False)
@@ -105,7 +106,7 @@ class TestEndToEndWorkflow:
 class TestKnownFailureProbabilities:
     """Test against problems with known failure probabilities."""
 
-    def test_simple_sphere_problem(self):
+    def test_simple_sphere_problem(self, seed):
         """Test simple sphere problem with analytical solution."""
         # For standard normal in R^d, P(||u|| > beta) is known
         beta = 3.0
@@ -118,21 +119,29 @@ class TestKnownFailureProbabilities:
             limit_state_function=sphere_limit_state,
             dimension=d,
             N=2000,
-            max_iterations=15
+            max_iterations=15,
+            random_state=seed,
         )
 
         pf_estimated, _ = ice.run(verbose=False)
 
         # Analytical solution for d=2: P(χ²(2) > beta²)
         from scipy import stats
+
         pf_analytical = 1 - stats.chi2.cdf(beta**2, df=d)
 
         # Check relative error (allow 50% due to Monte Carlo variance)
         relative_error = abs(pf_estimated - pf_analytical) / pf_analytical
         assert relative_error < 0.5
 
-    def test_linear_limit_state(self):
-        """Test linear limit state with known solution."""
+    def test_linear_limit_state(self, seed):
+        """Test linear limit state with known solution.
+
+        Note: the estimator sits at roughly 0.54x the analytical value here,
+        and that gap does not shrink as N grows from 1e3 to 8e3, so it is a
+        systematic bias rather than Monte Carlo noise. The 50% tolerance below
+        is wide enough to absorb it; tighten it once the bias is fixed.
+        """
         # Linear limit state: g(u) = a₀ + Σaᵢuᵢ
         # For standard normal, failure probability is Φ(-a₀/||a||)
         a = np.array([1.0, 1.0])  # Coefficients
@@ -147,13 +156,15 @@ class TestKnownFailureProbabilities:
             limit_state_function=linear_limit_state,
             dimension=2,
             N=1000,
-            max_iterations=10
+            max_iterations=10,
+            random_state=seed,
         )
 
         pf_estimated, _ = ice.run(verbose=False)
 
         # Analytical solution
         from scipy import stats
+
         pf_analytical = stats.norm.cdf(-a0 / np.linalg.norm(a))
 
         # Check relative error
@@ -164,7 +175,7 @@ class TestKnownFailureProbabilities:
 class TestPerformanceRegression:
     """Test for performance regression."""
 
-    def test_execution_time_reasonable(self):
+    def test_execution_time_reasonable(self, seed):
         """Test that execution time is reasonable for standard problem."""
         problems = BenchmarkProblems()
         g = problems.four_mode_series_system()
@@ -173,18 +184,20 @@ class TestPerformanceRegression:
             limit_state_function=g,
             dimension=2,
             N=500,
-            max_iterations=5
+            max_iterations=5,
+            random_state=seed,
         )
 
         start_time = time.time()
-        pf, _ = ice.run(verbose=False)
+        _pf, _ = ice.run(verbose=False)
         execution_time = time.time() - start_time
 
         # Should complete within reasonable time (adjust based on system)
         assert execution_time < 60  # 60 seconds max
 
-    def test_memory_usage_scales_linearly(self):
+    def test_memory_usage_scales_linearly(self, seed):
         """Test that memory usage scales linearly with samples."""
+
         def simple_limit_state(u):
             return 3.0 - np.linalg.norm(u, axis=-1)
 
@@ -197,7 +210,8 @@ class TestPerformanceRegression:
                 limit_state_function=simple_limit_state,
                 dimension=2,
                 N=N,
-                max_iterations=3
+                max_iterations=3,
+                random_state=seed,
             )
 
             _, results = ice.run(verbose=False)
@@ -205,8 +219,8 @@ class TestPerformanceRegression:
 
         # Check that sizes scale appropriately
         for i in range(1, len(result_sizes)):
-            ratio = result_sizes[i] / result_sizes[i-1]
-            expected_ratio = sample_sizes[i] / sample_sizes[i-1]
+            ratio = result_sizes[i] / result_sizes[i - 1]
+            expected_ratio = sample_sizes[i] / sample_sizes[i - 1]
             # Allow some variance due to adaptive sampling
             assert 0.5 * expected_ratio <= ratio <= 2.0 * expected_ratio
 
@@ -215,19 +229,20 @@ class TestHighDimensionalProblems:
     """Test performance in high dimensions."""
 
     @pytest.mark.slow
-    def test_dimension_10(self):
+    def test_dimension_10(self, seed):
         """Test 10-dimensional problem."""
         d = 10
 
         def high_dim_limit_state(u):
             # Sphere limit state with reachable threshold
-            return 2.0 - np.sqrt(np.sum(u ** 2, axis=-1) / d)
+            return 2.0 - np.sqrt(np.sum(u**2, axis=-1) / d)
 
         ice = SafeICE(
             limit_state_function=high_dim_limit_state,
             dimension=d,
             N=1000,
             max_iterations=10,
+            random_state=seed,
         )
 
         pf, results = ice.run(verbose=False)
@@ -236,7 +251,7 @@ class TestHighDimensionalProblems:
         assert results["final_samples"].shape[1] == d
 
     @pytest.mark.slow
-    def test_dimension_50(self):
+    def test_dimension_50(self, seed):
         """Test 50-dimensional problem (stress test)."""
         d = 50
 
@@ -252,6 +267,7 @@ class TestHighDimensionalProblems:
             dimension=d,
             N=2000,
             max_iterations=5,
+            random_state=seed,
         )
 
         pf, results = ice.run(verbose=False)
@@ -263,18 +279,22 @@ class TestHighDimensionalProblems:
 class TestWithPerformanceEvaluator:
     """Test integration with PerformanceEvaluator."""
 
-    def test_performance_comparison(self):
+    def test_performance_comparison(self, seed):
         """Test performance comparison between Safe-ICE and Monte Carlo."""
         problems = BenchmarkProblems()
         g = problems.four_mode_series_system()
 
         evaluator = PerformanceEvaluator()
 
-        # Run Monte Carlo reference (with fewer samples for speed)
-        pf_mc, std_mc = evaluator.run_monte_carlo_reference(
+        # Run Monte Carlo reference (with fewer samples for speed).
+        # At 10k samples this problem (pf ~ 1.2e-5) usually finds no failures
+        # at all, so the comparison below is skipped more often than not; the
+        # seed keeps which of the two happens reproducible.
+        pf_mc, _std_mc = evaluator.run_monte_carlo_reference(
             limit_state_func=g,
             dimension=2,
-            n_samples=10000
+            n_samples=10000,
+            random_state=seed,
         )
 
         # Run Safe-ICE
@@ -282,7 +302,8 @@ class TestWithPerformanceEvaluator:
             limit_state_function=g,
             dimension=2,
             N=500,
-            max_iterations=10
+            max_iterations=10,
+            random_state=seed,
         )
         pf_ice, _ = ice.run(verbose=False)
 
@@ -292,7 +313,7 @@ class TestWithPerformanceEvaluator:
             ratio = pf_ice / pf_mc
             assert 0.1 < ratio < 10.0
 
-    def test_compute_metrics(self):
+    def test_compute_metrics(self, seed):
         """Test metric computation from results."""
         problems = BenchmarkProblems()
         g = problems.four_mode_series_system()
@@ -301,12 +322,13 @@ class TestWithPerformanceEvaluator:
             limit_state_function=g,
             dimension=2,
             N=500,
-            max_iterations=5
+            max_iterations=5,
+            random_state=seed,
         )
 
-        pf, results = ice.run(verbose=False)
+        _pf, results = ice.run(verbose=False)
 
-        evaluator = PerformanceEvaluator()
+        PerformanceEvaluator()
 
         # Compute coefficient of variation
         weights = results["final_weights"]
@@ -314,15 +336,18 @@ class TestWithPerformanceEvaluator:
 
         failure_indicator = (g_values <= 0).astype(float)
         if np.sum(failure_indicator * weights) > 0:
-            cv = np.sqrt(np.var(failure_indicator * weights)) / np.mean(failure_indicator * weights)
+            cv = np.sqrt(np.var(failure_indicator * weights)) / np.mean(
+                failure_indicator * weights
+            )
             assert cv > 0
 
 
 class TestEdgeCases:
     """Test edge cases and boundary conditions."""
 
-    def test_single_sample_per_iteration(self):
+    def test_single_sample_per_iteration(self, seed):
         """Test with minimal samples per iteration."""
+
         def simple_limit_state(u):
             return 2.0 - np.linalg.norm(u, axis=-1)
 
@@ -330,14 +355,15 @@ class TestEdgeCases:
             limit_state_function=simple_limit_state,
             dimension=2,
             N=10,  # Very few samples
-            max_iterations=3
+            max_iterations=3,
+            random_state=seed,
         )
 
         # Should still run without errors
-        pf, results = ice.run(verbose=False)
+        pf, _results = ice.run(verbose=False)
         assert 0 <= pf <= 1
 
-    def test_single_iteration(self):
+    def test_single_iteration(self, seed):
         """Test with only one iteration allowed."""
         problems = BenchmarkProblems()
         g = problems.four_mode_series_system()
@@ -346,17 +372,19 @@ class TestEdgeCases:
             limit_state_function=g,
             dimension=2,
             N=1000,
-            max_iterations=1
+            max_iterations=1,
+            random_state=seed,
         )
 
-        pf, results = ice.run(verbose=False)
+        _pf, results = ice.run(verbose=False)
 
         # Should have samples from exactly one iteration
         assert len(results["iterations"]) == 1
         assert len(results["final_samples"]) == 1000
 
-    def test_very_rare_event(self):
+    def test_very_rare_event(self, seed):
         """Test with extremely rare event (small failure probability)."""
+
         def rare_event_limit_state(u):
             return 6.0 - np.linalg.norm(u, axis=-1)  # Very rare
 
@@ -364,16 +392,27 @@ class TestEdgeCases:
             limit_state_function=rare_event_limit_state,
             dimension=2,
             N=1000,
-            max_iterations=20
+            max_iterations=20,
+            random_state=seed,
         )
 
-        pf, results = ice.run(verbose=False)
+        pf, _results = ice.run(verbose=False)
 
         # Should give very small probability
         assert pf < 1e-6
 
-    def test_certain_failure(self):
+    @pytest.mark.xfail(
+        strict=True,
+        reason=(
+            "Known estimator weakness: for a limit state that fails everywhere "
+            "the true probability is exactly 1, but the estimate wanders well "
+            "off it and across seeds can even exceed 1, which is not a valid "
+            "probability. Remove this marker once the estimator is corrected."
+        ),
+    )
+    def test_certain_failure(self, seed):
         """Test with certain failure (large failure probability)."""
+
         def certain_failure_limit_state(u):
             return -1.0 - np.linalg.norm(u, axis=-1)  # Always negative
 
@@ -381,10 +420,11 @@ class TestEdgeCases:
             limit_state_function=certain_failure_limit_state,
             dimension=2,
             N=100,
-            max_iterations=2
+            max_iterations=2,
+            random_state=seed,
         )
 
-        pf, results = ice.run(verbose=False)
+        pf, _results = ice.run(verbose=False)
 
         # Should give probability close to 1
         assert pf > 0.99

--- a/tests/test_safe_ice.py
+++ b/tests/test_safe_ice.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import numpy as np
 import pytest
-from typing import Callable
 
 from safe_ice import SafeICE
 from safe_ice.core.parameters import vMFNMParameters
@@ -14,15 +13,17 @@ from safe_ice.problems.benchmarks import BenchmarkProblems
 class TestSafeICEInitialization:
     """Test SafeICE initialization and configuration."""
 
-    def test_basic_initialization(self):
+    def test_basic_initialization(self, seed):
         """Test SafeICE can be initialized with minimal parameters."""
+
         def g(u):
             return 3.5 - np.linalg.norm(u, axis=-1)
 
         ice = SafeICE(
             limit_state_function=g,
             dimension=2,
-            N=100
+            N=100,
+            random_state=seed,
         )
 
         assert ice is not None
@@ -31,8 +32,9 @@ class TestSafeICEInitialization:
         assert ice.max_iterations == 20  # default value
         assert ice.delta_target == 4.0  # default value
 
-    def test_initialization_with_custom_parameters(self):
+    def test_initialization_with_custom_parameters(self, seed):
         """Test SafeICE initialization with custom parameters."""
+
         def g(u):
             return 3.5 - np.linalg.norm(u, axis=-1)
 
@@ -45,7 +47,8 @@ class TestSafeICEInitialization:
             delta_star=1.0,
             sigma0=2.0,
             K0=15,
-            em_max_iter=50
+            em_max_iter=50,
+            random_state=seed,
         )
 
         assert ice.d == 5
@@ -57,11 +60,10 @@ class TestSafeICEInitialization:
         assert ice.K0 == 15
 
 
-
 class TestSafeICEExecution:
     """Test SafeICE algorithm execution."""
 
-    def test_single_iteration(self):
+    def test_single_iteration(self, seed):
         """Test that a single iteration runs without errors."""
         problems = BenchmarkProblems()
         g = problems.four_mode_series_system()
@@ -71,6 +73,7 @@ class TestSafeICEExecution:
             dimension=2,
             N=100,
             max_iterations=1,
+            random_state=seed,
         )
 
         # Run one iteration
@@ -84,7 +87,7 @@ class TestSafeICEExecution:
         assert len(results["final_weights"]) == len(results["final_samples"])
         assert np.all(results["final_weights"] >= 0)
 
-    def test_multiple_iterations(self):
+    def test_multiple_iterations(self, seed):
         """Test multiple iterations with convergence."""
         problems = BenchmarkProblems()
         g = problems.four_mode_series_system()
@@ -94,6 +97,7 @@ class TestSafeICEExecution:
             dimension=2,
             N=200,
             max_iterations=5,
+            random_state=seed,
         )
 
         pf, results = ice.run(verbose=False)
@@ -105,8 +109,9 @@ class TestSafeICEExecution:
         assert results["final_samples"].shape[1] == 2
         assert len(results["final_weights"]) == len(results["final_samples"])
 
-    def test_deterministic_limit_state(self):
+    def test_deterministic_limit_state(self, seed):
         """Test with a deterministic limit state function."""
+
         def g(u):
             # Simple sphere: failure if ||u|| > 3
             return 3.0 - np.linalg.norm(u, axis=-1)
@@ -116,16 +121,18 @@ class TestSafeICEExecution:
             dimension=2,
             N=500,
             max_iterations=10,
+            random_state=seed,
         )
 
-        pf, results = ice.run(verbose=False)
+        pf, _results = ice.run(verbose=False)
 
         # For a 2D standard normal, P(||u|| > 3) should be small
         assert pf > 0
         assert pf < 0.1  # Should be around 0.01
 
-    def test_high_dimensional_problem(self):
+    def test_high_dimensional_problem(self, seed):
         """Test with higher dimensional problem."""
+
         def g(u):
             # High-dimensional sphere
             return 4.5 - np.linalg.norm(u, axis=-1)
@@ -135,6 +142,7 @@ class TestSafeICEExecution:
             dimension=10,
             N=500,
             max_iterations=3,
+            random_state=seed,
         )
 
         pf, results = ice.run(verbose=False)
@@ -144,8 +152,9 @@ class TestSafeICEExecution:
         assert len(results["final_weights"]) == len(results["final_samples"])
 
     @pytest.mark.parametrize("dimension", [2, 5, 10])
-    def test_dimension_consistency(self, dimension):
+    def test_dimension_consistency(self, dimension, seed):
         """Test that output dimensions are consistent with input."""
+
         def g(u):
             return 3.5 - np.linalg.norm(u, axis=-1)
 
@@ -154,9 +163,10 @@ class TestSafeICEExecution:
             dimension=dimension,
             N=100,
             max_iterations=2,
+            random_state=seed,
         )
 
-        pf, results = ice.run(verbose=False)
+        _pf, results = ice.run(verbose=False)
 
         assert results["final_samples"].shape[1] == dimension
 
@@ -164,8 +174,9 @@ class TestSafeICEExecution:
 class TestSafeICEWithInitialParams:
     """Test SafeICE with initial parameter specification."""
 
-    def test_with_initial_params(self):
+    def test_with_initial_params(self, seed):
         """Test SafeICE with user-provided initial parameters."""
+
         def g(u):
             return 3.5 - np.linalg.norm(u, axis=-1)
 
@@ -177,7 +188,7 @@ class TestSafeICEWithInitialParams:
             m=np.array([2.0, 2.5]),
             Omega=np.array([1.0, 1.2]),
             mu=np.array([[1.0, 0.0], [0.0, 1.0]]) / np.sqrt(2),
-            kappa=np.array([5.0, 3.0])
+            kappa=np.array([5.0, 3.0]),
         )
 
         ice = SafeICE(
@@ -185,12 +196,10 @@ class TestSafeICEWithInitialParams:
             dimension=2,
             N=200,
             max_iterations=3,
+            random_state=seed,
         )
 
-        pf, results = ice.run(
-            initial_params=initial_params,
-            verbose=False
-        )
+        pf, results = ice.run(initial_params=initial_params, verbose=False)
 
         assert pf > 0
         assert results["final_samples"].shape[1] == 2
@@ -199,7 +208,19 @@ class TestSafeICEWithInitialParams:
 class TestBenchmarkProblems:
     """Test with benchmark problems."""
 
-    def test_four_mode_series_system(self):
+    @pytest.mark.xfail(
+        strict=True,
+        reason=(
+            "Known estimator reliability gap on the paper's headline benchmark. "
+            "The reference probability is ~1.22e-5, but at this seed the "
+            "estimate is ~5e-2, four orders of magnitude high. A sweep over 12 "
+            "seeds lands inside the asserted range only 6 times, with estimates "
+            "ranging from 6e-6 to 5e-1. This test previously passed only "
+            "because an unrelated test seeded the global RNG first. Remove this "
+            "marker once the estimator is corrected."
+        ),
+    )
+    def test_four_mode_series_system(self, seed):
         """Test the four-mode series system benchmark."""
         problems = BenchmarkProblems()
         g = problems.four_mode_series_system()
@@ -209,15 +230,16 @@ class TestBenchmarkProblems:
             dimension=2,
             N=500,
             max_iterations=10,
+            random_state=seed,
         )
 
-        pf, results = ice.run(verbose=False)
+        pf, _results = ice.run(verbose=False)
 
         # Reference probability is approximately 1.22e-5
         assert pf > 1e-6
         assert pf < 1e-4
 
-    def test_three_mode_problem(self):
+    def test_three_mode_problem(self, seed):
         """Test the three-mode problem benchmark."""
         problems = BenchmarkProblems()
         g = problems.three_mode_problem()
@@ -227,16 +249,17 @@ class TestBenchmarkProblems:
             dimension=2,
             N=300,
             max_iterations=5,
+            random_state=seed,
         )
 
-        pf, results = ice.run(verbose=False)
+        pf, _results = ice.run(verbose=False)
 
         # Reference probability is approximately 2.3e-3
         assert pf > 1e-4
         assert pf < 1e-2
 
     @pytest.mark.slow
-    def test_two_mode_opposite_directions(self):
+    def test_two_mode_opposite_directions(self, seed):
         """Test the two-mode opposite directions benchmark (slow test)."""
         problems = BenchmarkProblems()
         # Test with dimension 10
@@ -246,7 +269,8 @@ class TestBenchmarkProblems:
             limit_state_function=g,
             dimension=10,
             N=500,
-            max_iterations=5
+            max_iterations=5,
+            random_state=seed,
         )
 
         pf, results = ice.run(verbose=False)
@@ -258,8 +282,9 @@ class TestBenchmarkProblems:
 class TestErrorHandling:
     """Test error handling and edge cases."""
 
-    def test_limit_state_returns_nan(self):
+    def test_limit_state_returns_nan(self, seed):
         """Test handling when limit state function returns NaN."""
+
         def g(u):
             # Return NaN for some inputs
             result = 3.5 - np.linalg.norm(u, axis=-1)
@@ -271,14 +296,16 @@ class TestErrorHandling:
             dimension=2,
             N=100,
             max_iterations=2,
+            random_state=seed,
         )
 
         # Should handle NaN gracefully
         with pytest.warns(RuntimeWarning):
-            pf, results = ice.run(verbose=False)
+            _pf, _results = ice.run(verbose=False)
 
-    def test_limit_state_returns_inf(self):
+    def test_limit_state_returns_inf(self, seed):
         """Test handling when limit state function returns infinity."""
+
         def g(u):
             # Return infinity for some inputs
             result = 3.5 - np.linalg.norm(u, axis=-1)
@@ -290,15 +317,17 @@ class TestErrorHandling:
             dimension=2,
             N=100,
             max_iterations=2,
+            random_state=seed,
         )
 
         # Should handle infinity gracefully
-        pf, results = ice.run(verbose=False)
+        pf, _results = ice.run(verbose=False)
         assert pf >= 0
         assert pf <= 1
 
-    def test_all_samples_fail(self):
+    def test_all_samples_fail(self, seed):
         """Test when all samples are in failure region."""
+
         def g(u):
             # Always in failure (negative values)
             return -1.0 * np.ones(len(u))
@@ -308,16 +337,18 @@ class TestErrorHandling:
             dimension=2,
             N=100,
             max_iterations=2,
+            random_state=seed,
         )
 
-        pf, results = ice.run(verbose=False)
+        pf, _results = ice.run(verbose=False)
 
         # Should give high probability (IS estimate may be < 1 due to
         # weight mismatch when the true P_f is 1.0)
         assert pf > 0.5
 
-    def test_no_samples_fail(self):
+    def test_no_samples_fail(self, seed):
         """Test when no samples are in failure region."""
+
         def g(u):
             # Never in failure (always positive)
             return 10.0 * np.ones(len(u))
@@ -327,9 +358,10 @@ class TestErrorHandling:
             dimension=2,
             N=100,
             max_iterations=2,
+            random_state=seed,
         )
 
-        pf, results = ice.run(verbose=False)
+        pf, _results = ice.run(verbose=False)
 
         # Should give very low probability
         assert pf < 1e-10
@@ -338,8 +370,9 @@ class TestErrorHandling:
 class TestConvergence:
     """Test convergence behavior."""
 
-    def test_cv_convergence(self):
+    def test_cv_convergence(self, seed):
         """Test that CV convergence criterion works."""
+
         def g(u):
             return 3.5 - np.linalg.norm(u, axis=-1)
 
@@ -350,15 +383,17 @@ class TestConvergence:
             max_iterations=20,
             delta_target=0.1,  # Strict convergence
             cv_tolerance=0.01,
+            random_state=seed,
         )
 
-        pf, results = ice.run(verbose=False)
+        _pf, results = ice.run(verbose=False)
 
         # With strict CV, should converge or reach max_iterations
         assert len(results["final_samples"]) <= 1000 * 20
 
-    def test_early_stopping(self):
+    def test_early_stopping(self, seed):
         """Test that algorithm stops early when converged."""
+
         def g(u):
             # Simple problem that should converge quickly
             return 2.0 - np.linalg.norm(u, axis=-1)
@@ -368,10 +403,11 @@ class TestConvergence:
             dimension=2,
             N=500,
             max_iterations=20,  # Allow many iterations
-            delta_target=0.5,  # Relaxed convergence
+            delta_target=0.5,  # Relaxed convergence,
+            random_state=seed,
         )
 
-        pf, results = ice.run(verbose=False)
+        _pf, results = ice.run(verbose=False)
 
         # Should stop before max_iterations
         assert len(results["final_samples"]) < 500 * 20
@@ -382,53 +418,81 @@ class TestReproducibility:
 
     def test_same_seed_same_result(self):
         """Two runs with identical seed produce identical outputs."""
+
         def g(u):
             return 3.5 - np.linalg.norm(u, axis=-1)
 
         pf1, _ = SafeICE(
-            g, dimension=2, N=100, max_iterations=2, random_state=42,
+            g,
+            dimension=2,
+            N=100,
+            max_iterations=2,
+            random_state=42,
         ).run(verbose=False)
 
         pf2, _ = SafeICE(
-            g, dimension=2, N=100, max_iterations=2, random_state=42,
+            g,
+            dimension=2,
+            N=100,
+            max_iterations=2,
+            random_state=42,
         ).run(verbose=False)
 
         assert pf1 == pf2
 
     def test_different_seed_different_result(self):
         """Two runs with different seeds produce different outputs."""
+
         def g(u):
             return 3.5 - np.linalg.norm(u, axis=-1)
 
         pf1, _ = SafeICE(
-            g, dimension=2, N=200, max_iterations=3, random_state=1,
+            g,
+            dimension=2,
+            N=200,
+            max_iterations=3,
+            random_state=1,
         ).run(verbose=False)
 
         pf2, _ = SafeICE(
-            g, dimension=2, N=200, max_iterations=3, random_state=2,
+            g,
+            dimension=2,
+            N=200,
+            max_iterations=3,
+            random_state=2,
         ).run(verbose=False)
 
         assert pf1 != pf2
 
     def test_generator_accepted(self):
         """A np.random.Generator can be passed directly."""
+
         def g(u):
             return 3.5 - np.linalg.norm(u, axis=-1)
 
         rng = np.random.default_rng(99)
         pf, _ = SafeICE(
-            g, dimension=2, N=100, max_iterations=2, random_state=rng,
+            g,
+            dimension=2,
+            N=100,
+            max_iterations=2,
+            random_state=rng,
         ).run(verbose=False)
 
         assert np.isfinite(pf) and pf >= 0
 
     def test_none_is_backward_compatible(self):
         """random_state=None uses global np.random (no crash)."""
+
         def g(u):
             return 3.5 - np.linalg.norm(u, axis=-1)
 
         pf, _ = SafeICE(
-            g, dimension=2, N=100, max_iterations=1, random_state=None,
+            g,
+            dimension=2,
+            N=100,
+            max_iterations=1,
+            random_state=None,
         ).run(verbose=False)
 
         assert np.isfinite(pf) and pf >= 0


### PR DESCRIPTION
Tests drew from NumPy's global random state, so results depended on test ordering. I hit an intermittent failure and traced it to this: one test passed **only** because an unrelated test had called `np.random.seed(42)` earlier in the session. It fails on its own.

- Everything is seeded now, via the `rng` and `seed` fixtures in `tests/conftest.py`. Six consecutive runs give identical results.
- Slow tests are marked, so plain `pytest` takes ~15s instead of 20+ minutes. Use `pytest -m ""` for everything.
- Two accuracy problems are recorded as strict `xfail` rather than hidden behind loosened thresholds:
  - the four-mode benchmark lands in range for only 6 of 12 seeds, with estimates from `6e-6` to `5e-1` against a reference of `1.22e-5`
  - for a limit state that always fails (true probability exactly 1), the estimate can exceed 1

Both predate this work — they reproduce on current `develop`. Strict xfail means they will fail loudly the moment someone fixes the estimator.

Stacked on #64.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the test suite deterministic and fast by removing reliance on NumPy’s global RNG and marking slow tests. Previously, test outcomes depended on execution order; now all randomized paths use seeded generators and known accuracy issues surface as strict xfail.

- All randomized tests use `rng` and `seed` fixtures from `tests/conftest.py`. Pass `random_state=seed` to `SafeICE`, and pass `rng` to `VonMisesFisherSampler.sample`, `NakagamiDistribution.sample`, `InverseNakagamiDistribution.sample`, and `vMFNMDistribution.sample`. Do not call `np.random.seed` or `np.random.randn` in tests.
- Slow cases are marked `@pytest.mark.slow`; `pytest` now completes in ~15s. Run the full suite with `pytest -m ""`.
- Two scenarios are strict xfail to expose estimator issues that already exist on `develop`: the four‑mode series benchmark often misses the ~1.22e‑5 reference by orders of magnitude, and a limit state that always fails can yield estimates >1.

<sup>Written for commit 7fbacc3b0cd6a5fd06cb0d60de164b446132379d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/adaptive-importance-sampling-ice/pull/65?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

