### PR TITLE
perf: vectorise Wood's vMF sampler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Performance
 
+- **Wood's vMF sampler is vectorised.** It drew one point per Python-loop
+  iteration, with a separate Householder rotation each time, costing about
+  200 microseconds per sample. Rejection now happens in batches and the
+  rotation is applied to every row at once. Drawing 20000 samples at d=20,
+  kappa=50 goes from 1.74 s to 0.065 s; at d=10 from 4.20 s to 0.047 s. The
+  default test suite drops from 26 s to 12 s and the full suite from 118 s to
+  89 s. Verified statistically identical to the per-sample version by a
+  two-sample KS test (p = 0.29 to 0.86), and the batched rotation matches the
+  scalar one to 4e-16. The now-unreferenced scalar helpers are removed rather
+  than left to drift out of step.
+
 - **Roughly 200x faster.** `vMFNMDistribution.pdf`, the penalized-EM E-step and
   the heavy-tailed density each looped in Python over every (sample, component)
   pair, calling scalar PDFs; `NakagamiDistribution.pdf` alone was called 4.2

--- a/safe_ice/distributions/vmf.py
+++ b/safe_ice/distributions/vmf.py
@@ -84,44 +84,98 @@ class VonMisesFisherSampler:
 
         # General case d >= 3. Wood's rejection sampler is exact and holds up at
         # any concentration: measured against I_{d/2}(k)/I_{d/2-1}(k) it is
-        # accurate to ~1e-6 out to kappa = 1e4, at constant cost per sample.
+        # accurate to ~1e-6 out to kappa = 1e4.
         #
         # A "high-concentration" shortcut used to intercept kappa >= 30 with a
         # Gaussian around mu using scale 0.2/sqrt(kappa). The 0.2 is arbitrary
         # and roughly five times too small -- the tangent-space standard
-        # deviation is 1/sqrt(kappa) -- and it ignores the dimension entirely,
+        # deviation is 1/sqrt(kappa) -- and it ignored the dimension entirely,
         # so samples clustered far too tightly around mu. At d=20, kappa=50 the
         # mean resultant length came out at 0.9925 against a true 0.8263.
-        out: NDArrayF = np.zeros((n_samples, d), dtype=np.float64)
-        for i in range(n_samples):
-            w: float = VonMisesFisherSampler._sample_w_wood(float(kappa), d, _rng)
+        w: NDArrayF = VonMisesFisherSampler._sample_w_wood_batch(
+            float(kappa), d, n_samples, _rng
+        )
 
-            # v ~ Unif(S^{d-2}) in R^{d-1}
-            v_raw: NDArrayF = np.asarray(
-                _rng.normal(loc=0.0, scale=1.0, size=(d - 1,)),
-                dtype=np.float64,
+        # Directions v ~ Unif(S^{d-2}) in R^{d-1}, one row per sample.
+        v_raw: NDArrayF = np.asarray(
+            _rng.normal(loc=0.0, scale=1.0, size=(n_samples, d - 1)),
+            dtype=np.float64,
+        )
+        v_norms: NDArrayF = np.linalg.norm(v_raw, axis=1, keepdims=True)
+        # A row of exact zeros has probability zero, but guard it anyway.
+        degenerate = (v_norms <= 0.0).reshape(-1)
+        v_norms = np.maximum(v_norms, float(np.finfo(np.float64).tiny))
+        v: NDArrayF = v_raw / v_norms
+        if np.any(degenerate):
+            v[degenerate] = 0.0
+            v[degenerate, 0] = 1.0
+
+        # Points on S^{d-1} aligned with e_d: the first d-1 coordinates scale by
+        # sqrt(1 - w^2), the last one is w.
+        radial: NDArrayF = np.sqrt(np.maximum(0.0, 1.0 - w * w)).reshape(-1, 1)
+        xy: NDArrayF = np.concatenate([radial * v, w.reshape(-1, 1)], axis=1)
+
+        # Rotate e_d -> mu with a single Householder reflection, applied to
+        # every row at once.
+        return VonMisesFisherSampler._householder_rotation_batch(xy, mu_unit)
+
+    @staticmethod
+    def _sample_w_wood_batch(kappa: float, d: int, n: int, rng: RNGLike) -> NDArrayF:
+        """Sample n values of w with Wood (1994), rejecting in batches.
+
+        Mathematically identical to drawing them one at a time; the acceptance
+        rate is high, so a modest over-draw usually finishes in one pass.
+        """
+        b: float = (d - 1.0) / (
+            2.0 * kappa + math.sqrt(4.0 * kappa * kappa + (d - 1.0) ** 2)
+        )
+        x0: float = (1.0 - b) / (1.0 + b)
+        c: float = kappa * x0 + (d - 1.0) * math.log(1.0 - x0 * x0)
+        a_beta: float = (d - 1.0) / 2.0
+
+        if n <= 0:
+            return np.zeros(0, dtype=np.float64)
+
+        kept: list[NDArrayF] = []
+        remaining: int = n
+        while remaining > 0:
+            # Over-draw a little so a single pass usually suffices.
+            draw = max(int(remaining * 1.3) + 8, 16)
+            z: NDArrayF = np.asarray(
+                rng.beta(a=a_beta, b=a_beta, size=draw), dtype=np.float64
             )
-            v_norm: float = float(np.linalg.norm(v_raw))
-            if v_norm > 0.0:
-                v: NDArrayF = (v_raw / v_norm).astype(np.float64, copy=False)
-            else:
-                v = np.zeros(d - 1, dtype=np.float64)
-                v[0] = 1.0
+            w_try: NDArrayF = (1.0 - (1.0 + b) * z) / (1.0 - (1.0 - b) * z)
+            u: NDArrayF = np.asarray(rng.uniform(0.0, 1.0, size=draw), dtype=np.float64)
 
-            # Point on S^{d-1} aligned with e_d
-            xy: NDArrayF = np.concatenate(
-                [
-                    (math.sqrt(max(0.0, 1.0 - w * w)) * v).astype(
-                        np.float64, copy=False
-                    ),
-                    np.asarray([w], dtype=np.float64),
-                ]
-            ).astype(np.float64, copy=False)
+            # 1 - x0 * w_try is strictly positive: |w_try| <= 1 and 0 < x0 < 1.
+            accept = (kappa * w_try + (d - 1.0) * np.log1p(-x0 * w_try) - c) >= np.log(
+                u
+            )
 
-            # Rotate e_d -> mu via Householder and apply to xy
-            out[i, :] = VonMisesFisherSampler._householder_rotation(xy, mu_unit)
+            taken = w_try[accept][:remaining]
+            kept.append(taken)
+            remaining -= int(taken.shape[0])
 
-        return out
+        return np.concatenate(kept).astype(np.float64, copy=False)
+
+    @staticmethod
+    def _householder_rotation_batch(x: NDArrayF, mu: NDArrayF) -> NDArrayF:
+        """Apply the reflection mapping e_d to mu, to every row of x."""
+        d: int = int(mu.shape[0])
+        if x.shape[1] != d:
+            raise ValueError("x rows and mu must have the same dimension.")
+
+        e_d: NDArrayF = np.zeros(d, dtype=np.float64)
+        e_d[-1] = 1.0
+
+        u: NDArrayF = e_d - mu
+        u_norm: float = float(np.linalg.norm(u))
+        if u_norm < 1e-15:
+            # mu already is e_d, so the reflection is the identity.
+            return x.astype(np.float64, copy=False)
+
+        u = u / u_norm
+        return (x - 2.0 * np.outer(x @ u, u)).astype(np.float64, copy=False)
 
     @staticmethod
     def _sample_circular(
@@ -142,49 +196,3 @@ class VonMisesFisherSampler:
         return np.column_stack([np.cos(angles), np.sin(angles)]).astype(
             np.float64, copy=False
         )
-
-    @staticmethod
-    def _sample_w_wood(kappa: float, d: int, rng: RNGLike) -> float:
-        """Sample the last coordinate w using Wood (1994) rejection sampler."""
-        b: float = (d - 1.0) / (
-            2.0 * kappa + math.sqrt(4.0 * kappa * kappa + (d - 1.0) ** 2)
-        )
-        x0: float = (1.0 - b) / (1.0 + b)
-        c: float = kappa * x0 + (d - 1.0) * math.log(1.0 - x0 * x0)
-
-        a_beta: float = (d - 1.0) / 2.0
-        b_beta: float = a_beta
-
-        while True:
-            z: float = float(rng.beta(a=a_beta, b=b_beta))
-            w: float = (1.0 - (1.0 + b) * z) / (1.0 - (1.0 - b) * z)
-            u: float = float(rng.uniform(0.0, 1.0))
-
-            test_val: float = kappa * w + (d - 1.0) * math.log(1.0 - x0 * w) - c
-            if test_val >= math.log(u):
-                return w
-
-    @staticmethod
-    def _householder_rotation(x: npt.ArrayLike, mu: npt.ArrayLike) -> NDArrayF:
-        """Apply Householder reflection that maps e_d to mu."""
-        x_arr: NDArrayF = np.asarray(x, dtype=np.float64).reshape(-1)
-        mu_arr: NDArrayF = np.asarray(mu, dtype=np.float64).reshape(-1)
-        d: int = int(mu_arr.shape[0])
-
-        if x_arr.shape[0] != d:
-            raise ValueError("x and mu must have the same dimension.")
-
-        e_d: NDArrayF = np.zeros(d, dtype=np.float64)
-        e_d[-1] = 1.0
-
-        if np.allclose(mu_arr, e_d):
-            return x_arr.astype(np.float64, copy=False)
-
-        u: NDArrayF = (e_d - mu_arr).astype(np.float64, copy=False)
-        u_norm: float = float(np.linalg.norm(u))
-        if u_norm < 1e-15:
-            return x_arr.astype(np.float64, copy=False)
-
-        u /= u_norm
-        dot: float = float(np.dot(u, x_arr))
-        return (x_arr - 2.0 * dot * u).astype(np.float64, copy=False)

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -53,16 +53,28 @@ class TestVonMisesFisherSampler:
         assert np.linalg.norm(mean_direction) < 0.2
 
     def test_high_kappa_concentration(self, rng) -> None:
-        """Test that high kappa concentrates around mean."""
+        """Test that high kappa concentrates around mean.
+
+        This used to assert that *every* sample had ``x . mu > 0.9``. For
+        vMF_3 at kappa=50 the tail probability below 0.9 is 0.0067, so over 100
+        draws that assertion fails about half the time: measured at 98 of 200
+        seeds. It passed reliably only because the sampler had a bug that
+        over-concentrated samples around mu. The concentration is now checked
+        through its expectation, which is what the parameter actually controls.
+        """
         mu: npt.NDArray[np.float64] = np.array([1.0, 0.0, 0.0], dtype=np.float64)
         kappa: float = 50.0
-        n_samples: int = 100
+        n_samples: int = 4000
 
         samples = VonMisesFisherSampler.sample(mu, kappa, n_samples, rng=rng)
-
-        # All samples should be close to mu
         dot_products = np.dot(samples, mu)
-        assert np.all(dot_products > 0.9)
+
+        # E[x . mu] = I_{d/2}(k)/I_{d/2-1}(k); for d=3 that is coth(k) - 1/k.
+        expected = 1.0 / np.tanh(kappa) - 1.0 / kappa
+        assert float(np.mean(dot_products)) == pytest.approx(expected, abs=0.01)
+
+        # Still overwhelmingly concentrated: the bulk sits well above 0.9.
+        assert float(np.mean(dot_products > 0.9)) > 0.95
 
     def test_circular_vmf(self, rng) -> None:
         """Test 2D circular case."""


### PR DESCRIPTION
Follow-up to #79, as flagged there. The sampler drew one point per Python-loop iteration, each with its own Householder rotation — about 200 µs per sample. That became the dominant cost in sample-heavy tests once the incorrect high-concentration shortcut was removed, since the shortcut had been the only vectorised path.

Rejection sampling now runs in batches with a modest over-draw, and the rotation is applied to all rows at once.

| case | before | after |
| --- | --- | --- |
| 20k samples, d=10, κ=50 | 4.20 s | **0.047 s** |
| 20k samples, d=20, κ=50 | 1.74 s | **0.065 s** |
| default test suite | 26 s | **12 s** |
| full test suite | 118 s | **89 s** |

## Checked equivalent, not assumed

- Two-sample KS test between per-sample and batched `w` draws: p = 0.29–0.86 across dimensions and concentrations.
- Batched Householder rotation matches the scalar one to **4e-16**.
- Accuracy against `I_{d/2}(k)/I_{d/2-1}(k)` unchanged.

The scalar helpers are now unreferenced, so they are removed. Leaving two implementations of the same maths in place is what let `nakagami_stable.py` drift into being the only correct one while looking like dead code.

## One test was encoding the old bug

`test_high_kappa_concentration` asserted that **every** one of 100 samples had `x . mu > 0.9`. For vMF₃ at κ=50 the tail below 0.9 has probability 0.0067, so that assertion fails for roughly half of all seeds — 98 of 200 measured. It passed reliably only because the sampler bug over-concentrated samples around `mu`.

It survived #79 by luck of the seed and surfaced here because batching changes the RNG consumption order. It now checks the expectation, which is what `kappa` actually controls, plus that >95% of the mass sits above 0.9. Passes for 200 of 200 seeds.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Vectorizes Wood’s von Mises–Fisher sampler by batching rejection sampling and applying a single Householder rotation per batch. Previously, each sample ran in a Python loop with its own rotation (~200 µs/sample); batching changes RNG consumption order but preserves distributional correctness.

**Review notes**
- Replaces per-sample `w` draw with `_sample_w_wood_batch`: modest over-draw, exact n via concatenation, uses log1p for stability; RNG order differs from scalar loop.
- Adds `_householder_rotation_batch` applied to all rows; identity when μ ≈ e_d; numerically matches scalar rotation to 4e-16.
- Removes now-unreferenced scalar helpers; no public API changes.
- Fixes `test_high_kappa_concentration` to assert the expected mean and that >95% of mass lies above 0.9, avoiding false failures from the old over-concentration bug.

**Performance**
- 20k samples: d=10 κ=50 → 4.20 s to 0.047 s; d=20 κ=50 → 1.74 s to 0.065 s.
- Test suites: default 26 s to 12 s; full 118 s to 89 s.

<sup>Written for commit 499d12f8900b6ad0a1f71573d28748c2441ec36c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/adaptive-importance-sampling/pull/80?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

