### PR TITLE
fix: two correctness bugs that biased every failure probability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The heavy-tailed proposal component was missing the polar Jacobian.** It is
+  built as a radial density times an angular one, so recovering a density on
+  R^d needs `du = r^(d-1) dr dw`, which `vMFNMDistribution.pdf` applied and
+  this did not. The component integrated to 2.7 at d=2 and 114 at d=5, and
+  since it sits in the importance-sampling denominator every estimate was
+  scaled by that error. On a linear limit state with a closed-form answer the
+  estimate was 0.54x the analytical value regardless of sample size; it is now
+  1.02x. `OptimizedSafeICE` had the same omission in both of its components.
+- **Cosine annealing drove lambda to exactly 1.0**, which removed the
+  heavy-tailed component from the proposal altogether. That component is what
+  keeps the proposal's tails heavier than the target so importance weights stay
+  bounded; without it a single tail sample could carry the estimate (99.5% of
+  it on one seed, giving 0.71 for a 5.8e-5 event). Lambda is now capped by a
+  new `lambda_max` parameter, default 0.95, matching the cap `AdaptiveSafeICE`
+  already applied. On the four-mode benchmark, 4 of 12 seeds landed within 2x
+  of the true value before; all 12 do now.
+- The four-mode benchmark test cited a reference of 1.22e-5. Crude Monte Carlo
+  over 2e7 samples puts it at 5.8e-5 +/- 1.7e-6 for the default z=3.8.
+
 - **`PerformanceEvaluator.compare_methods` crashed** with `TypeError` because it
   treated `results["iterations"]` (a list of per-iteration records) as a count.
 - **The README's quick-start example printed a list of dicts** where it claimed

--- a/README.md
+++ b/README.md
@@ -15,10 +15,9 @@ and `g` is a limit-state function. It targets problems where the failure
 probability is far too small for crude Monte Carlo to resolve at a practical
 sample count.
 
-> **Status: alpha.** The algorithm runs end to end and the numerics are covered
-> by tests, but the estimator does not yet reproduce the reference
-> probabilities from the paper reliably. Please read
-> [Known limitations](#known-limitations) before depending on the results.
+> **Status: alpha.** Two correctness bugs that biased every estimate have been
+> fixed, and the estimator now tracks known analytical answers to within about
+> 10%. See [Accuracy](#accuracy) for the numbers and what is still open.
 
 Implements the method described in:
 
@@ -32,7 +31,7 @@ Implements the method described in:
 - [How it works](#how-it-works)
 - [Reproducibility](#reproducibility)
 - [Further usage](#further-usage)
-- [Known limitations](#known-limitations)
+- [Accuracy](#accuracy)
 - [Development](#development)
 - [Citation](#citation)
 - [License](#license)
@@ -217,29 +216,45 @@ safe-ice benchmark --problem four-mode
 `nonlinear_oscillator_simplified`, and `nakagami_ratio_problem`, plus
 `HeatTransferProblem` — a PDE problem using a Karhunen-Loève expansion.
 
-## Known limitations
+## Accuracy
 
-These are measured, reproducible gaps between this implementation and the
-behaviour the method should have. They are recorded as `xfail` tests rather
-than hidden, so they will announce themselves the moment they are fixed.
+Two correctness bugs that biased every estimate have been fixed:
 
-- **Accuracy on the headline benchmark is unreliable.** On the four-mode series
-  system (reference `P_F ≈ 1.22e-5`), a sweep over 12 seeds at `N=500`,
-  `max_iterations=10` lands inside `[1e-6, 1e-4]` only 6 times, with estimates
-  ranging from `6e-6` to `5e-1`. See
-  `tests/test_safe_ice.py::TestBenchmarkProblems::test_four_mode_series_system`.
-- **Systematic bias on a linear limit state.** Where the answer is known in
-  closed form (`Φ(-a₀/‖a‖)`), the estimate sits at roughly `0.54x` the
-  analytical value, and the gap does not shrink as `N` grows from `1e3` to
-  `8e3` — so it is bias, not Monte Carlo noise.
-- **Estimates are not constrained to `[0, 1]`.** For a limit state that fails
-  everywhere (true probability exactly 1), the estimator can return values
-  above 1. See
-  `tests/test_integration.py::TestEdgeCases::test_certain_failure`.
+- The heavy-tailed component of the proposal was missing the polar Jacobian
+  `r^(d-1)`, so it was not a probability density: it integrated to `2.7` at
+  `d=2` and `114` at `d=5`. Since it sits in the importance-sampling
+  denominator, every estimate was scaled by that error, which is why results
+  came out at roughly `0.54x` the analytical answer no matter how large `N`
+  was.
+- The cosine annealing schedule drove `λ` to exactly `1.0`, removing the
+  heavy-tailed component from the proposal entirely. That component is the
+  "safe" part of Safe-ICE: it keeps the proposal's tails heavier than the
+  target so the weights stay bounded. Without it the estimate could be
+  dominated by a single sample — on one seed, 99.5% of the estimate came from
+  one point. `λ` is now capped by `lambda_max` (default `0.95`).
+
+Current accuracy against problems with known answers, median over seeds:
+
+| Problem | Reference | Estimate / reference |
+| --- | --- | --- |
+| Linear limit state, closed form | `1.69e-2` | `1.08` |
+| Sphere `d=2`, closed form | `1.11e-2` | `1.02` |
+| Four-mode series system, 2e7-sample MC | `5.8e-5` | `1.10` |
+
+`tests/test_proposal_normalisation.py` pins this down: it integrates each
+proposal component numerically and fails if the Jacobian is dropped again.
+
+### Remaining limitations
+
+- **Estimates are not constrained to `[0, 1]`.** The estimator is unbiased but
+  unconstrained, so for a limit state that fails everywhere (true probability
+  exactly 1) it scatters around 1 and can land slightly above. Clamping would
+  fix it, but that is a modelling decision rather than a bug.
 - **High-dimensional variance is large.** At `d=10` with a small iteration
-  budget, estimates span several orders of magnitude across seeds.
-
-Contributions that close any of these are very welcome.
+  budget, estimates still vary considerably across seeds.
+- The reference value quoted for the four-mode problem used to be `1.22e-5`.
+  Crude Monte Carlo over 2e7 samples puts it at `5.8e-5 ± 1.7e-6` for the
+  default `z=3.8`.
 
 ## Development
 

--- a/safe_ice/core/safe_ice.py
+++ b/safe_ice/core/safe_ice.py
@@ -83,6 +83,7 @@ class SafeICE:
         sigma0: float = 1.0,
         em_max_iter: int = 100,
         cv_tolerance: float = 0.01,
+        lambda_max: float = 0.95,
         random_state: int | np.random.Generator | None = None,
     ) -> None:
         self.g = limit_state_function
@@ -94,6 +95,7 @@ class SafeICE:
         self.N = int(N)
         self.sigma0 = float(sigma0)
         self.cv_tolerance = float(cv_tolerance)
+        self.lambda_max = float(lambda_max)
 
         # Deterministic RNG support
         if random_state is None:
@@ -314,11 +316,21 @@ class SafeICE:
         return vMFNMParameters(pi=pi, m=m, Omega=Omega, mu=mu, kappa=kappa)
 
     def _cosine_annealing_schedule(self, sigma: float, M: float) -> float:
-        """Cosine annealing schedule for lambda parameter."""
+        """Cosine annealing schedule for lambda parameter.
+
+        The raw schedule reaches exactly 1 as sigma goes to 0, which drops the
+        heavy-tailed component from the proposal altogether. That component is
+        the "safe" part of Safe-ICE: it keeps the proposal's tails heavier than
+        the target so the importance weights stay bounded. Without it a single
+        sample from the tail can carry essentially the whole estimate. The
+        result is capped at ``lambda_max`` so some heavy-tailed mass always
+        remains.
+        """
         if sigma > M:
             return 0.0
         # Return Python float to avoid numpy floating[Any]
-        return float(0.5 * (1.0 + math.cos(math.pi * sigma / M)))
+        raw = 0.5 * (1.0 + math.cos(math.pi * sigma / M))
+        return float(min(raw, self.lambda_max))
 
     # -------------------------------------------------------------------------
     # Sampling
@@ -602,9 +614,18 @@ class SafeICE:
     def _evaluate_heavy_tailed_density(
         self, samples: NDArrayF, params: vMFNMParameters
     ) -> NDArrayF:
-        """Evaluate density of the heavy-tailed component for each sample."""
+        """Evaluate density of the heavy-tailed component for each sample.
+
+        The component is written in polar form as a radial density times an
+        angular one. Converting that back to a density on R^d needs the
+        Jacobian of the polar map, ``du = r^(d-1) dr dw``, exactly as
+        :meth:`vMFNMDistribution.pdf` does. Without it the component does not
+        integrate to one, and since it is part of the importance-sampling
+        denominator every estimate is scaled by the error.
+        """
         n_samples = int(samples.shape[0])
         radii, directions = radii_and_directions(samples)
+        jacobian = radii ** (self.d - 1)
 
         # The inverse-Nakagami shape depends only on the problem dimension, so
         # it is hoisted out of the per-component loop.
@@ -628,7 +649,9 @@ class SafeICE:
                 directions, params.mu[k], float(params.kappa[k])
             )
 
-            densities += float(params.pi[k]) * radial_density * angular_density
+            densities += (
+                float(params.pi[k]) * radial_density * angular_density / jacobian
+            )
 
         return densities
 

--- a/safe_ice/core/safe_ice_optimized.py
+++ b/safe_ice/core/safe_ice_optimized.py
@@ -61,6 +61,7 @@ class OptimizedSafeICE:
         enable_caching: bool = True,
         enable_parallel: bool = True,
         batch_size: int | None = None,
+        lambda_max: float = 0.95,
         random_state: int | np.random.Generator | None = None,
     ) -> None:
         """
@@ -102,6 +103,7 @@ class OptimizedSafeICE:
         self.N = int(N)
         self.sigma0 = float(sigma0)
         self.em_max_iter = int(em_max_iter)
+        self.lambda_max = float(lambda_max)
 
         # Deterministic RNG support
         if random_state is None:
@@ -536,6 +538,10 @@ class OptimizedSafeICE:
         directions = np.zeros_like(samples)
         directions[valid_mask] = samples[valid_mask] / radii[valid_mask, np.newaxis]
 
+        # See the note in the heavy-tailed density: the polar form needs the
+        # r^(d-1) Jacobian to be a density on R^d.
+        jacobian = np.maximum(radii, 1e-12) ** (self.d - 1)
+
         # For each component
         for k in range(params.K):
             # Radial density (Nakagami)
@@ -552,7 +558,9 @@ class OptimizedSafeICE:
             angular_density *= C_d
 
             # Component contribution
-            densities += float(params.pi[k]) * radial_density * angular_density
+            densities += (
+                float(params.pi[k]) * radial_density * angular_density / jacobian
+            )
 
         return densities
 
@@ -569,6 +577,11 @@ class OptimizedSafeICE:
 
         directions = np.zeros_like(samples)
         directions[valid_mask] = samples[valid_mask] / radii[valid_mask, np.newaxis]
+
+        # Polar-to-Cartesian Jacobian: du = r^(d-1) dr dw. Without it the
+        # component does not integrate to one and, since it sits in the
+        # importance-sampling denominator, biases every estimate.
+        jacobian = np.maximum(radii, 1e-12) ** (self.d - 1)
 
         # For each component
         for k in range(params.K):
@@ -590,7 +603,9 @@ class OptimizedSafeICE:
             angular_density *= C_d
 
             # Component contribution
-            densities += float(params.pi[k]) * radial_density * angular_density
+            densities += (
+                float(params.pi[k]) * radial_density * angular_density / jacobian
+            )
 
         return densities
 
@@ -615,10 +630,15 @@ class OptimizedSafeICE:
         return vMFNMParameters(pi=pi, m=m, Omega=Omega, mu=mu, kappa=kappa)
 
     def _cosine_annealing_schedule(self, sigma: float, M: float) -> float:
-        """Cosine annealing schedule for lambda parameter."""
+        """Cosine annealing schedule for lambda parameter.
+
+        Capped at ``lambda_max`` so the heavy-tailed component never leaves the
+        proposal; see the note on the same method in :class:`SafeICE`.
+        """
         if sigma > M:
             return 0.0
-        return float(0.5 * (1.0 + math.cos(math.pi * sigma / M)))
+        raw = 0.5 * (1.0 + math.cos(math.pi * sigma / M))
+        return float(min(raw, self.lambda_max))
 
     def _adapt_sigma(self, sigma: float, K_old: int, K_new: int) -> float:
         """Adapt sigma based on component evolution."""

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -404,13 +404,14 @@ class TestEdgeCases:
     @pytest.mark.xfail(
         strict=False,
         reason=(
-            "Known estimator weakness: for a limit state that fails everywhere "
-            "the true probability is exactly 1, but the estimate wanders well "
-            "off it and across seeds can even exceed 1, which is not a valid "
-            "probability. Not strict: the estimate lands either side of the "
-            "0.99 threshold depending on the platform and NumPy version, so "
-            "the outcome is not stable enough to assert either way. Remove "
-            "this marker once the estimator is corrected."
+            "Degenerate problem: the limit state fails everywhere, so the "
+            "true probability is exactly 1. The importance-sampling estimator "
+            "is unbiased but unconstrained, so with N=100 it scatters around "
+            "1 and lands either side of the 0.99 threshold; across seeds the "
+            "median is about 1.07. Not strict, because which side it falls on "
+            "depends on the platform and NumPy version. Clamping the estimate "
+            "to [0, 1] would fix this, but that is a modelling decision rather "
+            "than a bug."
         ),
     )
     def test_certain_failure(self, seed):

--- a/tests/test_proposal_normalisation.py
+++ b/tests/test_proposal_normalisation.py
@@ -1,0 +1,180 @@
+"""The proposal components must be probability densities on R^d.
+
+Every component of ``q_safe`` sits in the denominator of the importance
+weights, so if one of them integrates to something other than 1 the failure
+probability is scaled by that factor no matter how many samples are drawn.
+That is what a missing polar Jacobian did: the heavy-tailed component
+integrated to 2.7 at d=2 and 114 at d=5, and estimates came out at roughly
+half the analytical answer regardless of N.
+
+Each density is written in polar form as a radial density times an angular
+one, so recovering a density on R^d needs ``du = r^(d-1) dr dw``. These tests
+integrate the components numerically and would fail again if that factor were
+dropped.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from scipy import stats
+
+from safe_ice import OptimizedSafeICE, SafeICE
+from safe_ice.core.parameters import vMFNMParameters
+from safe_ice.distributions.mixture import vMFNMDistribution
+
+
+def build_params(rng: np.random.Generator, K: int, d: int) -> vMFNMParameters:
+    """A well-formed mixture with K components in d dimensions."""
+    mu = rng.standard_normal((K, d))
+    mu /= np.linalg.norm(mu, axis=1, keepdims=True)
+    return vMFNMParameters(
+        pi=rng.dirichlet(np.ones(K)),
+        m=rng.uniform(1.0, 4.0, size=K),
+        Omega=rng.uniform(1.0, 6.0, size=K),
+        mu=mu,
+        kappa=rng.uniform(0.5, 8.0, size=K),
+    )
+
+
+def integrate_density(density_fn, d: int, n: int = 200_000, scale: float = 6.0):
+    """Estimate the integral of a density over R^d, by importance sampling.
+
+    Uses a wide Gaussian as the reference:
+    ``int q(u) du = E_{u~N(0, s^2 I)}[ q(u) / N(u; 0, s^2 I) ]``.
+
+    Returns the estimate and its standard error.
+    """
+    rng = np.random.default_rng(4242)
+    u = rng.standard_normal((n, d)) * scale
+    log_reference = stats.multivariate_normal.logpdf(
+        u, mean=np.zeros(d), cov=(scale**2) * np.eye(d)
+    )
+    ratio = np.asarray(density_fn(u), dtype=np.float64) / np.exp(log_reference)
+    return float(np.mean(ratio)), float(np.std(ratio) / np.sqrt(n))
+
+
+# A generous tolerance: this is a Monte Carlo integral of a heavy-tailed
+# integrand, so it is noisy. The bug being guarded against was off by 2.7x to
+# 114x, which this catches many times over.
+TOLERANCE = 0.15
+
+
+@pytest.mark.parametrize("d", [2, 3])
+@pytest.mark.parametrize("K", [1, 3])
+def test_vmfnm_mixture_integrates_to_one(d: int, K: int, rng) -> None:
+    dist = vMFNMDistribution(build_params(rng, K, d))
+    integral, stderr = integrate_density(dist.pdf, d)
+    assert integral == pytest.approx(1.0, abs=max(TOLERANCE, 3 * stderr))
+
+
+@pytest.mark.parametrize("d", [2, 3])
+@pytest.mark.parametrize("K", [1, 3])
+def test_heavy_tailed_component_integrates_to_one(d: int, K: int, rng, seed) -> None:
+    params = build_params(rng, K, d)
+    ice = SafeICE(
+        limit_state_function=lambda u: np.sum(u, axis=-1),
+        dimension=d,
+        N=10,
+        random_state=seed,
+    )
+    integral, stderr = integrate_density(
+        lambda u: ice._evaluate_heavy_tailed_density(u, params), d
+    )
+    assert integral == pytest.approx(1.0, abs=max(TOLERANCE, 3 * stderr))
+
+
+@pytest.mark.parametrize("lambda_val", [0.0, 0.5, 0.95])
+def test_safe_mixture_integrates_to_one(lambda_val: float, rng, seed) -> None:
+    d, K = 2, 3
+    params = build_params(rng, K, d)
+    ice = SafeICE(
+        limit_state_function=lambda u: np.sum(u, axis=-1),
+        dimension=d,
+        N=10,
+        random_state=seed,
+    )
+    integral, stderr = integrate_density(
+        lambda u: ice._evaluate_safe_mixture_density(u, params, lambda_val), d
+    )
+    assert integral == pytest.approx(1.0, abs=max(TOLERANCE, 3 * stderr))
+
+
+@pytest.mark.parametrize("d", [2, 3])
+def test_optimized_components_integrate_to_one(d: int, rng, seed) -> None:
+    """OptimizedSafeICE has its own density code, with the same requirement."""
+    params = build_params(rng, 3, d)
+    ice = OptimizedSafeICE(
+        limit_state_function=lambda u: np.sum(u, axis=-1),
+        dimension=d,
+        N=10,
+        random_state=seed,
+    )
+
+    light, light_se = integrate_density(
+        lambda u: ice._evaluate_vmfnm_density_vectorized(u, params, 1.0), d
+    )
+    assert light == pytest.approx(1.0, abs=max(TOLERANCE, 3 * light_se))
+
+    heavy, heavy_se = integrate_density(
+        lambda u: ice._evaluate_heavy_tailed_density_vectorized(u, params), d
+    )
+    assert heavy == pytest.approx(1.0, abs=max(TOLERANCE, 3 * heavy_se))
+
+
+class TestLambdaCap:
+    """The heavy-tailed component must never be annealed fully away."""
+
+    def test_lambda_never_reaches_one(self, seed) -> None:
+        # sigma -> 0 drives the raw cosine schedule to exactly 1.0, which would
+        # drop the heavy-tailed component and let a single tail sample carry
+        # the whole estimate.
+        ice = SafeICE(
+            limit_state_function=lambda u: np.sum(u, axis=-1),
+            dimension=2,
+            N=10,
+            random_state=seed,
+        )
+        for sigma in (1.0, 0.5, 1e-3, 1e-8, 0.0):
+            assert ice._cosine_annealing_schedule(sigma, 1.0) <= ice.lambda_max
+
+    def test_lambda_max_is_configurable(self, seed) -> None:
+        ice = SafeICE(
+            limit_state_function=lambda u: np.sum(u, axis=-1),
+            dimension=2,
+            N=10,
+            lambda_max=0.8,
+            random_state=seed,
+        )
+        assert ice._cosine_annealing_schedule(0.0, 1.0) == pytest.approx(0.8)
+
+
+class TestKnownAnalyticalAnswers:
+    """End-to-end accuracy against problems with closed-form solutions."""
+
+    @pytest.mark.slow
+    def test_linear_limit_state_is_unbiased(self) -> None:
+        """The estimate should centre on the analytical value, not half of it."""
+        a = np.array([1.0, 1.0])
+        a0 = 3.0
+        analytical = float(stats.norm.cdf(-a0 / np.linalg.norm(a)))
+
+        def limit_state(u: np.ndarray) -> np.ndarray:
+            return a0 + np.dot(u.reshape(-1, 2), a)
+
+        estimates = []
+        for s in range(6):
+            ice = SafeICE(
+                limit_state_function=limit_state,
+                dimension=2,
+                N=2000,
+                max_iterations=15,
+                random_state=s,
+            )
+            pf, _ = ice.run(verbose=False)
+            estimates.append(pf)
+
+        mean_estimate = float(np.mean(estimates))
+        # Before the Jacobian fix this ratio sat at ~0.54 and did not improve
+        # with more samples.
+        assert 0.75 < mean_estimate / analytical < 1.35

--- a/tests/test_safe_ice.py
+++ b/tests/test_safe_ice.py
@@ -208,18 +208,6 @@ class TestSafeICEWithInitialParams:
 class TestBenchmarkProblems:
     """Test with benchmark problems."""
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason=(
-            "Known estimator reliability gap on the paper's headline benchmark. "
-            "The reference probability is ~1.22e-5, but at this seed the "
-            "estimate is ~5e-2, four orders of magnitude high. A sweep over 12 "
-            "seeds lands inside the asserted range only 6 times, with estimates "
-            "ranging from 6e-6 to 5e-1. This test previously passed only "
-            "because an unrelated test seeded the global RNG first. Remove this "
-            "marker once the estimator is corrected."
-        ),
-    )
     def test_four_mode_series_system(self, seed):
         """Test the four-mode series system benchmark."""
         problems = BenchmarkProblems()
@@ -235,7 +223,9 @@ class TestBenchmarkProblems:
 
         pf, _results = ice.run(verbose=False)
 
-        # Reference probability is approximately 1.22e-5
+        # Crude Monte Carlo over 2e7 samples puts the reference at
+        # 5.8e-5 +/- 1.7e-6 for the default z=3.8. (An earlier comment here
+        # claimed 1.22e-5, which does not match this problem's parameters.)
         assert pf > 1e-6
         assert pf < 1e-4
 


### PR DESCRIPTION
The estimator sat at ~`0.54x` the analytical answer on a linear limit state, and the gap did not shrink as `N` went from 1e3 to 8e3 — so it was bias, not Monte Carlo noise. Integrating each proposal component numerically found why.

## 1. Missing polar Jacobian

The heavy-tailed component is built as a radial density times an angular one, so recovering a density on `R^d` needs `du = r^(d-1) dr dw`. `vMFNMDistribution.pdf` applied that factor; `_evaluate_heavy_tailed_density` did not.

Measured by numerical integration, the component integrated to:

| d | before | after |
| --- | --- | --- |
| 2 | 2.68 | 1.01 |
| 3 | 12.1 | 1.01 |
| 5 | 113.7 | 0.94 |

It sits in the importance-sampling denominator, so every estimate was scaled by that error. At `d=2` with `λ≈0.5` the proposal was ~1.84x too large, predicting `1/1.84 ≈ 0.54` — which is exactly the bias observed.

`OptimizedSafeICE` omitted the same factor in **both** of its components.

## 2. λ annealed to exactly 1.0

`λ = 0.5·(1 + cos(π·σ/M))` reaches exactly `1.0` as `σ → 0`, which removes the heavy-tailed component from the proposal entirely. That component is the "safe" part of Safe-ICE: it keeps the proposal's tails heavier than the target so importance weights stay bounded.

Without it the estimate could be carried by a single sample. On seed 1 of the four-mode benchmark, the top sample contributed **99.5%** of the estimate (max weight 555 vs median 5e-6), returning `0.71` for a `5.8e-5` event.

λ is now capped by a new `lambda_max` parameter, default `0.95` — the cap `AdaptiveSafeICE` already applied to its own schedule.

## Results

Median over seeds, against known answers:

| Problem | Reference | Before | After |
| --- | --- | --- | --- |
| Linear limit state (closed form) | `1.69e-2` | `0.54x` | `1.08x` |
| Sphere d=2 (closed form) | `1.11e-2` | — | `1.02x` |
| Four-mode benchmark | `5.8e-5` | 4/12 seeds within 2x | **12/12** |

## Also

The four-mode test cited a reference of `1.22e-5`. Crude Monte Carlo over 2e7 samples puts it at `5.8e-5 ± 1.7e-6` for the default `z=3.8`, so the comment is corrected. Its `xfail` is removed — the test passes now.

`tests/test_proposal_normalisation.py` integrates each component numerically and fails if the Jacobian is dropped again. I verified it actually catches the bug by reverting the fix: 7 failures.

Still open: the estimator is unbiased but unconstrained, so on a degenerate always-fails problem it scatters around 1 and can land slightly above. Clamping would fix that, but it is a modelling decision rather than a bug, so it stays a non-strict `xfail`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two bugs that biased all failure probabilities and could drop the safe heavy‑tailed mass. Before: the heavy‑tailed proposal missed the polar Jacobian and λ annealed to 1.0, giving ~0.54x estimates and single‑sample dominance. Now: densities include r^(d−1) and λ is capped by `lambda_max` (default 0.95), bringing results within ~2–8% of references.

**Review notes**
- Correctness: apply the polar Jacobian r^(d−1) in `SafeICE._evaluate_heavy_tailed_density` and in `OptimizedSafeICE` for both VMFNM and heavy‑tailed paths (with `np.maximum(r, 1e-12)` guard).
- Scheduling: cap `_cosine_annealing_schedule` by new `lambda_max` in both `SafeICE` and `OptimizedSafeICE`; default 0.95 to keep heavy‑tailed mass.
- Tests: add `tests/test_proposal_normalisation.py` that numerically integrates each component (≈1) and asserts λ never reaches 1; verifies `lambda_max` is configurable.
- Docs/tests: README “Accuracy” updates; correct four‑mode reference to 5.8e-5 and remove its xfail; clarify non‑strict xfail for certain‑failure case; update CHANGELOG.
- Results: linear limit state 0.54x -> 1.08x; sphere d=2 -> 1.02x; four‑mode 4/12 -> 12/12 seeds within 2x.

<sup>Written for commit ed18b965368dfc7154b29ef87e7e36fe1481b136. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/adaptive-importance-sampling/pull/73?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

