### PR TITLE
fix: repair the monthly reminder schedule and the dependency health check

### DIFF
--- a/.github/workflows/dependency-health.yml
+++ b/.github/workflows/dependency-health.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v7
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - name: Extract dependencies (pyproject/poetry.lock/requirements)
         id: extract
@@ -61,7 +61,7 @@ jobs:
             project = data.get("project") or {}
             for dep in project.get("dependencies", []) or []:
               name = dep.split(";")[0].strip()
-              name = re.split(r"[<>=!~\[\( ]", name, 1)[0]
+              name = re.split(r"[<>=!~\[\( ]", name, maxsplit=1)[0]
               if name and name.lower() != "python":
                 direct.add(norm(name))
             # Poetry-style
@@ -71,20 +71,26 @@ jobs:
               if name.lower() != "python":
                 direct.add(norm(name))
 
-          # 2) poetry.lock (TOML since Poetry 1.2)
-          lock = root / "poetry.lock"
-          if lock.exists():
-            try:
-              ldata = tomllib.loads(lock.read_text(encoding="utf-8"))
-              # Keep only top-level (category="main") packages
-              for pkg in ldata.get("package", []) or []:
-                if pkg.get("category") == "main":
-                  n = pkg.get("name")
-                  if n:
-                    direct.add(norm(n))
-            except Exception:
-              # Older Poetry lock or different format: ignore gracefully
-              pass
+          # 2) [project.optional-dependencies] and PEP 735 [dependency-groups]
+          #
+          # poetry.lock used to be read here, keeping packages with
+          # category="main". Poetry removed that field in 1.5, so the filter
+          # matched nothing and the lock contributed no names at all. The lock
+          # also lists transitive packages, which is not what "direct" means;
+          # pyproject.toml is the authoritative source for direct dependencies.
+          if pp.exists():
+            for _group, entries in (project.get("optional-dependencies") or {}).items():
+              for dep in entries or []:
+                name = re.split(r"[<>=!~\[\( ;]", dep.strip(), maxsplit=1)[0]
+                if name:
+                  direct.add(norm(name))
+            for _group, entries in (data.get("dependency-groups") or {}).items():
+              for dep in entries or []:
+                if not isinstance(dep, str):
+                  continue
+                name = re.split(r"[<>=!~\[\( ;]", dep.strip(), maxsplit=1)[0]
+                if name:
+                  direct.add(norm(name))
 
           # 3) requirements.txt
           req = root / "requirements.txt"
@@ -95,7 +101,7 @@ jobs:
                 continue
               # Strip version pins and comments
               line = line.split("#", 1)[0].strip()
-              name = re.split(r"(==|>=|<=|>|<|~=|!=)", line, 1)[0].strip()
+              name = re.split(r"(==|>=|<=|>|<|~=|!=)", line, maxsplit=1)[0].strip()
               if name:
                 direct.add(norm(name))
 
@@ -111,15 +117,16 @@ jobs:
           python -m pip install pip-audit
 
       - name: Run vulnerability audit (pip-audit)
-        # Prefer lock > requirements; else audit resolved env (empty) -> safe no-op
+        # Audits the installed environment, which is what ci.yml's security job
+        # does too. This previously ran `pip-audit -f json -p poetry.lock`, but
+        # `-p` is not a pip-audit flag: the command printed its usage message,
+        # `|| true` swallowed the failure, and audit.json ended up holding that
+        # text. deps_health.js falls back to an empty list on unparseable JSON,
+        # so the audit silently reported no vulnerabilities either way.
         run: |
-          if [ -f poetry.lock ]; then
-            pip-audit -f json -p poetry.lock > audit.json || true
-          elif [ -f requirements.txt ]; then
-            pip-audit -f json -r requirements.txt > audit.json || true
-          else
-            echo "[]" > audit.json
-          fi
+          pip install -e . || true
+          pip-audit -f json > audit.json || true
+          python -c "import json,pathlib; json.loads(pathlib.Path('audit.json').read_text() or '[]')"             || echo "[]" > audit.json
           echo "Audit written to audit.json"
 
       - name: Dependency Health Analyzer (node)

--- a/.github/workflows/monthly-reminder.yml
+++ b/.github/workflows/monthly-reminder.yml
@@ -2,18 +2,49 @@ name: Monthly maintenance reminder
 
 on:
   schedule:
-    # Second Monday of each month at 09:00 UTC
-    - cron: "0 9 8-14 * 1"
+    # Days 8-14 at 09:00 UTC; the `gate` job below keeps only the Monday, which
+    # is the second Monday of the month.
+    #
+    # This used to be "0 9 8-14 * 1", intended as "the second Monday". Cron
+    # treats day-of-month and day-of-week as OR when both are restricted, so it
+    # fired on days 8-14 *and* on every Monday: 11 times in August 2026 instead
+    # of once. Since October 2025 that put over 100 comments on issue #1.
+    - cron: "0 9 8-14 * *"
   workflow_dispatch:
 
 jobs:
+  gate:
+    # Cron cannot express "second Monday", so the schedule casts a wider net and
+    # the day-of-week test happens here. Manual runs always proceed.
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.check.outputs.should_run }}
+    steps:
+      - name: Keep only the second Monday
+        id: check
+        run: |
+          if [ "${{ github.event_name }}" != "schedule" ]; then
+            echo "Manual run; proceeding."
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+          elif [ "$(date -u +%u)" = "1" ]; then
+            echo "Second Monday of the month; proceeding."
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Day-of-week is $(date -u +%u), not Monday; skipping."
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+          fi
+
   monthly-reminder:
+    needs: gate
     runs-on: ubuntu-latest
     timeout-minutes: 10
     concurrency:
       group: monthly-reminder-${{ github.repository }}
       cancel-in-progress: true
-    if: ${{ !github.event.repository.fork && !github.event.repository.archived }}
+    if: >-
+      ${{ needs.gate.outputs.should_run == 'true'
+      && !github.event.repository.fork
+      && !github.event.repository.archived }}
     permissions:
       contents: read
       issues: write


### PR DESCRIPTION
The last two workflows I hadn't audited. Both had defects their green run history hid.

## monthly-reminder fired 11 times a month, not once

The cron was `0 9 8-14 * 1`, intended as "the second Monday". Cron treats day-of-month and day-of-week as **OR** when both are restricted, so it fired on days 8–14 *and* on every Monday.

Predicted firings for August 2026: days 3, 8, 9, 10, 11, 12, 13, 14, 17, 24, 31 — and the run history shows 08-12, 08-13, 08-14, 08-17. Exactly matching.

It does guard against duplicate issues, so rather than extra issues it has been **commenting on issue #1 every run — 100+ comments since October 2025**.

Cron cannot express "second Monday", so the schedule now selects days 8–14 and a `gate` job keeps only the Monday among them. Verified against the next four months: exactly one firing each, on days 10, 14, 12, 9. Manual dispatch still runs unconditionally.

## dependency-health analysed 3 of 25 dependencies, and never audited anything

Two independent problems, both of which the analyzer degraded silently past:

**The audit never ran.** It called `pip-audit -f json -p poetry.lock`. There is no `-p` flag — the command prints its usage message, `|| true` swallowed the failure, and `audit.json` ended up holding that text. `deps_health.js` falls back to `[]` on unparseable JSON, so it always reported no vulnerabilities. It now audits the installed environment (as `ci.yml`'s security job does) and validates the output is JSON before use.

**Extraction found 3 of 25 dependencies.** It read `poetry.lock` keeping packages with `category="main"` — a field Poetry removed in 1.5, so the filter matched nothing:

| source | contributed |
| --- | --- |
| `[project].dependencies` | 3 |
| `[tool.poetry.dependencies]` | 0 (metadata is PEP 621 now) |
| `poetry.lock` `category="main"` | **0** (field removed in Poetry 1.5+) |
| `requirements.txt` | absent |

It now reads `[project].dependencies`, `[project.optional-dependencies]` and the PEP 735 `[dependency-groups]` — all **25**. The lock is no longer consulted: it also lists transitive packages, and pyproject is authoritative for direct ones.

I verified this by extracting the embedded script and running it standalone.

## Also

Positional `re.split` `maxsplit` arguments (deprecated in 3.13) are now keyword arguments, and the job moves to Python 3.12 for consistency with the other workflows.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Repairs the monthly reminder and dependency health workflows so the reminder fires once on the second Monday and the health check reports real vulnerabilities. Previously the reminder ran on days 8–14 and every Monday (spamming issue #1 with 100+ comments), and `pip-audit` was mis-invoked so the workflow reported no vulnerabilities while analyzing only 3 of 25 direct dependencies.

**Monthly reminder**
- Cron widened to days 8–14 at 09:00 UTC; a `gate` job runs only on Monday to yield the second Monday.
- Manual dispatch remains unconditional; existing concurrency settings are unchanged.

**Dependency health**
- Audits the installed environment with `pip-audit -f json` and validates the output is JSON before use.
- Extracts direct dependencies from `pyproject.toml` (`[project].dependencies`, `[project.optional-dependencies]`, PEP 735 `[dependency-groups]`); no longer reads `poetry.lock`.
- Upgrades to Python 3.12 and switches to `re.split(..., maxsplit=1)` to avoid deprecations.

<sup>Written for commit b2b5f4e461579fe138520bde5ccb521cb9c1ded2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/adaptive-importance-sampling/pull/83?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

