### PR TITLE
fix: the proposal density was floored at 1e-15, capping usable dimension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   also the *correct* implementation for large shapes, so its behaviour was
   folded into `nakagami.py` before deleting it. The only thing lost is a
   `log_pdf` helper that nothing called.
+- **The proposal density was floored at 1e-15 before being divided into the
+  prior.** That is not a small number for a probability density on R^d, which
+  shrinks geometrically with dimension. Measured on the sphere problem, the
+  median proposal density is 4.5e-2 at d=2, 1.6e-8 at d=10, 4.3e-15 at d=20 and
+  7.1e-22 at d=30, so the floor clamped nothing at low dimension, 11% of samples
+  at d=20, and every sample at d=30. Clamping inflates the denominator and
+  collapses the estimate: d=30 returned about 1e-9 against a true 1.6e-2.
+
+  This presented as a hard ceiling between d=20 and d=30 and was twice
+  attributed here to importance-weight degeneracy. That is a real phenomenon,
+  but it was the wrong diagnosis: with the floor at the smallest positive float,
+  the sphere problem holds to within a few percent through d=200. The same fixed
+  floor was also applied inside two log-likelihood computations, capping every
+  term at log(1e-15) and flattening the EM objective in high dimensions.
+
+  Sphere problem, median over seeds, ratio to the exact chi-square tail:
+
+    d=20   0.75 -> 1.01
+    d=30   0.00 -> 0.98   (was 7e-9 against 1.6e-2)
+    d=50   0.00 -> 0.98
+    d=200    --  -> 1.01
+
 - **The mixture was initialised with dimension-independent parameters.** The
   target is the standard normal in R^d, whose radius follows chi_d, and chi_d
   is exactly Nakagami(m = d/2, Omega = d), so the fixed values used before were

--- a/README.md
+++ b/README.md
@@ -226,6 +226,10 @@ Two correctness bugs that biased every estimate have been fixed:
   denominator, every estimate was scaled by that error, which is why results
   came out at roughly `0.54x` the analytical answer no matter how large `N`
   was.
+- The proposal density was floored at `1e-15` before being divided into the
+  prior. That is not a small number for a density on `R^d`: it clamped 11% of
+  samples at `d=20` and 100% at `d=30`, which is what produced the apparent
+  dimensional ceiling.
 - The mixture was initialised with fixed Nakagami parameters, independent of
   dimension. The target is the standard normal in `R^d`, whose radius follows
   `chi_d`, and `chi_d` is exactly `Nakagami(m = d/2, Ω = d)` — so the old fixed
@@ -253,8 +257,10 @@ Current accuracy against problems with known answers, median over seeds:
 | --- | --- | --- |
 | Linear limit state, closed form | `1.69e-2` | `1.02` |
 | Sphere `d=2`, closed form | `1.11e-2` | `1.01` |
-| Sphere `d=10`, closed form | `5.35e-3` | `1.01` |
-| Sphere `d=20`, closed form | `1.54e-2` | `0.76` |
+| Sphere `d=10`, closed form | `5.35e-3` | `1.00` |
+| Sphere `d=20`, closed form | `1.54e-2` | `1.01` |
+| Sphere `d=50`, closed form | `3.61e-3` | `0.98` |
+| Sphere `d=200`, closed form | `4.57e-3` | `1.01` |
 | Four-mode series system, 2e7-sample MC | `5.8e-5` | `1.01` |
 
 `tests/test_proposal_normalisation.py` pins this down: it integrates each
@@ -266,12 +272,13 @@ proposal component numerically and fails if the Jacobian is dropped again.
   unconstrained, so for a limit state that fails everywhere (true probability
   exactly 1) it scatters around 1 and can land slightly above. Clamping would
   fix it, but that is a modelling decision rather than a bug.
-- **It still breaks down above roughly `d=20`.** On the sphere problem, `d=20`
-  now works (6 of 6 seeds within `3x`, ratio `0.76`), but `d=30` does not —
-  every seed collapses. Importance weights become extremely heavy-tailed as
-  dimension grows: the ratio of largest to median weight goes from `~10` at
-  `d=2` to `~8e11` at `d=20`, so a few samples carry the estimate. Raising `N`
-  helps but does not fix it. Treat `d > 20` as unsupported.
+- **High dimensions now work.** The apparent ceiling above `d=20` was a fixed
+  `1e-15` floor applied to the proposal density before dividing it into the
+  prior. Densities on `R^d` shrink geometrically with dimension, so that floor
+  clamped 11% of samples at `d=20` and *every* sample at `d=30`, collapsing the
+  estimate to `~1e-9` against a true `1.6e-2`. With the floor at the smallest
+  positive float instead, the sphere problem holds to within a few percent
+  through `d=200`.
 - The reference value quoted for the four-mode problem used to be `1.22e-5`.
   Crude Monte Carlo over 2e7 samples puts it at `5.8e-5 ± 1.7e-6` for the
   default `z=3.8`.

--- a/safe_ice/core/safe_ice.py
+++ b/safe_ice/core/safe_ice.py
@@ -35,6 +35,18 @@ from .parameters import vMFNMParameters
 # ----------------------------
 NDArrayF = npt.NDArray[np.float64]
 
+#: Smallest positive normal float64. Used to keep a proposal density out of a
+#: denominator without distorting it.
+#:
+#: A fixed 1e-15 floor was used here before. Probability densities on R^d shrink
+#: geometrically with dimension, so that floor is far below any real value at
+#: d=2 but sits above most of them by d=20: measured on the sphere problem, the
+#: median proposal density is 4.5e-2 at d=2, 4.3e-15 at d=20 and 7.1e-22 at
+#: d=30, where every single sample was being clamped. Clamping inflates the
+#: denominator and drives the estimate to zero, which is why d=30 returned
+#: ~1e-9 for a true 1.6e-2.
+DENSITY_FLOOR: float = float(np.finfo(np.float64).tiny)
+
 
 class _SafeICEHistory(TypedDict):
     """History container for monitoring algorithm progress."""
@@ -550,7 +562,7 @@ class SafeICE:
 
         # W_t = h * p / q_safe
         weights: NDArrayF = (
-            h_values * prior_densities / np.maximum(safe_densities, 1e-15)
+            h_values * prior_densities / np.maximum(safe_densities, DENSITY_FLOOR)
         ).astype(np.float64, copy=False)
         return weights
 
@@ -592,7 +604,7 @@ class SafeICE:
 
         # Importance weights
         importance_weights: NDArrayF = (
-            prior_densities / np.maximum(safe_densities, 1e-15)
+            prior_densities / np.maximum(safe_densities, DENSITY_FLOOR)
         ).astype(np.float64, copy=False)
 
         # Monte Carlo estimate

--- a/safe_ice/distributions/mixture.py
+++ b/safe_ice/distributions/mixture.py
@@ -120,4 +120,8 @@ class vMFNMDistribution:
 
     def log_likelihood(self, x: npt.ArrayLike) -> float:
         pdf_vals = self.pdf(x)
-        return float(np.sum(np.log(np.maximum(pdf_vals, 1e-15))))
+        # Floor at the smallest positive float rather than 1e-15: densities on
+        # R^d fall below 1e-15 routinely once d is around 20, and flooring there
+        # caps every term at log(1e-15) = -34.5, flattening real differences.
+        floor = float(np.finfo(np.float64).tiny)
+        return float(np.sum(np.log(np.maximum(pdf_vals, floor))))

--- a/safe_ice/optimization/penalized_em.py
+++ b/safe_ice/optimization/penalized_em.py
@@ -381,7 +381,10 @@ class PenalizedEMOptimizer:
         """Compute weighted log-likelihood."""
         dist = vMFNMDistribution(params)
         pdf_vals: NDArrayF = np.asarray(dist.pdf(data), dtype=np.float64)
-        log_pdf: NDArrayF = np.log(np.maximum(pdf_vals, 1e-15)).astype(
+        # See mixture.log_likelihood: 1e-15 is not a small density once the
+        # dimension is around 20, and flooring there flattens the objective.
+        floor = float(np.finfo(np.float64).tiny)
+        log_pdf: NDArrayF = np.log(np.maximum(pdf_vals, floor)).astype(
             np.float64, copy=False
         )
         return float(np.sum(weights * log_pdf))

--- a/tests/test_high_dimensional.py
+++ b/tests/test_high_dimensional.py
@@ -1,0 +1,119 @@
+"""The estimator has to work in high dimensions, which is its whole point.
+
+A fixed ``1e-15`` floor used to be applied to the proposal density before it
+was divided into the prior. Probability densities on R^d shrink geometrically
+with dimension, so that floor sat far below any real value at d=2 but above
+almost all of them by d=30:
+
+    d      median proposal density     fraction hitting the 1e-15 floor
+    2      4.5e-02                     0%
+    10     1.6e-08                     0.1%
+    20     4.3e-15                     11%
+    30     7.1e-22                     100%
+
+Clamping inflates the denominator, so the estimate collapses: d=30 returned
+about 1e-9 for a true 1.6e-2. It presented as a hard ceiling somewhere between
+d=20 and d=30, and looked like importance-weight degeneracy, which is a real
+phenomenon and was the wrong diagnosis here.
+
+These tests fix the behaviour at dimensions where any fixed floor of that kind
+would bite.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from scipy import stats
+
+from safe_ice import SafeICE
+from safe_ice.core.safe_ice import DENSITY_FLOOR
+
+
+def sphere_problem(beta: float):
+    """P(||u|| > beta) for a standard normal, known exactly as a chi-square tail."""
+
+    def limit_state(u: np.ndarray) -> np.ndarray:
+        return beta - np.linalg.norm(u, axis=-1)
+
+    return limit_state
+
+
+class TestDensityFloor:
+    """The floor must only guard division by zero, never distort a density."""
+
+    def test_floor_is_the_smallest_positive_float(self) -> None:
+        assert float(np.finfo(np.float64).tiny) == DENSITY_FLOOR
+
+    def test_floor_is_far_below_realistic_high_dimensional_densities(self) -> None:
+        """At d=200 a proposal density is around 1e-150; the floor must clear it."""
+        assert DENSITY_FLOOR < 1e-300
+
+    @pytest.mark.parametrize("d", [30, 50])
+    def test_proposal_densities_fall_below_the_old_floor(self, d: int, seed) -> None:
+        """Confirms the premise: real densities here are smaller than 1e-15.
+
+        If this ever fails, the dimensions chosen for these tests no longer
+        exercise the bug and should be raised.
+        """
+        ice = SafeICE(
+            limit_state_function=sphere_problem(float(d) ** 0.5 + 2.0),
+            dimension=d,
+            N=2000,
+            random_state=seed,
+        )
+        params = ice._initialize_vmfnm_parameters()
+        samples = ice._generate_safe_mixture_samples(params, 0.95)
+        densities = ice._evaluate_safe_mixture_density(samples, params, 0.95)
+
+        assert float(np.median(densities)) < 1e-15
+        assert float(np.min(densities)) > 0.0
+
+
+class TestHighDimensionalAccuracy:
+    """End-to-end accuracy against the chi-square tail, which is exact."""
+
+    @pytest.mark.slow
+    @pytest.mark.parametrize(("d", "beta"), [(20, 6.0), (30, 7.0), (50, 9.0)])
+    def test_sphere_problem(self, d: int, beta: float) -> None:
+        expected = float(1 - stats.chi2.cdf(beta**2, df=d))
+
+        estimates = []
+        for s in range(4):
+            ice = SafeICE(
+                limit_state_function=sphere_problem(beta),
+                dimension=d,
+                N=2000,
+                max_iterations=15,
+                random_state=s,
+            )
+            pf, _ = ice.run(verbose=False)
+            estimates.append(pf)
+
+        median = float(np.median(estimates))
+        # Generous, because this is a stochastic estimator. The bug being
+        # guarded against drove d=30 to 1e-9 against a true 1.6e-2, seven
+        # orders of magnitude out, so a factor of three catches it easily.
+        assert expected / 3 < median < expected * 3, f"estimates: {estimates}"
+
+    @pytest.mark.slow
+    def test_estimate_does_not_collapse_with_dimension(self) -> None:
+        """Accuracy must not degrade systematically as d grows.
+
+        The failure mode was not noise but collapse: every seed returned a value
+        many orders of magnitude too small.
+        """
+        ratios = []
+        for d, beta in ((10, 5.0), (30, 7.0), (50, 9.0)):
+            expected = float(1 - stats.chi2.cdf(beta**2, df=d))
+            ice = SafeICE(
+                limit_state_function=sphere_problem(beta),
+                dimension=d,
+                N=2000,
+                max_iterations=15,
+                random_state=0,
+            )
+            pf, _ = ice.run(verbose=False)
+            ratios.append(pf / expected)
+
+        assert all(0.3 < r < 3.0 for r in ratios), f"ratios by dimension: {ratios}"


### PR DESCRIPTION
`_estimate_failure_probability` divided the prior by `max(q, 1e-15)`. That is not a small number for a probability density on `R^d`, which shrinks geometrically with dimension:

| d | median proposal density | samples hitting the 1e-15 floor |
| --- | --- | --- |
| 2 | 4.5e-02 | 0% |
| 10 | 1.6e-08 | 0.1% |
| 20 | 4.3e-15 | **11%** |
| 30 | 7.1e-22 | **100%** |

Clamping inflates the denominator and drives the estimate toward zero. At `d=30` that returned about **1e-9 against a true 1.6e-2**, consistently across every seed.

## I had this wrong twice

I attributed the ceiling to importance-weight degeneracy in #75 and again when documenting it in the README. Degeneracy is a real phenomenon and it was the wrong diagnosis.

What settled it: recomputing the estimate by hand from the *same* final parameters, differing only in using a `1e-300` floor, gave **1.44e-2** where `run()` reported **7.6e-9**. Same parameters, same formula, same samples — only the floor differed. Before that I had checked, and cleared, the proposal's coverage (57% of samples were in the failure region) and its normalisation (`E_q[prior/q] ≈ 1` at every dimension).

## Effect

Sphere problem, median over seeds, ratio to the exact chi-square tail:

| d | before | after |
| --- | --- | --- |
| 20 | 0.75 | **1.01** |
| 30 | 0.00 (7e-9) | **0.98** |
| 40 | 0.00 (4e-16) | **0.99** |
| 50 | 0.00 | **0.98** |
| 100 | — | **0.99** |
| 200 | — | **1.01** |

Low dimensions are unchanged: linear `1.00`, four-mode `1.02` at 12/12 seeds.

The same fixed value was also used inside `mixture.log_likelihood` and `_weighted_log_likelihood`, capping every term at `log(1e-15) = -34.5` and flattening the EM objective in high dimensions. Both now use the same floor.

## Tests

`tests/test_high_dimensional.py` asserts accuracy at d=20/30/50, checks the floor is below any representable high-dimensional density, and — importantly — confirms real densities at those dimensions *do* fall under 1e-15, so the tests keep exercising the bug rather than silently ceasing to. Reverting the floor fails five of them.

The README no longer claims a dimensional ceiling.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the fixed 1e-15 proposal-density floor with the smallest positive float64 to prevent clamping high-dimensional densities and collapsing estimates. Previously we divided by max(q, 1e-15); now we use `np.finfo(np.float64).tiny` consistently, restoring correct estimates through high dimensions and unflattening the EM objective.

- Introduces `DENSITY_FLOOR` in `safe_ice/core/safe_ice.py` and uses it in `_estimate_failure_probability` and `_calculate_intermediate_weights`.
- Aligns `mixture.log_likelihood` and `_weighted_log_likelihood` to the same floor to avoid capping terms at log(1e-15).
- Adds `tests/test_high_dimensional.py` that:
  - Assert sphere-problem accuracy at d=20/30/50 within a generous factor.
  - Verify real proposal densities fall below 1e-15 yet above the new floor.
- Updates README and CHANGELOG to remove the claimed dimensional ceiling and report new high-d accuracy (e.g., d=30: ~0.98x vs exact, was ~7e-9).

<sup>Written for commit 70b47791c3e31b1f326bf13e1620105367446337. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/adaptive-importance-sampling/pull/85?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

