### PR TITLE
ci: make the performance regression check work

### DIFF
--- a/.github/workflows/performance-regression.yml
+++ b/.github/workflows/performance-regression.yml
@@ -63,6 +63,9 @@ jobs:
         with:
           name: pr-benchmarks
           path: .benchmarks/
+          # .benchmarks is a dot-directory and upload-artifact skips hidden
+          # files by default, which silently produced an empty artifact.
+          include-hidden-files: true
           if-no-files-found: error
           retention-days: 30
 
@@ -115,6 +118,9 @@ jobs:
         with:
           name: base-benchmarks
           path: .benchmarks/
+          # .benchmarks is a dot-directory and upload-artifact skips hidden
+          # files by default, which silently produced an empty artifact.
+          include-hidden-files: true
           if-no-files-found: error
           retention-days: 30
 

--- a/.github/workflows/performance-regression.yml
+++ b/.github/workflows/performance-regression.yml
@@ -3,11 +3,11 @@ name: Performance Regression Detector
 on:
   pull_request:
     branches: [main, master, develop]
-  workflow_dispatch:
 
 permissions:
   contents: read
   pull-requests: write
+  checks: write        # the summary is published as a check run
 
 env:
   BENCHMARK_ITERATIONS: 10
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - name: Cache dependencies
         uses: actions/cache@v5
@@ -38,38 +38,32 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-          if [ -f pyproject.toml ]; then pip install poetry && poetry install; fi
-          pip install pytest pytest-benchmark memory-profiler psutil
+          pip install -e .
+          pip install pytest pytest-benchmark
 
       - name: Run PR benchmarks
         id: pr-bench
         run: |
-          # Create benchmarks directory if it doesn't exist
           mkdir -p .benchmarks
-          
-          # Run pytest-benchmark if tests exist
-          if [ -d "tests" ] || [ -d "test" ]; then
-            python -m pytest tests/ --benchmark-only --benchmark-json=.benchmarks/pr_results.json || echo "No benchmark tests found"
-          fi
-          
-          # Run custom performance script if it exists
-          if [ -f "benchmarks/run_benchmarks.py" ]; then
-            python benchmarks/run_benchmarks.py --output .benchmarks/pr_custom.json
-          fi
-          
-          # Run memory profiling on key modules
-          if [ -f "benchmarks/profile_memory.py" ]; then
-            python -m memory_profiler benchmarks/profile_memory.py > .benchmarks/pr_memory.txt
-          fi
-          
-          echo "PR benchmarks completed"
 
+          if compgen -G "benchmarks/test_*.py" > /dev/null; then
+            python -m pytest benchmarks/ --benchmark-only --benchmark-json=.benchmarks/pr_results.json || true
+          fi
+
+          # Always leave a readable file behind. upload-artifact creates nothing
+          # for an empty directory, and the compare job would then fail on a
+          # missing artifact rather than reporting there was no baseline.
+          if [ ! -f .benchmarks/pr_results.json ]; then
+            echo '{"benchmarks": []}' > .benchmarks/pr_results.json
+          fi
+
+          echo "pr benchmarks completed"
       - name: Upload PR benchmark results
         uses: actions/upload-artifact@v6
         with:
           name: pr-benchmarks
           path: .benchmarks/
+          if-no-files-found: error
           retention-days: 30
 
   benchmark-base:
@@ -83,7 +77,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - name: Cache dependencies
         uses: actions/cache@v5
@@ -96,34 +90,32 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-          if [ -f pyproject.toml ]; then pip install poetry && poetry install; fi
-          pip install pytest pytest-benchmark memory-profiler psutil
+          pip install -e .
+          pip install pytest pytest-benchmark
 
       - name: Run base benchmarks
         id: base-bench
         run: |
           mkdir -p .benchmarks
-          
-          if [ -d "tests" ] || [ -d "test" ]; then
-            python -m pytest tests/ --benchmark-only --benchmark-json=.benchmarks/base_results.json || echo "No benchmark tests found"
-          fi
-          
-          if [ -f "benchmarks/run_benchmarks.py" ]; then
-            python benchmarks/run_benchmarks.py --output .benchmarks/base_custom.json
-          fi
-          
-          if [ -f "benchmarks/profile_memory.py" ]; then
-            python -m memory_profiler benchmarks/profile_memory.py > .benchmarks/base_memory.txt
-          fi
-          
-          echo "Base benchmarks completed"
 
+          if compgen -G "benchmarks/test_*.py" > /dev/null; then
+            python -m pytest benchmarks/ --benchmark-only --benchmark-json=.benchmarks/base_results.json || true
+          fi
+
+          # Always leave a readable file behind. upload-artifact creates nothing
+          # for an empty directory, and the compare job would then fail on a
+          # missing artifact rather than reporting there was no baseline.
+          if [ ! -f .benchmarks/base_results.json ]; then
+            echo '{"benchmarks": []}' > .benchmarks/base_results.json
+          fi
+
+          echo "base benchmarks completed"
       - name: Upload base benchmark results
         uses: actions/upload-artifact@v6
         with:
           name: base-benchmarks
           path: .benchmarks/
+          if-no-files-found: error
           retention-days: 30
 
   compare-and-report:
@@ -369,7 +361,7 @@ jobs:
             
             report += '---\n';
             report += '*Performance tests run on ubuntu-latest. Results may vary across environments.*\n';
-            report += '*To reproduce locally: `pytest tests/ --benchmark-only`*';
+            report += '*To reproduce locally: `pytest benchmarks/ --benchmark-only`*';
             
             // Post comment
             await github.rest.issues.createComment({

--- a/benchmarks/test_perf.py
+++ b/benchmarks/test_perf.py
@@ -1,0 +1,107 @@
+"""Performance benchmarks for the hot paths of the Safe-ICE algorithm.
+
+These live outside ``tests/`` on purpose. ``testpaths`` in pyproject.toml points
+at ``tests``, so a normal ``pytest`` run ignores this file and stays fast; the
+performance-regression workflow runs it explicitly with ``--benchmark-only``.
+
+Run locally with:
+
+    pytest benchmarks/ --benchmark-only
+
+The three densities below were each a per-sample Python loop calling scalar
+PDFs, which made a 2-D run take about two minutes. They are now vectorised, and
+these benchmarks exist so that does not quietly regress.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from safe_ice import SafeICE
+from safe_ice.core.parameters import vMFNMParameters
+from safe_ice.distributions._numeric import radii_and_directions
+from safe_ice.distributions.mixture import vMFNMDistribution
+from safe_ice.optimization.penalized_em import PenalizedEMOptimizer
+from safe_ice.problems.benchmarks import BenchmarkProblems
+
+SEED = 20240117
+
+
+def make_params(rng: np.random.Generator, K: int, d: int) -> vMFNMParameters:
+    """Build a well-formed mixture with K components in d dimensions."""
+    mu = rng.standard_normal((K, d))
+    mu /= np.linalg.norm(mu, axis=1, keepdims=True)
+    return vMFNMParameters(
+        pi=rng.dirichlet(np.ones(K)),
+        m=rng.uniform(1.0, 5.0, size=K),
+        Omega=rng.uniform(1.0, 8.0, size=K),
+        mu=mu,
+        kappa=rng.uniform(0.5, 20.0, size=K),
+    )
+
+
+@pytest.mark.benchmark(group="density")
+@pytest.mark.parametrize(("n", "d", "K"), [(1000, 2, 20), (1000, 10, 20)])
+def test_mixture_pdf(benchmark, n: int, d: int, K: int) -> None:
+    """Mixture density over a full batch of samples."""
+    rng = np.random.default_rng(SEED)
+    dist = vMFNMDistribution(make_params(rng, K, d))
+    X = rng.standard_normal((n, d)) * 2.0
+
+    result = benchmark(dist.pdf, X)
+    assert np.all(np.isfinite(result))
+
+
+@pytest.mark.benchmark(group="density")
+def test_heavy_tailed_density(benchmark) -> None:
+    """Heavy-tailed safety component of the proposal."""
+    rng = np.random.default_rng(SEED)
+    d, K, n = 2, 20, 1000
+    params = make_params(rng, K, d)
+    ice = SafeICE(
+        limit_state_function=lambda u: np.sum(u, axis=-1),
+        dimension=d,
+        N=n,
+        random_state=SEED,
+    )
+    X = rng.standard_normal((n, d)) * 2.0
+
+    result = benchmark(ice._evaluate_heavy_tailed_density, X, params)
+    assert np.all(np.isfinite(result))
+
+
+@pytest.mark.benchmark(group="em")
+def test_em_e_step(benchmark) -> None:
+    """Posterior responsibilities for a full batch."""
+    rng = np.random.default_rng(SEED)
+    d, K, n = 2, 20, 1000
+    params = make_params(rng, K, d)
+    X = rng.standard_normal((n, d)) * 2.0
+    radii, directions = radii_and_directions(X)
+    weights = rng.uniform(0.0, 2.0, size=n)
+    optimizer = PenalizedEMOptimizer()
+
+    result = benchmark(optimizer._e_step, X, radii, directions, params, weights)
+    assert result.shape == (n, K)
+
+
+@pytest.mark.benchmark(group="end-to-end")
+def test_safe_ice_run(benchmark) -> None:
+    """A short end-to-end run on the four-mode benchmark problem."""
+    g = BenchmarkProblems.four_mode_series_system()
+
+    def run() -> float:
+        ice = SafeICE(
+            limit_state_function=g,
+            dimension=2,
+            N=500,
+            max_iterations=3,
+            random_state=SEED,
+        )
+        pf, _ = ice.run(verbose=False)
+        return float(pf)
+
+    # Deterministic, so a single round per sample is enough.
+    pf = benchmark.pedantic(run, rounds=3, iterations=1)
+    assert np.isfinite(pf)


### PR DESCRIPTION
This workflow has failed on every pull request since it was added, including unrelated dependabot ones. Two independent reasons:

- It ran `pytest tests/ --benchmark-only`, but there are no benchmark tests, and neither `benchmarks/run_benchmarks.py` nor `benchmarks/profile_memory.py` exists. Nothing was ever written, so `upload-artifact` produced no artifact and the compare job died on `Artifact not found for name: pr-benchmarks`.
- The last step calls `github.rest.checks.create`, which needs `checks: write`. The workflow declared only `contents` and `pull-requests`, hence `Resource not accessible by integration`.

**Gives it something to measure.** Adds benchmarks for the three densities that were vectorised recently (mixture PDF, EM E-step, heavy-tailed density) plus a short end-to-end run, so the ~200x speedup cannot quietly regress. They live in `benchmarks/` rather than `tests/`, outside `testpaths`, so a normal `pytest` run is unaffected — verified, still 108 tests.

**Other fixes**

- Installs the package with `pip install -e .` instead of `poetry install`, which put dependencies in a virtualenv the later `python -m pytest` never saw.
- Always writes a results file, so a base commit that predates a benchmark reports "nothing to compare" instead of failing the job. That also makes this PR itself work, since `main` has no benchmarks yet.
- `upload-artifact` now uses `if-no-files-found: error`, so an empty upload can't silently recur.
- Drops `workflow_dispatch`: every job reads `github.event.pull_request`, so manual runs could never work.

Run locally with `pytest benchmarks/ --benchmark-only`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the performance regression check so it runs and reports instead of failing on every PR. Previously it ran `pytest tests/ --benchmark-only` with no benchmarks and lacked `checks: write`, causing missing-artifact and permission failures; now it benchmarks files under `benchmarks/`, always uploads results (including hidden files), and publishes a check.

**Key changes**
- Add `benchmarks/test_perf.py` with microbenchmarks for mixture PDF, heavy‑tailed density, EM E‑step, and a short end‑to‑end run; kept outside `tests/` so normal `pytest` runs are unchanged.
- Workflow updates:
  - Grant `checks: write`; bump to Python 3.12.
  - Install with `pip install -e .`; run `pytest benchmarks/ --benchmark-only`.
  - Always write `.benchmarks/*_results.json`; set `actions/upload-artifact` with `include-hidden-files: true` and `if-no-files-found: error`.
  - Remove `workflow_dispatch`; update repro hint in the report to `pytest benchmarks/ --benchmark-only`.

<sup>Written for commit 975ef30b8d307d92eba4aca173d9d53c898edb3f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/adaptive-importance-sampling/pull/70?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

