### PR TITLE
fix: Nakagami sampler drew the wrong distribution for shapes above 100

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   scaled by that error. On a linear limit state with a closed-form answer the
   estimate was 0.54x the analytical value regardless of sample size; it is now
   1.02x. `OptimizedSafeICE` had the same omission in both of its components.
+- **The Nakagami sampler drew from the wrong distribution for shapes above
+  100.** A normal approximation replaced the exact `sqrt(Gamma(m, Omega/m))`
+  route there. Its variance, `Omega*(1 - 1/(4m))/m`, is about `Omega/m`, while
+  the Nakagami variance tends to `Omega/(4m)`, so samples came out with exactly
+  twice the correct spread. A KS test against `scipy.stats.nakagami` rejected at
+  p = 0 for every shape above the cutoff, and passes at p > 0.1 now. The second
+  moment stayed within 0.3% of `Omega`, so a moment check alone did not reveal
+  it. `InverseNakagamiDistribution.sample` inherited the error, since it draws
+  R and returns 1/R.
 - **The Nakagami density was badly wrong for shape parameters above 170.** A
   normal approximation replaced the exact form there, on the theory that the
   exact one would overflow. It does not: log-space with `loggamma` is stable for

--- a/safe_ice/distributions/nakagami.py
+++ b/safe_ice/distributions/nakagami.py
@@ -153,13 +153,14 @@ class NakagamiDistribution:
         Omega = float(Omega)
         n = int(n)
 
-        if m > 100:
-            mean = np.sqrt(Omega * (m - 0.5) / m) if m > 0.5 else 0.0
-            variance = Omega * (1 - 1 / (4 * m)) / m if m > 0.25 else Omega
-            std = np.sqrt(variance)
-            samples = _rng.normal(mean, std, n)
-            return np.asarray(np.abs(samples), dtype=np.float64)
-
+        # R = sqrt(X) with X ~ Gamma(shape=m, scale=Omega/m) is exact for every
+        # shape, and NumPy's gamma sampler is stable for large m.
+        #
+        # A normal approximation used to take over for m > 100. It was wrong
+        # twice over: its variance, Omega*(1 - 1/(4m))/m, is about Omega/m,
+        # whereas the Nakagami variance tends to Omega/(4m), so the samples came
+        # out with exactly twice the correct spread. A KS test against
+        # scipy.stats.nakagami rejected at p = 0 for every m above the cutoff.
         x = np.asarray(_rng.gamma(shape=m, scale=(Omega / m), size=n), dtype=np.float64)
         return np.asarray(np.sqrt(x), dtype=np.float64)
 

--- a/tests/test_nakagami_accuracy.py
+++ b/tests/test_nakagami_accuracy.py
@@ -99,6 +99,42 @@ class TestNakagamiSampling:
         samples = NakagamiDistribution.sample(m, omega, 20_000, rng=rng)
         assert float(np.mean(samples**2)) == pytest.approx(omega, rel=0.03)
 
+    @pytest.mark.parametrize("m", [2.0, 99.0, 101.0, 200.0, 1000.0])
+    def test_samples_follow_the_distribution(self, m: float, rng) -> None:
+        """A moment check is not enough: the shape has to be right too.
+
+        A normal approximation used to take over for m > 100 whose variance was
+        four times too large, so samples had twice the correct spread. E[R^2]
+        was still within 0.3% of Omega, so only a distributional test catches
+        it. This one rejected at p = 0 for every m above the old cutoff.
+        """
+        omega = 5.0
+        samples = NakagamiDistribution.sample(m, omega, 20_000, rng=rng)
+
+        result = stats.kstest(
+            samples, lambda x: stats.nakagami.cdf(x, m, scale=np.sqrt(omega))
+        )
+        assert result.pvalue > 0.001, f"KS statistic {result.statistic:.4f}"
+
+    @pytest.mark.parametrize("m", [2.0, 200.0])
+    def test_sample_spread_matches_the_distribution(self, m: float, rng) -> None:
+        omega = 5.0
+        samples = NakagamiDistribution.sample(m, omega, 40_000, rng=rng)
+        expected = float(stats.nakagami.std(m, scale=np.sqrt(omega)))
+        # The old approximation gave exactly twice this.
+        assert float(np.std(samples)) == pytest.approx(expected, rel=0.05)
+
+    @pytest.mark.parametrize("m", [2.0, 200.0])
+    def test_inverse_sampler_inherits_the_fix(self, m: float, rng) -> None:
+        """InverseNakagami draws R then returns 1/R, so 1/Y must be Nakagami."""
+        omega = 5.0
+        y = InverseNakagamiDistribution.sample(m, omega, 20_000, rng=rng)
+
+        result = stats.kstest(
+            1.0 / y, lambda x: stats.nakagami.cdf(x, m, scale=np.sqrt(omega))
+        )
+        assert result.pvalue > 0.001, f"KS statistic {result.statistic:.4f}"
+
     def test_chi_identity(self, rng) -> None:
         """chi_d is exactly Nakagami(m=d/2, Omega=d), which the initialiser uses."""
         for d in (2, 5, 20):


### PR DESCRIPTION
`sample()` replaced the exact `sqrt(Gamma(m, Omega/m))` route with a normal approximation for `m > 100`. NumPy's gamma sampler is stable for large shapes, so it was unnecessary — and its variance was wrong.

It used `Omega*(1 - 1/(4m))/m`, which is about `Omega/m`. The Nakagami variance tends to `Omega/(4m)`. So samples came out with **exactly twice the correct spread**:

| m | sample std before | sample std after | true std |
| --- | --- | --- | --- |
| 101 | 0.2223 | 0.1113 | 0.1112 |
| 200 | 0.1589 | 0.0794 | 0.0790 |
| 1000 | 0.0702 | 0.0353 | 0.0354 |

KS test against `scipy.stats.nakagami`, n=40000:

| m | before (stat / p) | after (stat / p) |
| --- | --- | --- |
| 99 | 0.0039 / 0.58 | 0.0039 / 0.58 |
| 101 | 0.1637 / **0.0** | 0.0047 / 0.35 |
| 200 | 0.1664 / **0.0** | 0.0037 / 0.63 |
| 1000 | 0.1636 / **0.0** | 0.0061 / 0.11 |

`InverseNakagamiDistribution.sample` inherited the same error, since it draws R and returns 1/R.

## Why the existing tests missed it

Under the approximation, `E[R^2]` stayed within **0.3%** of `Omega`, so the moment test I added in the previous PR passed at m=200. Only a distributional test exposes a wrong shape with a roughly right mean. The new tests KS-test the sampler across shapes spanning the old cutoff and check the spread directly. Reverting the fix fails 5 of them.

This is the same family as the density bug in the previous change, and the third and last approximation of its kind in the module — I swept for `m > 100` / `m > 170` / normal-approximation patterns and nothing else remains.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Nakagami sampling for m > 100 by removing the normal approximation and always sampling R = sqrt(Gamma(m, Ω/m)). The old path produced samples with twice the correct spread; the new path matches `scipy.stats.nakagami`. `InverseNakagamiDistribution.sample` now inherits the correct behavior since it returns 1/R.

- Replace the approximation with exact sampling via `numpy`’s gamma RNG; no API changes, but outputs for m > 100 will be narrower and may affect baselines.
- Add KS-based distribution tests across the m=100 cutoff and a direct spread check; reverting the fix fails these tests. Update CHANGELOG to document the bug and fix.

<sup>Written for commit 13f33811106df00ff6a811f08077385379569ee3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/adaptive-importance-sampling/pull/78?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

