### PR TITLE
fix: vMF sampler was wrong for concentrations above 30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   scaled by that error. On a linear limit state with a closed-form answer the
   estimate was 0.54x the analytical value regardless of sample size; it is now
   1.02x. `OptimizedSafeICE` had the same omission in both of its components.
+- **The von Mises-Fisher sampler was wrong for concentrations above 30.** A
+  shortcut intercepted `kappa >= 30` and replaced Wood's rejection sampler with
+  a Gaussian around `mu` of scale `0.2 / sqrt(kappa)`. The 0.2 is arbitrary and
+  roughly five times too small (the tangent-space standard deviation is
+  `1 / sqrt(kappa)`), and it ignores the dimension, so samples clustered far too
+  tightly around `mu`. Measured against the closed-form mean resultant length
+  `I_{d/2}(k)/I_{d/2-1}(k)`, at d=20 and kappa=50 it gave 0.9925 against a true
+  0.8263. Wood's sampler is exact at any concentration, accurate to ~1e-6 out to
+  kappa = 1e4 at constant cost, so the shortcut only introduced error. Removing
+  it also improved the estimator, since for `kappa >= 30` the sampler and the
+  density it is weighted by no longer agreed: the sphere problem went from 0.86
+  to 1.01 of the closed form at d=10, and 0.54 to 0.76 at d=20.
 - **The Nakagami sampler drew from the wrong distribution for shapes above
   100.** A normal approximation replaced the exact `sqrt(Gamma(m, Omega/m))`
   route there. Its variance, `Omega*(1 - 1/(4m))/m`, is about `Omega/m`, while

--- a/README.md
+++ b/README.md
@@ -253,8 +253,8 @@ Current accuracy against problems with known answers, median over seeds:
 | --- | --- | --- |
 | Linear limit state, closed form | `1.69e-2` | `1.02` |
 | Sphere `d=2`, closed form | `1.11e-2` | `1.01` |
-| Sphere `d=10`, closed form | `5.35e-3` | `0.86` |
-| Sphere `d=20`, closed form | `1.54e-2` | `0.54` |
+| Sphere `d=10`, closed form | `5.35e-3` | `1.01` |
+| Sphere `d=20`, closed form | `1.54e-2` | `0.76` |
 | Four-mode series system, 2e7-sample MC | `5.8e-5` | `1.01` |
 
 `tests/test_proposal_normalisation.py` pins this down: it integrates each
@@ -267,7 +267,7 @@ proposal component numerically and fails if the Jacobian is dropped again.
   exactly 1) it scatters around 1 and can land slightly above. Clamping would
   fix it, but that is a modelling decision rather than a bug.
 - **It still breaks down above roughly `d=20`.** On the sphere problem, `d=20`
-  now works (6 of 6 seeds within `3x`, ratio `0.54`), but `d=30` does not —
+  now works (6 of 6 seeds within `3x`, ratio `0.76`), but `d=30` does not —
   every seed collapses. Importance weights become extremely heavy-tailed as
   dimension grows: the ratio of largest to median weight goes from `~10` at
   `d=2` to `~8e11` at `d=20`, so a few samples carry the estimate. Raising `N`

--- a/safe_ice/distributions/vmf.py
+++ b/safe_ice/distributions/vmf.py
@@ -82,21 +82,16 @@ class VonMisesFisherSampler:
                 mu_unit, float(kappa), n_samples, _rng
             )
 
-        # High-concentration regime (d >= 3): numerically stable local
-        # Gaussian approximation around mu on the tangent space.
-        if kappa >= 30.0:
-            noise_scale = 0.2 / math.sqrt(float(kappa))
-            raw: NDArrayF = np.asarray(
-                mu_unit + _rng.normal(0.0, noise_scale, size=(n_samples, d)),
-                dtype=np.float64,
-            )
-            norms_h: NDArrayF = np.linalg.norm(raw, axis=1, keepdims=True).astype(
-                np.float64, copy=False
-            )
-            eps_h: float = float(np.finfo(np.float64).tiny)
-            return np.asarray(raw / np.maximum(norms_h, eps_h), dtype=np.float64)
-
-        # General case d >= 3
+        # General case d >= 3. Wood's rejection sampler is exact and holds up at
+        # any concentration: measured against I_{d/2}(k)/I_{d/2-1}(k) it is
+        # accurate to ~1e-6 out to kappa = 1e4, at constant cost per sample.
+        #
+        # A "high-concentration" shortcut used to intercept kappa >= 30 with a
+        # Gaussian around mu using scale 0.2/sqrt(kappa). The 0.2 is arbitrary
+        # and roughly five times too small -- the tangent-space standard
+        # deviation is 1/sqrt(kappa) -- and it ignores the dimension entirely,
+        # so samples clustered far too tightly around mu. At d=20, kappa=50 the
+        # mean resultant length came out at 0.9925 against a true 0.8263.
         out: NDArrayF = np.zeros((n_samples, d), dtype=np.float64)
         for i in range(n_samples):
             w: float = VonMisesFisherSampler._sample_w_wood(float(kappa), d, _rng)

--- a/tests/test_vmf_sampler.py
+++ b/tests/test_vmf_sampler.py
@@ -1,0 +1,125 @@
+"""The von Mises-Fisher sampler is checked against its closed-form moment.
+
+The mean resultant length of vMF_d(mu, kappa) has an exact expression,
+
+    E[x . mu] = A_d(kappa) = I_{d/2}(kappa) / I_{d/2-1}(kappa),
+
+which pins the concentration without needing a full distributional test. It is
+computed here with the exponentially scaled Bessel function ``ive``, whose ratio
+equals the ratio of the unscaled ones and does not overflow.
+
+A "high-concentration" shortcut used to intercept kappa >= 30 and replace Wood's
+rejection sampler with a Gaussian around mu of scale ``0.2 / sqrt(kappa)``. The
+0.2 is arbitrary and about five times too small, and it ignores the dimension,
+so samples clustered far too tightly: at d=20, kappa=50 the mean resultant
+length came out at 0.9925 against a true 0.8263. Wood's sampler is exact at any
+concentration, so the shortcut only ever introduced error.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from scipy.special import ive
+
+from safe_ice.distributions.vmf import VonMisesFisherSampler
+
+# Deliberately straddles the old kappa >= 30 cutoff.
+CONCENTRATIONS = [0.5, 2.0, 10.0, 29.0, 30.0, 31.0, 50.0, 200.0]
+
+
+def mean_resultant_length(kappa: float, d: int) -> float:
+    """A_d(kappa) = I_{d/2}(kappa) / I_{d/2-1}(kappa)."""
+    return float(ive(d / 2.0, kappa) / ive(d / 2.0 - 1.0, kappa))
+
+
+def assert_concentration(d: int, kappa: float, rng, n: int) -> None:
+    """Check E[x . mu] against A_d(kappa) within the sampling error."""
+    mu = np.zeros(d)
+    mu[0] = 1.0
+
+    samples = VonMisesFisherSampler.sample(mu, kappa, n, rng=rng)
+    projections = samples @ mu
+
+    expected = mean_resultant_length(kappa, d)
+    # Tolerance comes from the sampling error of the mean, with a floor so the
+    # low-kappa cases, where the expectation is near zero, are not held to an
+    # unreachable relative accuracy.
+    standard_error = float(np.std(projections) / np.sqrt(len(projections)))
+    assert float(np.mean(projections)) == pytest.approx(
+        expected, abs=max(5.0 * standard_error, 0.005)
+    )
+
+
+class TestMeanResultantLength:
+    @pytest.mark.parametrize("kappa", [2.0, 29.0, 31.0, 200.0])
+    def test_concentration_matches_closed_form(self, kappa: float, rng) -> None:
+        """Fast check at one dimension, straddling the old cutoff."""
+        assert_concentration(20, kappa, rng, n=15_000)
+
+    @pytest.mark.slow
+    @pytest.mark.parametrize("d", [2, 3, 20])
+    @pytest.mark.parametrize("kappa", CONCENTRATIONS)
+    def test_concentration_across_dimensions(self, d: int, kappa: float, rng) -> None:
+        """Across dimensions; slow because each case needs many samples.
+
+        Wood's sampler draws one point per Python-loop iteration, so sample
+        counts here dominate the suite's runtime. The dimension list is kept
+        short deliberately; the fast test above covers d=20 in more detail.
+        """
+        assert_concentration(d, kappa, rng, n=20_000)
+
+    @pytest.mark.parametrize("kappa", [29.0, 30.0, 31.0])
+    def test_no_jump_across_the_old_cutoff(self, kappa: float, rng) -> None:
+        """Concentration must vary smoothly through kappa = 30."""
+        d = 20
+        mu = np.zeros(d)
+        mu[0] = 1.0
+        samples = VonMisesFisherSampler.sample(mu, kappa, 15_000, rng=rng)
+        got = float(np.mean(samples @ mu))
+        assert got == pytest.approx(mean_resultant_length(kappa, d), abs=0.01)
+
+
+class TestSamplerInvariants:
+    @pytest.mark.parametrize("d", [2, 3, 10])
+    @pytest.mark.parametrize("kappa", [0.0, 1.0, 50.0])
+    def test_samples_are_unit_vectors(self, d: int, kappa: float, rng) -> None:
+        mu = np.zeros(d)
+        mu[0] = 1.0
+        samples = VonMisesFisherSampler.sample(mu, kappa, 500, rng=rng)
+        assert samples.shape == (500, d)
+        assert np.allclose(np.linalg.norm(samples, axis=1), 1.0)
+
+    @pytest.mark.parametrize("d", [3, 10])
+    def test_zero_concentration_is_uniform(self, d: int, rng) -> None:
+        """With kappa=0 there is no preferred direction."""
+        mu = np.zeros(d)
+        mu[0] = 1.0
+        samples = VonMisesFisherSampler.sample(mu, 0.0, 15_000, rng=rng)
+        assert float(np.mean(samples @ mu)) == pytest.approx(0.0, abs=0.02)
+
+    @pytest.mark.parametrize("kappa", [2.0, 50.0])
+    def test_direction_follows_mu(self, kappa: float, rng) -> None:
+        """Concentration must track mu, not a fixed axis."""
+        d = 10
+        rotated = np.zeros(d)
+        rotated[3] = 1.0
+
+        samples = VonMisesFisherSampler.sample(rotated, kappa, 15_000, rng=rng)
+        along = float(np.mean(samples @ rotated))
+        assert along == pytest.approx(mean_resultant_length(kappa, d), abs=0.01)
+
+        # Orthogonal directions carry no systematic component.
+        other = np.zeros(d)
+        other[0] = 1.0
+        assert float(np.mean(samples @ other)) == pytest.approx(0.0, abs=0.02)
+
+    def test_non_unit_mu_is_normalised(self, rng) -> None:
+        d, kappa = 5, 20.0
+        mu = np.zeros(d)
+        mu[0] = 7.5  # deliberately not a unit vector
+        samples = VonMisesFisherSampler.sample(mu, kappa, 15_000, rng=rng)
+        unit = mu / np.linalg.norm(mu)
+        assert float(np.mean(samples @ unit)) == pytest.approx(
+            mean_resultant_length(kappa, d), abs=0.01
+        )


### PR DESCRIPTION
A shortcut intercepted `kappa >= 30` and replaced Wood's rejection sampler with a Gaussian around `mu` of scale `0.2 / sqrt(kappa)`. The `0.2` is arbitrary and about five times too small — the tangent-space standard deviation is `1 / sqrt(kappa)` — and it ignores the dimension entirely. Samples clustered far too tightly around `mu`.

Against the closed-form mean resultant length `A_d(k) = I_{d/2}(k)/I_{d/2-1}(k)`:

| d | kappa | sampled | exact |
| --- | --- | --- | --- |
| 20 | 30 | 0.9903 | 0.7287 |
| 20 | 50 | 0.9925 | 0.8263 |
| 20 | 200 | 0.9982 | 0.9535 |
| 50 | 50 | 0.9975 | 0.6211 |

Wood's sampler — already implemented directly below the shortcut — is exact at any concentration: accurate to ~1e-6 out to `kappa = 1e4`, at constant cost per sample. The shortcut only ever introduced error.

## How it was isolated

`E[x . mu]` was too high, which could have been the `w` sampler, the assembly, or the rotation. Sampling `_sample_w_wood` directly gave `E[w] = 0.8263` against an exact `0.8263` — so `w` was right and the rotation was kappa-independent, which is what pointed at a branch above it.

## It also improves the estimator

For `kappa >= 30` the sampler and the density used to weight it no longer described the same distribution, which breaks the basic importance-sampling requirement. Fixing it improves accuracy against closed forms:

| Problem | before | after |
| --- | --- | --- |
| Sphere d=10 | 0.86 | **1.01** |
| Sphere d=20 | 0.54 | **0.76** |

Linear and four-mode are unchanged at 1.00 and 1.02.

## Note on cost

Wood's draws one point per Python-loop iteration (~200 µs/sample), where the removed shortcut was vectorised. The library is unaffected in practice (four-mode end-to-end is 0.22 s), but it makes sample-heavy tests expensive, so the exhaustive dimension/concentration matrix is marked `slow`. Default suite 26 s, full suite 2 min. Vectorising Wood's is worth doing on its own, with these tests as the correctness check.

`tests/test_vmf_sampler.py` checks the concentration against the closed form across dimensions and concentrations straddling the old cutoff, plus that `mu` is respected rather than a fixed axis. Reverting the fix fails 18 of them.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the high‑concentration shortcut in the von Mises–Fisher (vMF) sampler and always use Wood’s rejection sampler for d ≥ 3. This fixes severe over‑concentration for kappa ≥ 30 and restores consistency between the sampler and its density, improving estimator accuracy.

**Review and rollout**
- Behavior: for kappa ≥ 30 the sampler no longer uses a Gaussian with scale 0.2/sqrt(kappa); it now always uses Wood’s sampler. High‑kappa samples will be less concentrated and match the closed‑form mean resultant length A_d(kappa).
- Tests: new `tests/test_vmf_sampler.py` checks E[x · mu] against the closed form across dimensions and concentrations (including around the old cutoff) and validates unit‑norm and mu‑alignment; the exhaustive matrix is marked slow.
- Docs: `README.md` accuracy table and `CHANGELOG.md` record the fix and improved sphere results (d=10 from 0.86→1.01; d=20 from 0.54→0.76).
- Performance: Wood’s sampler runs one sample per Python loop; library workloads are unaffected in practice, but the slow test matrix increases CI time.
- Migration: no API changes. Downstream consumers may see different (less concentrated) draws for high kappa.

<sup>Written for commit 96c4e2bd0c1ee249289b21e37b16e30e9205a758. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/adaptive-importance-sampling/pull/79?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

