### PR TITLE
fix: correct the sign of the cross-entropy penalty in the EM step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   scaled by that error. On a linear limit state with a closed-form answer the
   estimate was 0.54x the analytical value regardless of sample size; it is now
   1.02x. `OptimizedSafeICE` had the same omission in both of its components.
+- **The cross-entropy penalty in the EM step had its sign inverted.**
+  Equation 21 uses `[ln pi_k - sum_s pi_s ln pi_s]`, and `sum_s pi_s ln pi_s`
+  is minus the entropy; the code subtracted the entropy instead. At uniform
+  weights the bracket should be 0 but evaluated to -2 ln K, subtracting a flat
+  0.3 from every weight at K=20 and zeroing all but the largest component on
+  the first EM step. The mixture collapsed to one component every run, which
+  defeats the automatic component selection the penalty exists to provide. It
+  now settles on 2-4 components for the four-mode problem, and the estimate
+  improves from 1.08x to 1.01x of the reference.
 - **Cosine annealing drove lambda to exactly 1.0**, which removed the
   heavy-tailed component from the proposal altogether. That component is what
   keeps the proposal's tails heavier than the target so importance weights stay

--- a/README.md
+++ b/README.md
@@ -226,6 +226,14 @@ Two correctness bugs that biased every estimate have been fixed:
   denominator, every estimate was scaled by that error, which is why results
   came out at roughly `0.54x` the analytical answer no matter how large `N`
   was.
+- The cross-entropy penalty in the EM step had its sign inverted. Equation 21
+  uses `[ln π_k − Σ π_s ln π_s]`, and `Σ π_s ln π_s` is minus the entropy; the
+  code subtracted the entropy instead. At uniform weights the bracket should be
+  `0` but came out as `−2·ln K`, subtracting a flat `0.3` from every weight at
+  `K=20` and zeroing all but the largest component on the first EM step. The
+  mixture collapsed to a single component every time, which defeats the
+  automatic component selection the penalty exists to provide. On the four-mode
+  problem it now settles on 2–4 components, as a four-mode problem should.
 - The cosine annealing schedule drove `λ` to exactly `1.0`, removing the
   heavy-tailed component from the proposal entirely. That component is the
   "safe" part of Safe-ICE: it keeps the proposal's tails heavier than the
@@ -237,9 +245,10 @@ Current accuracy against problems with known answers, median over seeds:
 
 | Problem | Reference | Estimate / reference |
 | --- | --- | --- |
-| Linear limit state, closed form | `1.69e-2` | `1.08` |
-| Sphere `d=2`, closed form | `1.11e-2` | `1.02` |
-| Four-mode series system, 2e7-sample MC | `5.8e-5` | `1.10` |
+| Linear limit state, closed form | `1.69e-2` | `1.02` |
+| Sphere `d=2`, closed form | `1.11e-2` | `1.01` |
+| Sphere `d=10`, closed form | `5.35e-3` | `0.94` |
+| Four-mode series system, 2e7-sample MC | `5.8e-5` | `1.01` |
 
 `tests/test_proposal_normalisation.py` pins this down: it integrates each
 proposal component numerically and fails if the Jacobian is dropped again.
@@ -250,8 +259,15 @@ proposal component numerically and fails if the Jacobian is dropped again.
   unconstrained, so for a limit state that fails everywhere (true probability
   exactly 1) it scatters around 1 and can land slightly above. Clamping would
   fix it, but that is a modelling decision rather than a bug.
-- **High-dimensional variance is large.** At `d=10` with a small iteration
-  budget, estimates still vary considerably across seeds.
+- **It breaks down somewhere between `d=10` and `d=20`.** The sphere problem
+  is accurate and stable through `d=10` (ratio `0.94`, estimates within `1.3x`
+  of each other across seeds). At `d=20` it fails badly: for a true value of
+  `1.54e-2`, only 1 of 6 seeds lands within `3x`, and the others return
+  `1e-20` or smaller. The cause is importance-weight degeneracy, not a coding
+  error — the ratio of largest to median weight grows from `~10` at `d=2` to
+  `~8e11` at `d=20`, so a handful of samples carry the estimate. Raising `N`
+  from 2000 to 10000 helps but does not fix it. Treat `d > 10` as unsupported
+  for now.
 - The reference value quoted for the four-mode problem used to be `1.22e-5`.
   Crude Monte Carlo over 2e7 samples puts it at `5.8e-5 ± 1.7e-6` for the
   default `z=3.8`.

--- a/safe_ice/optimization/penalized_em.py
+++ b/safe_ice/optimization/penalized_em.py
@@ -223,22 +223,28 @@ class PenalizedEMOptimizer:
             np.float64, copy=False
         )
 
-        # Penalty
-        # Encourage spread based on current entropy of old_pi
+        # Cross-entropy penalty, Equation 21:
+        #   pi_k += beta * pi_k * [ ln pi_k - sum_s pi_s ln pi_s ]
+        #
+        # The bracket is the pointwise surprisal minus the mean surprisal, so it
+        # is negative for components that carry less than average weight and
+        # positive for the rest: the penalty drains small components into large
+        # ones and is exactly zero when the weights are uniform.
+        #
+        # Note the sign. `sum_s pi_s ln pi_s` is negative and equals minus the
+        # entropy. Subtracting the entropy instead, as this once did, makes the
+        # bracket -2 ln K at uniform weights rather than 0, which subtracts a
+        # flat ~0.3 from every weight at K=20 and drives all but the single
+        # largest component to zero on the first EM step. That defeated the
+        # automatic component selection this penalty exists to provide.
         safe_old = np.maximum(old_pi.astype(np.float64, copy=False), 1e-15)
-        entropy_current: float = float(-np.sum(safe_old * np.log(safe_old)))
+        mean_log_pi: float = float(np.sum(safe_old * np.log(safe_old)))
 
-        K = int(old_pi.shape[0])
-        penalty_term: NDArrayF = np.zeros(K, dtype=np.float64)
         # Normalize factor (total_weight/total_weight == 1), kept explicit for clarity
         norm_factor: float = 1.0
-        for k in range(K):
-            penalty_term[k] = (
-                float(beta)
-                * norm_factor
-                * float(old_pi[k])
-                * (float(np.log(max(float(old_pi[k]), 1e-15))) - float(entropy_current))
-            )
+        penalty_term: NDArrayF = (
+            float(beta) * norm_factor * safe_old * (np.log(safe_old) - mean_log_pi)
+        ).astype(np.float64, copy=False)
 
         new_pi: NDArrayF = (pi_em + penalty_term).astype(np.float64, copy=False)
 

--- a/tests/test_proposal_normalisation.py
+++ b/tests/test_proposal_normalisation.py
@@ -178,3 +178,58 @@ class TestKnownAnalyticalAnswers:
         # Before the Jacobian fix this ratio sat at ~0.54 and did not improve
         # with more samples.
         assert 0.75 < mean_estimate / analytical < 1.35
+
+
+class TestPenalizedWeightUpdate:
+    """The cross-entropy penalty must not collapse the mixture on sight."""
+
+    def test_penalty_vanishes_at_uniform_weights(self) -> None:
+        """Uniform weights are the maximum-entropy case, so the penalty is 0.
+
+        With the sign inverted the bracket becomes -2 ln K instead, which
+        subtracts a flat ~0.3 from every weight at K=20 and zeroes all but the
+        largest component on the very first step.
+        """
+        from safe_ice.optimization.penalized_em import PenalizedEMOptimizer
+
+        K, n = 20, 200
+        uniform = np.full(K, 1.0 / K)
+        # Responsibilities that are themselves uniform: EM alone would leave
+        # the weights untouched, so any change is entirely the penalty.
+        weighted_resp = np.full((n, K), 1.0 / K)
+
+        new_pi = PenalizedEMOptimizer()._update_mixture_weights_penalized(
+            weighted_resp, uniform, beta=1.0
+        )
+
+        assert new_pi == pytest.approx(uniform, abs=1e-12)
+
+    def test_penalty_drains_small_components_into_large_ones(self) -> None:
+        """Below-average components shrink, above-average ones grow."""
+        from safe_ice.optimization.penalized_em import PenalizedEMOptimizer
+
+        old_pi = np.array([0.7, 0.1, 0.1, 0.1])
+        weighted_resp = np.tile(old_pi, (200, 1))
+
+        new_pi = PenalizedEMOptimizer()._update_mixture_weights_penalized(
+            weighted_resp, old_pi, beta=1.0
+        )
+
+        assert new_pi[0] > old_pi[0]
+        assert np.all(new_pi[1:] < old_pi[1:])
+        assert new_pi.sum() == pytest.approx(1.0)
+
+    def test_mixture_is_not_collapsed_on_the_first_step(self) -> None:
+        """A K=20 mixture must not be reduced to one surviving component."""
+        from safe_ice.optimization.penalized_em import PenalizedEMOptimizer
+
+        n_components, n_samples = 20, 500
+        uniform = np.full(n_components, 1.0 / n_components)
+        rng = np.random.default_rng(7)
+        weighted_resp = rng.dirichlet(np.ones(n_components), size=n_samples)
+
+        new_pi = PenalizedEMOptimizer()._update_mixture_weights_penalized(
+            weighted_resp, uniform, beta=1.0
+        )
+
+        assert int(np.sum(new_pi > 1e-4)) > 1


### PR DESCRIPTION
Equation 21 updates the mixture weights with

```
pi_k += beta * pi_k * [ ln pi_k - sum_s pi_s ln pi_s ]
```

and `sum_s pi_s ln pi_s` is **minus** the entropy. The code subtracted the entropy itself, so the bracket came out with the wrong sign.

At uniform weights the bracket should be exactly `0` — uniform is the maximum-entropy case, so a sparsity penalty has nothing to do. Instead it evaluated to `-2 ln K`:

| | bracket at uniform, K=20 | penalty per component | resulting weight |
| --- | --- | --- | --- |
| as coded | `-5.99` | `-0.300` | `-0.250` → clamped to 0 |
| as written | `0.00` | `0.000` | `0.050` → unchanged |

Since the EM estimate of each weight is ~`0.05`, subtracting a flat `0.3` zeroed every component except the largest **on the first EM step**. The mixture collapsed to `K=1` on every run I looked at — which is precisely what this penalty exists to prevent, and a four-mode problem cannot be represented by a single component.

## Effect

| Problem | Reference | Before | After | K before → after |
| --- | --- | --- | --- | --- |
| Four-mode series | `5.8e-5` | `1.08x` | `1.01x` | always 1 → 2–4 |
| Linear (closed form) | `1.69e-2` | `1.08x` | `1.02x` | 1 → 1 |
| Sphere d=2 | `1.11e-2` | `1.02x` | `1.01x` | 1 → 1 |
| Sphere d=10 | `5.35e-3` | `0.99x` | `0.94x` | 1 → 1–2 |

Unimodal problems are unchanged within noise, as expected — the fix matters where the target genuinely has several modes.

## What this does not fix

The `d=20` breakdown. I chased it and it is **not** a coding error: `mean(phi/q)` stays near 1 at every dimension, so the sampler and density agree. It is importance-weight degeneracy — the ratio of largest to median weight grows from ~`10` at `d=2` to ~`8e11` at `d=20`, so a few samples carry the estimate. Raising `N` from 2000 to 10000 helps but does not fix it. The README now records this with the measurements and says to treat `d > 10` as unsupported.

Note I matched the formula as documented in this repo's README, since I do not have the paper. Worth a check against the source if you have it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the sign of the cross-entropy penalty in the EM mixture-weight update so the penalty is zero at uniform weights and no longer collapses the mixture to one component. Previously the code subtracted entropy rather than using the mean surprisal, making the bracket negative and zeroing all but the largest component on the first EM step.

**Review focus**
- In `safe_ice/optimization/penalized_em.py`, the penalty now uses `mean_log_pi = sum(pi_s * ln pi_s)` and updates with `beta * pi_k * (ln pi_k - mean_log_pi)`. Verify the `1e-15` floor and numeric stability of `log`.
- New tests in `tests/test_proposal_normalisation.py` assert: penalty vanishes at uniform weights, small components shrink while large grow, and a `K=20` mixture isn’t collapsed on the first step.
- `README.md` and `CHANGELOG.md` document the fix and note high-dimensional importance-weight degeneracy; treat `d > 10` as unsupported.

<sup>Written for commit 6b3b56dab4dc4ffbe69d33cf974b7f879d36fa23. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/adaptive-importance-sampling/pull/74?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

