### PR TITLE
fix: reshape pip-audit output for the dependency health analyzer

### DIFF
--- a/.github/workflows/dependency-health.yml
+++ b/.github/workflows/dependency-health.yml
@@ -125,9 +125,41 @@ jobs:
         # so the audit silently reported no vulnerabilities either way.
         run: |
           pip install -e . || true
-          pip-audit -f json > audit.json || true
-          python -c "import json,pathlib; json.loads(pathlib.Path('audit.json').read_text() or '[]')"             || echo "[]" > audit.json
-          echo "Audit written to audit.json"
+          pip-audit -f json > audit-raw.json || true
+          python - << 'PY'
+          # pip-audit emits {"dependencies": [{name, version, vulns: [...]}], ...}
+          # but deps_health.js iterates audit.json as a flat array of findings
+          # with .name and .advisory.*. An object is truthy, so its `|| []`
+          # fallback does not catch the mismatch and it fails with
+          # "auditJson is not iterable". Flatten to the shape it expects.
+          import json
+          from pathlib import Path
+
+          findings = []
+          try:
+            raw = json.loads(Path("audit-raw.json").read_text(encoding="utf-8"))
+          except Exception:
+            raw = {}
+
+          for dep in (raw.get("dependencies") if isinstance(raw, dict) else []) or []:
+            name = dep.get("name")
+            for vuln in dep.get("vulns") or []:
+              aliases = vuln.get("aliases") or []
+              cve = next((a for a in aliases if str(a).upper().startswith("CVE-")), None)
+              findings.append({
+                "name": name,
+                "version": dep.get("version"),
+                "advisory": {
+                  "id": vuln.get("id"),
+                  "summary": vuln.get("description"),
+                  "cve": cve,
+                },
+                "fix_versions": vuln.get("fix_versions") or [],
+              })
+
+          Path("audit.json").write_text(json.dumps(findings, indent=2), encoding="utf-8")
+          print(f"Audit: {len(findings)} finding(s) written to audit.json")
+          PY
 
       - name: Dependency Health Analyzer (node)
         env:


### PR DESCRIPTION
Fixing the audit invocation in #83 exposed a latent incompatibility, which that PR's manual run surfaced: `Dependency Health Analyzer (node)` failed with `TypeError: auditJson is not iterable`.

`pip-audit -f json` emits an **object**:

```json
{"dependencies": [{"name": "...", "version": "...", "vulns": [...]}], "fixes": []}
```

but `deps_health.js` iterates `audit.json` as a **flat array** of findings with `.name` and `.advisory.*`. An object is truthy, so its `|| []` fallback doesn't catch the mismatch.

This was hidden before because the audit had never produced valid JSON at all: the invalid `-p` flag meant `audit.json` held a usage message, `readJSONSafe` returned null, the fallback engaged, and the analyzer quietly reported no vulnerabilities. Repairing the audit made the shape mismatch reachable for the first time.

The workflow now flattens pip-audit's output into the expected shape, mapping each vuln to `advisory.id`, `advisory.summary`, `advisory.cve` (selected from `aliases`) and `fix_versions`. `deps_health.js` is untouched.

## Verified three ways

I extracted the transform from the workflow and ran it standalone against:

| input | result |
| --- | --- |
| real `pip-audit` output (743 packages) | 269 findings, keys `name`/`version`/`advisory`/`fix_versions` |
| synthetic vulnerability | every mapped field asserted, including `cve` picked from aliases |
| malformed text | empty **array** — iterable, so the analyzer degrades instead of crashing |

That last case matters: the previous fallback produced the right behaviour by accident. Now it produces it deliberately.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reshapes `pip-audit` output in the workflow to a flat array so the Dependency Health Analyzer runs successfully. Before: `audit.json` held an object and the analyzer crashed with “auditJson is not iterable.” Now: we write a flat array of findings and degrade to an empty array on malformed input, so vulnerabilities are reported and the job stays stable.

**Reviewer notes**
- Transform runs in the workflow: write `audit-raw.json`, then emit `audit.json` as an array with `name`, `version`, `advisory.id`, `advisory.summary`, `advisory.cve` (picked from `aliases`), and `fix_versions`.
- Leaves `deps_health.js` unchanged; only `.github/workflows/dependency-health.yml` is updated.
- No migration required; consumers of `audit.json` keep iterating an array.

<sup>Written for commit 59b6b5ca189d66b991bddf5a95debfc22a48abc5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/adaptive-importance-sampling/pull/84?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

