### PR TITLE
docs: repair the API reference and build clean

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,28 @@ jobs:
           path: dist/
           retention-days: 7
 
+  docs:
+    name: Build documentation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+
+      - name: Install package and docs dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+          pip install -r docs/requirements.txt
+
+      - name: Build with warnings as errors
+        # Read the Docs also builds with fail_on_warning, so catching it here
+        # keeps a broken autodoc reference from reaching the published site.
+        run: python -m sphinx -b html -W --keep-going docs/source docs/_build/html
+
   security:
     name: Security scan
     runs-on: ubuntu-latest

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,7 +11,10 @@ build:
 sphinx:
   configuration: docs/source/conf.py
   builder: html
-  fail_on_warning: false
+  # The build is warning-clean; keep it that way. A broken autodoc reference
+  # or a dangling toctree entry should fail the build rather than quietly
+  # publish a page with missing API documentation.
+  fail_on_warning: true
 
 formats:
   - pdf

--- a/docs/source/api/core.rst
+++ b/docs/source/api/core.rst
@@ -10,6 +10,7 @@ SafeICE Class
    :members:
    :undoc-members:
    :show-inheritance:
+   :exclude-members: vMFNMParameters
 
 Parameters
 ----------

--- a/docs/source/api/distributions.rst
+++ b/docs/source/api/distributions.rst
@@ -1,41 +1,45 @@
 Distributions Module
 ====================
 
-The distributions module implements the probability distributions used in Safe-ICE.
+The distributions module implements the probability distributions used in
+Safe-ICE. Three modules make up the public surface:
 
-von Mises-Fisher Distribution
------------------------------
+``safe_ice.distributions.vmf``
+    :class:`~safe_ice.distributions.vmf.VonMisesFisherSampler`, the angular part
+    of the proposal.
 
-.. automodule:: safe_ice.distributions.von_mises_fisher
+``safe_ice.distributions.nakagami``
+    :class:`~safe_ice.distributions.nakagami.NakagamiDistribution` and
+    :class:`~safe_ice.distributions.nakagami.InverseNakagamiDistribution`, the
+    light- and heavy-tailed radial parts.
+
+``safe_ice.distributions.mixture``
+    :class:`~safe_ice.distributions.mixture.vMFNMDistribution`, the combined
+    mixture used as the light-tailed proposal.
+
+.. note::
+
+   The samplers and densities are **static methods**: parameters are passed on
+   every call rather than to a constructor. Only ``vMFNMDistribution`` is
+   instantiated, because it holds a :class:`~safe_ice.core.parameters.vMFNMParameters`.
+
+von Mises-Fisher
+----------------
+
+.. automodule:: safe_ice.distributions.vmf
    :members:
    :undoc-members:
    :show-inheritance:
 
-Nakagami Distribution
----------------------
+Nakagami and Inverse Nakagami
+-----------------------------
 
 .. automodule:: safe_ice.distributions.nakagami
    :members:
    :undoc-members:
    :show-inheritance:
 
-Inverse Nakagami Distribution
------------------------------
-
-.. automodule:: safe_ice.distributions.inverse_nakagami
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-vMFNM Distribution
-------------------
-
-.. automodule:: safe_ice.distributions.vmfnm
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-Mixture Distribution
+vMF-Nakagami Mixture
 --------------------
 
 .. automodule:: safe_ice.distributions.mixture
@@ -49,89 +53,98 @@ Usage Examples
 von Mises-Fisher Sampling
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+Draws directions on the unit sphere, concentrated around ``mu``.
+
 .. code-block:: python
 
-   from safe_ice.distributions.von_mises_fisher import VonMisesFisherSampler
    import numpy as np
 
-   # Create sampler
-   sampler = VonMisesFisherSampler(dimension=3)
+   from safe_ice.distributions.vmf import VonMisesFisherSampler
 
-   # Sample from vMF distribution
-   mu = np.array([0, 0, 1])  # North pole
-   kappa = 10.0               # High concentration
+   mu = np.array([0.0, 0.0, 1.0])  # north pole
+   kappa = 10.0                    # high concentration
 
-   samples = sampler.sample(mu, kappa, n_samples=1000)
+   samples = VonMisesFisherSampler.sample(mu, kappa, 1000)
 
-   # Samples are on unit sphere
+   assert samples.shape == (1000, 3)
    assert np.allclose(np.linalg.norm(samples, axis=1), 1.0)
 
 Nakagami Distribution
 ~~~~~~~~~~~~~~~~~~~~~
 
+The radial part of the light-tailed proposal. Note that ``chi_d`` is exactly
+``Nakagami(m=d/2, Omega=d)``, which is how the mixture is initialised.
+
 .. code-block:: python
+
+   import numpy as np
 
    from safe_ice.distributions.nakagami import NakagamiDistribution
 
-   # Create distribution
-   nakagami = NakagamiDistribution(m=2.0, omega=1.0)
+   m, omega = 2.0, 1.0
 
-   # Evaluate PDF
-   x = np.linspace(0, 3, 100)
-   pdf_values = nakagami.pdf(x)
+   r = np.linspace(0.01, 3.0, 100)
+   pdf_values = NakagamiDistribution.pdf(r, m, omega)
+   cdf_values = NakagamiDistribution.cdf(r, m, omega)
 
-   # Sample
-   samples = nakagami.sample(1000)
+   samples = NakagamiDistribution.sample(m, omega, 1000)
 
-   # Compute CDF
-   cdf_values = nakagami.cdf(x)
+   # E[R^2] = Omega
+   assert abs(np.mean(samples**2) - omega) < 0.2
+
+Heavy-Tailed Sampling
+~~~~~~~~~~~~~~~~~~~~~
+
+The inverse Nakagami is the radial part of the safety component: it keeps mass
+in the far tail so the importance weights stay bounded.
+
+.. code-block:: python
+
+   import numpy as np
+
+   from safe_ice.distributions.nakagami import InverseNakagamiDistribution
+
+   m, omega = 2.0, 1.0
+
+   samples = InverseNakagamiDistribution.sample(m, omega, 1000)
+
+   y = np.linspace(0.1, 10.0, 100)
+   pdf_values = InverseNakagamiDistribution.pdf(y, m, omega)
+
+   # Tails decay far more slowly than the Nakagami's
+   print(f"density at y=10: {pdf_values[-1]:.2e}")
 
 vMFNM Mixture
 ~~~~~~~~~~~~~
 
 .. code-block:: python
 
-   from safe_ice.distributions.vmfnm import vMFNMDistribution
-   from safe_ice.core.parameters import vMFNMParameters
    import numpy as np
 
-   # Create mixture parameters
+   from safe_ice.core.parameters import vMFNMParameters
+   from safe_ice.distributions.mixture import vMFNMDistribution
+
+   mu = np.array([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]])
    params = vMFNMParameters(
-       K=2,                           # Two components
-       d=3,                           # 3D space
-       pi=np.array([0.6, 0.4]),      # Mixture weights
-       m=np.array([2.0, 3.0]),       # Nakagami shape
-       Omega=np.array([1.0, 1.5]),   # Nakagami scale
-       mu=np.array([[1, 0, 0],       # Component directions
-                    [0, 1, 0]]),
-       kappa=np.array([5.0, 8.0])    # Concentrations
+       pi=np.array([0.6, 0.4]),       # mixture weights, must sum to 1
+       m=np.array([2.0, 3.0]),        # Nakagami shape
+       Omega=np.array([1.0, 1.5]),    # Nakagami scale
+       mu=mu,                         # component directions, unit rows
+       kappa=np.array([5.0, 8.0]),    # concentrations
    )
 
-   # Create distribution
-   vmfnm = vMFNMDistribution(params)
+   dist = vMFNMDistribution(params)
 
-   # Sample
-   samples = vmfnm.sample(1000)
+   samples = dist.sample(1000)
+   densities = dist.pdf(samples)
+   total_log_likelihood = dist.log_likelihood(samples)
 
-   # Evaluate log-likelihood
-   log_prob = vmfnm.log_pdf(samples)
+   assert samples.shape == (1000, 3)
+   assert np.all(densities > 0)
 
-Heavy-Tailed Sampling
-~~~~~~~~~~~~~~~~~~~~~
+.. note::
 
-.. code-block:: python
-
-   from safe_ice.distributions.inverse_nakagami import InverseNakagamiDistribution
-
-   # Create heavy-tailed distribution
-   inv_nakagami = InverseNakagamiDistribution(m=2.0, omega_in=1.0)
-
-   # Sample (heavy-tailed)
-   samples = inv_nakagami.sample(1000)
-
-   # PDF evaluation
-   x = np.linspace(0.1, 10, 100)
-   pdf_values = inv_nakagami.pdf(x)
-
-   # Note: Heavy tails decay slower than Nakagami
-   print(f"Tail behavior at x=10: {pdf_values[-1]:.2e}")
+   ``pdf`` returns a density on ``R^d``, including the polar Jacobian
+   ``r^(d-1)``. Every component of the proposal must integrate to one, since it
+   sits in the denominator of the importance weights;
+   ``tests/test_proposal_normalisation.py`` checks this numerically.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -47,12 +47,13 @@ html_theme_options = {
     'sticky_navigation': True,
     'includehidden': True,
     'titles_only': False,
-    'display_version': True,
     'prev_next_buttons_location': 'both',
 }
 
 # Static files
-html_static_path = ['_static']
+# No _static assets are shipped; leaving this empty avoids a
+# build warning about a missing directory.
+html_static_path = []
 
 # Autodoc settings
 autodoc_default_options = {
@@ -71,7 +72,11 @@ napoleon_include_special_with_doc = True
 napoleon_use_admonition_for_examples = True
 napoleon_use_admonition_for_notes = True
 napoleon_use_admonition_for_references = False
-napoleon_use_ivar = False
+# Render 'Attributes' sections as :ivar: fields inside the class body rather
+# than as separate attribute objects. Otherwise a dataclass that documents
+# its fields in the docstring registers each one twice, once from autodoc and
+# once from napoleon, and Sphinx warns about duplicate descriptions.
+napoleon_use_ivar = True
 napoleon_use_param = True
 napoleon_use_rtype = True
 

--- a/docs/source/examples/index.rst
+++ b/docs/source/examples/index.rst
@@ -3,15 +3,8 @@ Examples
 
 This section provides detailed examples of using Safe-ICE for various applications.
 
-.. toctree::
-   :maxdepth: 2
-   :caption: Examples
-
-   basic_usage
-   benchmark_problems
-   custom_problems
-   advanced_features
-   visualization
+Runnable versions of these live in the ``examples/`` directory of the
+repository.
 
 Quick Examples
 --------------
@@ -72,7 +65,7 @@ Custom Problem with Visualization
 
 .. code-block:: python
 
-   from safe_ice.analysis.visualization import VisualizationTools
+   from safe_ice.analysis.visualization import AdvancedAnalysis
 
    # Define custom problem
    def custom_g(u):
@@ -86,6 +79,6 @@ Custom Problem with Visualization
    pf, results = ice.run()
 
    # Visualize results
-   viz = VisualizationTools()
-   viz.plot_convergence(results)
-   viz.analyze_sample_distribution(results, custom_g)
+   analyzer = AdvancedAnalysis()
+   analyzer.analyze_component_evolution(results)
+   analyzer.analyze_sample_distribution(results, custom_g)

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -65,8 +65,6 @@ Contents
    :caption: User Guide
 
    theory
-   algorithms
-   benchmarks
 
 .. toctree::
    :maxdepth: 2
@@ -74,16 +72,15 @@ Contents
 
    api/core
    api/distributions
-   api/optimization
-   api/problems
-   api/analysis
 
-.. toctree::
-   :maxdepth: 1
-   :caption: Development
+Development
+-----------
 
-   contributing
-   changelog
+Contribution guidelines and the changelog live in the repository:
+`CONTRIBUTING.md
+<https://github.com/DiogoRibeiro7/adaptive-importance-sampling-ice/blob/main/CONTRIBUTING.md>`_
+and `CHANGELOG.md
+<https://github.com/DiogoRibeiro7/adaptive-importance-sampling-ice/blob/main/CHANGELOG.md>`_.
 
 Indices and Tables
 ==================

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -223,4 +223,4 @@ Next Steps
 * Read the :doc:`theory` section to understand the algorithm
 * Explore :doc:`examples/index` for detailed use cases
 * Check the :doc:`api/core` for complete API reference
-* See :doc:`benchmarks` for problem descriptions
+* See :doc:`api/distributions` for the distributions used by the proposal

--- a/safe_ice/distributions/vmf.py
+++ b/safe_ice/distributions/vmf.py
@@ -31,18 +31,24 @@ class VonMisesFisherSampler:
         n_samples: int = 1,
         rng: RNGLike | None = None,
     ) -> NDArrayF:
-        """
-        Sample from a vMF_d(mu, kappa).
+        """Sample from a vMF_d(mu, kappa).
 
-        Args:
-            mu: Mean direction as a length-d array (need not be unit; we normalize).
-            kappa: Concentration (>= 0).
-            n_samples: Number of samples.
-            rng: Random number generator. If *None*, the global
-                ``np.random`` state is used (backward compatible).
+        Parameters
+        ----------
+        mu : array_like
+            Mean direction, a length-d array. It need not be a unit vector;
+            it is normalised internally.
+        kappa : float
+            Concentration, must be non-negative.
+        n_samples : int
+            Number of samples to draw.
+        rng : numpy random generator, optional
+            If *None*, the global ``np.random`` state is used.
 
-        Returns:
-            (n_samples, d) array of unit vectors on S^{d-1}.
+        Returns
+        -------
+        ndarray of shape (n_samples, d)
+            Unit vectors on S^{d-1}.
         """
         _rng = _default_rng(rng)
         mu_arr: NDArrayF = np.asarray(mu, dtype=np.float64).reshape(-1)

--- a/safe_ice/optimization/penalized_em.py
+++ b/safe_ice/optimization/penalized_em.py
@@ -30,17 +30,23 @@ class PenalizedEMOptimizer:
         initial_params: vMFNMParameters,
         beta_init: float = 1.0,
     ) -> tuple[vMFNMParameters, int]:
-        """
-        Fit vMFNM mixture using penalized EM.
+        """Fit vMFNM mixture using penalized EM.
 
-        Args:
-            data: (n, d) sample data.
-            weights: (n,) importance weights.
-            initial_params: initial vMFNM parameters.
-            beta_init: initial penalty parameter.
+        Parameters
+        ----------
+        data : ndarray of shape (n, d)
+            Sample data.
+        weights : ndarray of shape (n,)
+            Importance weights.
+        initial_params : vMFNMParameters
+            Starting point for the fit.
+        beta_init : float
+            Initial penalty parameter.
 
-        Returns:
-            (optimized_params, final_K)
+        Returns
+        -------
+        tuple of (vMFNMParameters, int)
+            The optimised parameters and the final number of components.
         """
         _n, _d = data.shape
         params = self._copy_parameters(initial_params)

--- a/safe_ice/problems/heat_transfer.py
+++ b/safe_ice/problems/heat_transfer.py
@@ -25,16 +25,22 @@ class HeatTransferProblem:
         threshold: float = 100.0,
         heat_source: float = 2000.0,
     ) -> None:
-        """
-        Initialize heat transfer problem.
+        """Initialize heat transfer problem.
 
-        Args:
-            grid_size: Discretization grid size.
-            correlation_length: Correlation length for random field.
-            n_terms: Number of KL expansion terms.
-            field_std: Standard deviation for lognormal conductivity field.
-            threshold: Failure threshold used in limit state function.
-            heat_source: Heat source magnitude.
+        Parameters
+        ----------
+        grid_size : int
+            Discretization grid size.
+        correlation_length : float
+            Correlation length for the random field.
+        n_terms : int
+            Number of Karhunen-Loeve expansion terms.
+        field_std : float
+            Standard deviation for the lognormal conductivity field.
+        threshold : float
+            Failure threshold used in the limit state function.
+        heat_source : float
+            Heat source magnitude.
         """
         self.grid_size = int(grid_size)
         self.l = float(correlation_length)


### PR DESCRIPTION
The published documentation was missing most of the distributions API, and `fail_on_warning: false` meant Read the Docs published around it silently.

## The API reference was pointing at modules that don't exist

`docs/source/api/distributions.rst` used `automodule` on `safe_ice.distributions.von_mises_fisher`, `.inverse_nakagami` and `.vmfnm`. None of those exist — the real modules are `vmf`, `nakagami` and `mixture`. Three of the five documented sections therefore rendered empty.

Every usage example on that page was also written against an API that doesn't exist:

| Documented | Actual |
| --- | --- |
| `VonMisesFisherSampler(dimension=3)` then `.sample(mu, kappa, n)` | `VonMisesFisherSampler.sample(mu, kappa, n)` — static |
| `NakagamiDistribution(m=2.0, omega=1.0)` then `.pdf(x)` | `NakagamiDistribution.pdf(r, m, Omega)` — static |
| `InverseNakagamiDistribution(m=2.0, omega_in=1.0)` | static, and takes `Omega` |
| `vmfnm.log_pdf(samples)` | `dist.log_likelihood(samples)` |

The page is rewritten against the real API. **I ran all four examples** rather than trusting them.

## Other build problems

- `examples/index.rst` listed five documents that were never written, and its final snippet imported a `VisualizationTools` class that does not exist (it is `AdvancedAnalysis`).
- `index.rst` referenced missing `algorithms`, `benchmarks`, `contributing` and `changelog` pages, plus three `api/*` pages that were never written.
- `quickstart.rst` linked to a missing `benchmarks` page.
- `vMFNMParameters` documents its fields in an `Attributes` section while autodoc documented them too, registering each twice. Fixed with `napoleon_use_ivar`.
- `html_static_path` pointed at a nonexistent directory, and `display_version` is not an option of the theme in use.
- Three docstrings were Google-style while napoleon is configured for NumPy only, so one failed to parse outright (`ERROR: Unexpected indentation`). The package convention is NumPy — those three are converted rather than loosening the config.

## Keeping it clean

The build now emits **zero warnings**, so `fail_on_warning: true` is set for Read the Docs and CI gained a `docs` job building with `-W --keep-going`. A broken autodoc reference or dangling toctree entry now fails the build instead of quietly publishing a page with missing API documentation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Repairs the distributions API reference and enforces warning-clean docs builds. Previously, autodoc targeted non-existent modules and Read the Docs published around warnings; now the pages point to the real modules and both RTD and CI fail on warnings.

- `docs/source/api/distributions.rst` now documents `safe_ice.distributions.vmf`, `safe_ice.distributions.nakagami`, and `safe_ice.distributions.mixture`; examples are rewritten to use static methods and the correct `log_likelihood`/`pdf` API, and were run to verify.
- Removes broken toctree entries and links in `index.rst`, `examples/index.rst`, and `quickstart.rst`; development docs are linked to `CONTRIBUTING.md` and `CHANGELOG.md` in-repo.
- Sphinx config: drops invalid `display_version`, sets `html_static_path` to `[]`, enables `napoleon_use_ivar=True` to avoid duplicate attribute docs, and keeps NumPy-style docstrings consistent.
- CI/RTD: adds a `docs` job building with `-W --keep-going`; sets `fail_on_warning: true` in `.readthedocs.yml`.
- Source changes are docstring-only in `safe_ice/distributions/vmf.py`, `safe_ice/optimization/penalized_em.py`, and `safe_ice/problems/heat_transfer.py`; no runtime behavior changes.

<sup>Written for commit bda0ebe316c77351453d456cd64f6bf25f0eded2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/adaptive-importance-sampling/pull/76?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

