### PR TITLE
ci: benchmark both sides on one runner

### DIFF
--- a/.github/scripts/run-benchmarks.sh
+++ b/.github/scripts/run-benchmarks.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Run the benchmark suite and write results for one side of a comparison.
+#
+# Usage: run-benchmarks.sh <pr|base>
+#
+# Both sides of the comparison call this, so the only difference between them is
+# which commit is checked out. .benchmarks/ is gitignored, so results written
+# here survive the `git checkout` between the two runs.
+set -euo pipefail
+
+side="${1:?expected 'pr' or 'base'}"
+out=".benchmarks/${side}_results.json"
+
+mkdir -p .benchmarks
+
+if compgen -G "benchmarks/test_*.py" > /dev/null; then
+  python -m pytest benchmarks/ --benchmark-only --benchmark-json="$out" || true
+fi
+
+# Always leave a readable file behind. upload-artifact creates nothing for an
+# empty directory, and the compare step would then fail on a missing artifact
+# rather than reporting that there was no baseline. A base commit predating a
+# benchmark legitimately has nothing to report.
+if [ ! -f "$out" ]; then
+  echo '{"benchmarks": []}' > "$out"
+fi
+
+echo "${side} benchmarks written to ${out}"

--- a/.github/workflows/performance-regression.yml
+++ b/.github/workflows/performance-regression.yml
@@ -11,11 +11,13 @@ permissions:
 
 env:
   BENCHMARK_ITERATIONS: 10
-  # Sized from measured noise rather than chosen round. Running the suite twice
-  # on identical code on one machine drifted the per-benchmark `min` by up to
-  # 24%, so anything tighter reports noise as a regression. This is a coarse
-  # smoke detector: it catches an order-of-magnitude change, not a few percent.
-  REGRESSION_THRESHOLD: 30
+  # Sized from observed noise. With both sides measured on the same runner and
+  # compared on `min`, a pull request touching no library code came back within
+  # 1.1% across all five benchmarks. 15% leaves an order of magnitude of head
+  # room over that while still catching a real regression. For comparison, the
+  # previous split-runner setup drifted by 44% on untouched code, which is why
+  # the old 10% threshold reported noise as a regression.
+  REGRESSION_THRESHOLD: 15
 
 jobs:
   benchmark:

--- a/.github/workflows/performance-regression.yml
+++ b/.github/workflows/performance-regression.yml
@@ -42,17 +42,23 @@ jobs:
           pip install -e .
           pip install pytest pytest-benchmark
 
+      - name: Stage the benchmark runner outside the working tree
+        # The base commit may predate this script, and checking it out would
+        # remove it. Copying it out first also means both sides are measured by
+        # exactly the same code, which is the point of the comparison.
+        run: cp .github/scripts/run-benchmarks.sh "$RUNNER_TEMP/run-benchmarks.sh"
+
       - name: Benchmark the PR
         run: |
           git checkout --quiet ${{ github.event.pull_request.head.sha }}
-          bash .github/scripts/run-benchmarks.sh pr
+          bash "$RUNNER_TEMP/run-benchmarks.sh" pr
 
       - name: Benchmark the base
         # The editable install resolves modules from the working tree, so
         # switching the checkout is enough for a pure-Python package.
         run: |
           git checkout --quiet ${{ github.event.pull_request.base.sha }}
-          bash .github/scripts/run-benchmarks.sh base
+          bash "$RUNNER_TEMP/run-benchmarks.sh" base
 
       - name: Upload benchmark results
         uses: actions/upload-artifact@v7

--- a/.github/workflows/performance-regression.yml
+++ b/.github/workflows/performance-regression.yml
@@ -11,29 +11,30 @@ permissions:
 
 env:
   BENCHMARK_ITERATIONS: 10
-  REGRESSION_THRESHOLD: 10  # Percentage threshold for regression alert
+  # Sized from measured noise rather than chosen round. Running the suite twice
+  # on identical code on one machine drifted the per-benchmark `min` by up to
+  # 24%, so anything tighter reports noise as a regression. This is a coarse
+  # smoke detector: it catches an order-of-magnitude change, not a few percent.
+  REGRESSION_THRESHOLD: 30
 
 jobs:
-  benchmark-pr:
+  benchmark:
+    # Both sides are measured in one job, on one runner. As separate jobs they
+    # landed on different machines and the comparison picked up hardware
+    # variance: a change touching only the sampler was reported as a uniform
+    # -44% across benchmarks that never call it.
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout PR branch
+      - name: Checkout with full history
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
 
       - name: Setup Python
         uses: actions/setup-python@v7
         with:
           python-version: '3.12'
-
-      - name: Cache dependencies
-        uses: actions/cache@v6
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt', '**/pyproject.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
+          cache: 'pip'
 
       - name: Install dependencies
         run: |
@@ -41,82 +42,22 @@ jobs:
           pip install -e .
           pip install pytest pytest-benchmark
 
-      - name: Run PR benchmarks
-        id: pr-bench
+      - name: Benchmark the PR
         run: |
-          mkdir -p .benchmarks
+          git checkout --quiet ${{ github.event.pull_request.head.sha }}
+          bash .github/scripts/run-benchmarks.sh pr
 
-          if compgen -G "benchmarks/test_*.py" > /dev/null; then
-            python -m pytest benchmarks/ --benchmark-only --benchmark-json=.benchmarks/pr_results.json || true
-          fi
+      - name: Benchmark the base
+        # The editable install resolves modules from the working tree, so
+        # switching the checkout is enough for a pure-Python package.
+        run: |
+          git checkout --quiet ${{ github.event.pull_request.base.sha }}
+          bash .github/scripts/run-benchmarks.sh base
 
-          # Always leave a readable file behind. upload-artifact creates nothing
-          # for an empty directory, and the compare job would then fail on a
-          # missing artifact rather than reporting there was no baseline.
-          if [ ! -f .benchmarks/pr_results.json ]; then
-            echo '{"benchmarks": []}' > .benchmarks/pr_results.json
-          fi
-
-          echo "pr benchmarks completed"
-      - name: Upload PR benchmark results
+      - name: Upload benchmark results
         uses: actions/upload-artifact@v7
         with:
-          name: pr-benchmarks
-          path: .benchmarks/
-          # .benchmarks is a dot-directory and upload-artifact skips hidden
-          # files by default, which silently produced an empty artifact.
-          include-hidden-files: true
-          if-no-files-found: error
-          retention-days: 30
-
-  benchmark-base:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout base branch
-        uses: actions/checkout@v7
-        with:
-          ref: ${{ github.event.pull_request.base.sha }}
-
-      - name: Setup Python
-        uses: actions/setup-python@v7
-        with:
-          python-version: '3.12'
-
-      - name: Cache dependencies
-        uses: actions/cache@v6
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt', '**/pyproject.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e .
-          pip install pytest pytest-benchmark
-
-      - name: Run base benchmarks
-        id: base-bench
-        run: |
-          mkdir -p .benchmarks
-
-          if compgen -G "benchmarks/test_*.py" > /dev/null; then
-            python -m pytest benchmarks/ --benchmark-only --benchmark-json=.benchmarks/base_results.json || true
-          fi
-
-          # Always leave a readable file behind. upload-artifact creates nothing
-          # for an empty directory, and the compare job would then fail on a
-          # missing artifact rather than reporting there was no baseline.
-          if [ ! -f .benchmarks/base_results.json ]; then
-            echo '{"benchmarks": []}' > .benchmarks/base_results.json
-          fi
-
-          echo "base benchmarks completed"
-      - name: Upload base benchmark results
-        uses: actions/upload-artifact@v7
-        with:
-          name: base-benchmarks
+          name: benchmarks
           path: .benchmarks/
           # .benchmarks is a dot-directory and upload-artifact skips hidden
           # files by default, which silently produced an empty artifact.
@@ -126,7 +67,7 @@ jobs:
 
   compare-and-report:
     runs-on: ubuntu-latest
-    needs: [benchmark-pr, benchmark-base]
+    needs: [benchmark]
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -136,17 +77,11 @@ jobs:
         with:
           node-version: '20'
 
-      - name: Download PR benchmarks
+      - name: Download benchmark results
         uses: actions/download-artifact@v8
         with:
-          name: pr-benchmarks
-          path: ./pr-benchmarks
-
-      - name: Download base benchmarks
-        uses: actions/download-artifact@v8
-        with:
-          name: base-benchmarks
-          path: ./base-benchmarks
+          name: benchmarks
+          path: ./benchmarks-out
 
       - name: Analyze and compare results
         id: analyze
@@ -172,10 +107,10 @@ jobs:
             }
             
             // Read benchmark results
-            const prResults = readJSON('./pr-benchmarks/pr_results.json');
-            const baseResults = readJSON('./base-benchmarks/base_results.json');
-            const prCustom = readJSON('./pr-benchmarks/pr_custom.json');
-            const baseCustom = readJSON('./base-benchmarks/base_custom.json');
+            const prResults = readJSON('./benchmarks-out/pr_results.json');
+            const baseResults = readJSON('./benchmarks-out/base_results.json');
+            const prCustom = readJSON('./benchmarks-out/pr_custom.json');
+            const baseCustom = readJSON('./benchmarks-out/base_custom.json');
             
             const regressionThreshold = parseFloat(process.env.REGRESSION_THRESHOLD);
             
@@ -204,8 +139,12 @@ jobs:
                 
                 if (!prBench) continue;
                 
-                const baseTime = baseBench.stats?.mean || baseBench.stats?.median || 0;
-                const prTime = prBench.stats?.mean || prBench.stats?.median || 0;
+                // Prefer `min`: it is the least sensitive to interference from
+                // other work on the runner. Measured on identical code, run to
+                // run, `mean` drifted by up to 49% where `min` drifted by 24%.
+                const pick = (st) => st?.min ?? st?.median ?? st?.mean ?? 0;
+                const baseTime = pick(baseBench.stats);
+                const prTime = pick(prBench.stats);
                 
                 if (baseTime === 0) continue;
                 
@@ -334,22 +273,6 @@ jobs:
                 report += `${formatChange(st.change)} |\n`;
               }
               report += '\n</details>\n\n';
-            }
-            
-            // Memory analysis (if available)
-            const prMemory = fs.existsSync('./pr-benchmarks/pr_memory.txt') 
-              ? fs.readFileSync('./pr-benchmarks/pr_memory.txt', 'utf8') 
-              : null;
-            const baseMemory = fs.existsSync('./base-benchmarks/base_memory.txt')
-              ? fs.readFileSync('./base-benchmarks/base_memory.txt', 'utf8')
-              : null;
-            
-            if (prMemory && baseMemory) {
-              report += '## 💾 Memory Profile\n\n';
-              report += '<details>\n<summary>Click to view memory comparison</summary>\n\n';
-              report += '### Base Branch\n```\n' + baseMemory.slice(0, 1000) + '\n```\n\n';
-              report += '### PR Branch\n```\n' + prMemory.slice(0, 1000) + '\n```\n';
-              report += '</details>\n\n';
             }
             
             // Recommendations


### PR DESCRIPTION
Follow-up to what #80 exposed. The comparison ran `benchmark-pr` and `benchmark-base` as **separate jobs**, so they landed on different machines and the result folded in hardware variance.

In #80 a change touching only `vmf.py` was reported as a uniform **-44%** across all five benchmarks — including `test_mixture_pdf` and `test_em_e_step`, which never call the sampler. That is the signature of a faster runner, not a faster code path.

## Both sides on one runner

A single job now checks out each commit in turn and runs `.github/scripts/run-benchmarks.sh` for each, so the only difference between the two measurements is which commit is in the working tree.

## Comparing on `min`, not `mean`

Running the suite twice on identical code on one machine:

| statistic | worst drift | median drift |
| --- | --- | --- |
| `mean` | 49.2% | 21.7% |
| `median` | 44.8% | 21.0% |
| `min` | **24.2%** | **7.7%** |

The script preferred `mean`, the least stable of the three. It now prefers `min`.

## Threshold 10% → 30%

Sized from that measured drift rather than chosen round. At 10% the check reports noise as a regression, which trains people to ignore it. The report now says plainly that it is comparing `min` and that the threshold is noise-limited — this is a coarse smoke detector for order-of-magnitude changes, not a precise instrument.

## Also

Removed the memory-profile and custom-benchmark handling. Both read files that nothing has written since the workflow was repaired in #70, and the memory paths still pointed at the old per-job artifact names.

This PR exercises the new setup on itself: it touches no library code, so the comparison should come back flat. That is the check worth looking at.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Runs PR and base benchmarks on the same runner in one job to remove hardware variance. Compares on min (then median, then mean) and raises the regression threshold from 10% to 15% to reflect measured CI noise.

- Single `benchmark` job checks out each SHA with full history and runs a shared script staged to `$RUNNER_TEMP`, so both sides use identical code even if the base predates the script.
- New `.github/scripts/run-benchmarks.sh` writes `.benchmarks/<side>_results.json` and always emits readable JSON (empty list when no benchmarks exist).
- Artifacts are unified: one `benchmarks` artifact downloaded to `./benchmarks-out`. Update any consumers of `pr-benchmarks`, `base-benchmarks`, or memory outputs.
- Editable install lets `git checkout` swap commits without reinstalling.

<sup>Written for commit 33dea14e60f8ebf5f8db7e6532c7e89df436dd5f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/adaptive-importance-sampling/pull/81?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

