### PR TITLE
fix: scale the initial mixture with the problem dimension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   scaled by that error. On a linear limit state with a closed-form answer the
   estimate was 0.54x the analytical value regardless of sample size; it is now
   1.02x. `OptimizedSafeICE` had the same omission in both of its components.
+- **The mixture was initialised with dimension-independent parameters.** The
+  target is the standard normal in R^d, whose radius follows chi_d, and chi_d
+  is exactly Nakagami(m = d/2, Omega = d), so the fixed values used before were
+  only appropriate near d=2. At d=20 the initial proposal sat at radius ~1.1
+  while the target sits at ~4.4; the two barely overlapped and the run never
+  recovered, returning ~1e-20 for a true 1.5e-2. Initialisation now scales with
+  the dimension, and d=20 goes from 0 of 6 seeds usable to 6 of 6.
 - **The cross-entropy penalty in the EM step had its sign inverted.**
   Equation 21 uses `[ln pi_k - sum_s pi_s ln pi_s]`, and `sum_s pi_s ln pi_s`
   is minus the entropy; the code subtracted the entropy instead. At uniform

--- a/README.md
+++ b/README.md
@@ -226,6 +226,12 @@ Two correctness bugs that biased every estimate have been fixed:
   denominator, every estimate was scaled by that error, which is why results
   came out at roughly `0.54x` the analytical answer no matter how large `N`
   was.
+- The mixture was initialised with fixed Nakagami parameters, independent of
+  dimension. The target is the standard normal in `R^d`, whose radius follows
+  `chi_d`, and `chi_d` is exactly `Nakagami(m = d/2, Ω = d)` — so the old fixed
+  values were only right near `d=2`. At `d=20` the proposal started at radius
+  `~1.1` while the target sits at `~4.4`, so the two barely overlapped and the
+  run could not recover. Initialisation now scales with `d`.
 - The cross-entropy penalty in the EM step had its sign inverted. Equation 21
   uses `[ln π_k − Σ π_s ln π_s]`, and `Σ π_s ln π_s` is minus the entropy; the
   code subtracted the entropy instead. At uniform weights the bracket should be
@@ -247,7 +253,8 @@ Current accuracy against problems with known answers, median over seeds:
 | --- | --- | --- |
 | Linear limit state, closed form | `1.69e-2` | `1.02` |
 | Sphere `d=2`, closed form | `1.11e-2` | `1.01` |
-| Sphere `d=10`, closed form | `5.35e-3` | `0.94` |
+| Sphere `d=10`, closed form | `5.35e-3` | `0.86` |
+| Sphere `d=20`, closed form | `1.54e-2` | `0.54` |
 | Four-mode series system, 2e7-sample MC | `5.8e-5` | `1.01` |
 
 `tests/test_proposal_normalisation.py` pins this down: it integrates each
@@ -259,15 +266,12 @@ proposal component numerically and fails if the Jacobian is dropped again.
   unconstrained, so for a limit state that fails everywhere (true probability
   exactly 1) it scatters around 1 and can land slightly above. Clamping would
   fix it, but that is a modelling decision rather than a bug.
-- **It breaks down somewhere between `d=10` and `d=20`.** The sphere problem
-  is accurate and stable through `d=10` (ratio `0.94`, estimates within `1.3x`
-  of each other across seeds). At `d=20` it fails badly: for a true value of
-  `1.54e-2`, only 1 of 6 seeds lands within `3x`, and the others return
-  `1e-20` or smaller. The cause is importance-weight degeneracy, not a coding
-  error — the ratio of largest to median weight grows from `~10` at `d=2` to
-  `~8e11` at `d=20`, so a handful of samples carry the estimate. Raising `N`
-  from 2000 to 10000 helps but does not fix it. Treat `d > 10` as unsupported
-  for now.
+- **It still breaks down above roughly `d=20`.** On the sphere problem, `d=20`
+  now works (6 of 6 seeds within `3x`, ratio `0.54`), but `d=30` does not —
+  every seed collapses. Importance weights become extremely heavy-tailed as
+  dimension grows: the ratio of largest to median weight goes from `~10` at
+  `d=2` to `~8e11` at `d=20`, so a few samples carry the estimate. Raising `N`
+  helps but does not fix it. Treat `d > 20` as unsupported.
 - The reference value quoted for the four-mode problem used to be `1.22e-5`.
   Crude Monte Carlo over 2e7 samples puts it at `5.8e-5 ± 1.7e-6` for the
   default `z=3.8`.

--- a/safe_ice/core/safe_ice.py
+++ b/safe_ice/core/safe_ice.py
@@ -297,9 +297,24 @@ class SafeICE:
         # Equal mixture weights
         pi: NDArrayF = np.ones(K, dtype=np.float64) / float(K)
 
-        # Nakagami parameters
-        m: NDArrayF = np.asarray(self._rng.uniform(1.0, 3.0, K), dtype=np.float64)
-        Omega: NDArrayF = np.asarray(self._rng.uniform(0.5, 2.0, K), dtype=np.float64)
+        # Nakagami parameters, scaled to the problem dimension.
+        #
+        # The target is the standard normal in R^d, whose radius follows a chi
+        # distribution with d degrees of freedom, and chi_d is exactly
+        # Nakagami(m = d/2, Omega = d). Initialising around that puts the
+        # proposal on top of the target from the start; the jitter keeps the
+        # components distinguishable so EM has something to separate.
+        #
+        # Fixed values were used here before, which happen to be right only
+        # near d=2. At d=20 they left the proposal at radius ~1.1 while the
+        # target sits at ~4.4, so the two barely overlapped and the run could
+        # never recover.
+        m: NDArrayF = np.asarray(
+            self._rng.uniform(0.75, 1.5, K) * (d / 2.0), dtype=np.float64
+        )
+        Omega: NDArrayF = np.asarray(
+            self._rng.uniform(0.75, 1.5, K) * float(d), dtype=np.float64
+        )
 
         # von Mises-Fisher parameters
         mu: NDArrayF = np.asarray(self._rng.normal(0.0, 1.0, (K, d)), dtype=np.float64)

--- a/safe_ice/core/safe_ice_optimized.py
+++ b/safe_ice/core/safe_ice_optimized.py
@@ -618,8 +618,20 @@ class OptimizedSafeICE:
         d = int(self.d)
 
         pi = np.ones(K, dtype=np.float64) / float(K)
-        m = np.asarray(self._rng.uniform(1.0, 3.0, K), dtype=np.float64)
-        Omega = np.asarray(self._rng.uniform(0.5, 2.0, K), dtype=np.float64)
+        # Nakagami parameters, scaled to the problem dimension.
+        #
+        # The target is the standard normal in R^d, whose radius follows a chi
+        # distribution with d degrees of freedom, and chi_d is exactly
+        # Nakagami(m = d/2, Omega = d). Initialising around that puts the
+        # proposal on top of the target from the start; the jitter keeps the
+        # components distinguishable so EM has something to separate.
+        #
+        # Fixed values were used here before, which happen to be right only
+        # near d=2. At d=20 they left the proposal at radius ~1.1 while the
+        # target sits at ~4.4, so the two barely overlapped and the run could
+        # never recover.
+        m = np.asarray(self._rng.uniform(0.75, 1.5, K) * (d / 2.0), dtype=np.float64)
+        Omega = np.asarray(self._rng.uniform(0.75, 1.5, K) * float(d), dtype=np.float64)
 
         mu = np.asarray(self._rng.normal(0.0, 1.0, (K, d)), dtype=np.float64)
         row_norms = np.linalg.norm(mu, axis=1, keepdims=True)

--- a/tests/test_proposal_normalisation.py
+++ b/tests/test_proposal_normalisation.py
@@ -233,3 +233,64 @@ class TestPenalizedWeightUpdate:
         )
 
         assert int(np.sum(new_pi > 1e-4)) > 1
+
+
+class TestInitialisationScalesWithDimension:
+    """The initial proposal has to sit on top of the target it is fitting.
+
+    The target is the standard normal in R^d, whose radius follows chi_d, and
+    chi_d is exactly Nakagami(m = d/2, Omega = d). Fixed initial values happen
+    to be about right near d=2 but leave the proposal at radius ~1.1 for any
+    dimension, while the target's radius grows like sqrt(d). At d=20 the two
+    barely overlapped and estimates came out around 1e-20 for a true 1.5e-2.
+    """
+
+    @pytest.mark.parametrize("d", [2, 5, 10, 20])
+    def test_initial_radius_tracks_the_target(self, d: int, seed) -> None:
+        ice = SafeICE(
+            limit_state_function=lambda u: 3.0 - np.linalg.norm(u, axis=-1),
+            dimension=d,
+            N=4000,
+            random_state=seed,
+        )
+        params = ice._initialize_vmfnm_parameters()
+        samples = ice._generate_safe_mixture_samples(params, 0.95)
+        mean_radius = float(np.linalg.norm(samples, axis=1).mean())
+
+        target = float(stats.chi.mean(d))
+        # Generous: the point is that it scales with d at all, not that it
+        # matches exactly. Without scaling the ratio is 0.24 at d=20.
+        assert 0.6 < mean_radius / target < 1.7
+
+    @pytest.mark.parametrize("d", [2, 10, 20])
+    def test_omega_scales_with_dimension(self, d: int, seed) -> None:
+        """E[R^2] = Omega for Nakagami, and the target has E[||u||^2] = d."""
+        ice = SafeICE(
+            limit_state_function=lambda u: 3.0 - np.linalg.norm(u, axis=-1),
+            dimension=d,
+            N=10,
+            random_state=seed,
+        )
+        params = ice._initialize_vmfnm_parameters()
+        assert 0.5 * d < float(np.mean(params.Omega)) < 2.0 * d
+
+    @pytest.mark.slow
+    def test_high_dimensional_sphere_is_usable(self) -> None:
+        """d=20 used to return ~1e-20 for a true 1.5e-2."""
+        d, beta = 20, 6.0
+        true = float(1 - stats.chi2.cdf(beta**2, df=d))
+
+        estimates = []
+        for s in range(4):
+            ice = SafeICE(
+                limit_state_function=lambda u: beta - np.linalg.norm(u, axis=-1),
+                dimension=d,
+                N=2000,
+                max_iterations=15,
+                random_state=s,
+            )
+            pf, _ = ice.run(verbose=False)
+            estimates.append(pf)
+
+        within = sum(1 for pf in estimates if true / 4 < pf < true * 4)
+        assert within >= 3, f"only {within}/4 seeds usable: {estimates}"


### PR DESCRIPTION
The initial proposal sat at radius `~1.1` **whatever the dimension**, while the target's radius grows like `sqrt(d)`:

| d | initial proposal radius | target (`chi_d` mean) | ratio |
| --- | --- | --- | --- |
| 2 | 1.09 | 1.25 | 0.87 |
| 5 | 1.08 | 2.13 | 0.51 |
| 10 | 1.08 | 3.08 | 0.35 |
| 20 | 1.08 | 4.42 | **0.24** |

At `d=20` the proposal barely overlapped the distribution it was meant to be fitting, and the run could not recover — estimates came out around `1e-20` for a true `1.5e-2`.

## Why

The target is the standard normal in `R^d`, whose radius follows `chi_d`, and **`chi_d` is exactly `Nakagami(m = d/2, Ω = d)`**. The initialiser used `m ~ U(1,3)`, `Ω ~ U(0.5,2)` — fixed, and only about right near `d=2`. That is precisely why low dimensions worked and high ones did not.

Initialisation is now centred on that identity, with jitter so the components stay distinguishable for EM.

## Effect

Sphere problem, seeds within `3x` of the closed form:

| d | before | after | ratio before → after |
| --- | --- | --- | --- |
| 2 | 6/6 | 6/6 | 1.01 → 1.02 |
| 5 | 6/6 | 6/6 | 1.00 → 1.00 |
| 10 | 6/6 | 6/6 | 0.94 → 0.86 |
| 20 | **0/6** | **6/6** | 1.8e-18 → 0.54 |
| 30 | 0/6 | 0/6 | still unusable |

Four-mode is unchanged at 12/12. Applied to `OptimizedSafeICE` too, which had the same initialiser.

## What this does not fix

`d=30` still collapses. The remaining cause is weight degeneracy: the ratio of largest to median importance weight grows from `~10` at `d=2` to `~8e11` at `d=20`, so a few samples carry the estimate. This moves the usable ceiling from about `d=10` to about `d=20` rather than removing it, and the README now says exactly that.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scale the initial mixture to the problem dimension so the proposal overlaps the target in higher d. Previously the proposal radius was ~1.1 for any d; now it matches the standard normal’s chi_d radius via Nakagami(m = d/2, Ω = d) with jitter, making d=20 runs stable.

- Updates the initialiser in safe_ice.py and safe_ice_optimized.py to draw m ~ U(0.75,1.5) * d/2 and Ω ~ U(0.75,1.5) * d.
- Adds tests that the initial radius tracks the chi_d target, Ω scales with d, and the sphere at d=20 produces usable estimates; marks the high-d test as slow.
- Improves sphere results: d=20 goes from 0/6 usable seeds to 6/6 (median ratio 0.54). d=2 and d=5 unchanged; d=10 shifts to 0.86. d=30 still collapses; README now treats d > 20 as unsupported.
- No API changes. Initialization randomness changes, so seeded runs may produce different values than before.

<sup>Written for commit aaaf5d38072258365deac6f549b2f2e8354eafe1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/adaptive-importance-sampling/pull/75?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

