### PR TITLE
test: validate benchmarks against Monte Carlo, and record a broken one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The nonlinear oscillator benchmark cannot fail, and so measures nothing.**
+  Displacement is computed as `force_rms / (k * (1 - alpha))` with `k = 5e6`,
+  giving values around 4e-7 against a threshold of `z = 0.05`. Reaching it needs
+  a norm of about 7.3e5, where a 10-dimensional standard normal averages 3.1.
+  Crude Monte Carlo over 2e7 samples finds zero failures, and `safe-ice
+  benchmark oscillator` reported a probability of exactly 0 with an infinite
+  coefficient of variation. The scaling is inconsistent by roughly 1e5.
+  Reconstructing the intended formulation needs the source paper, so the defect
+  is documented on the problem, recorded as a strict xfail, and the problem is
+  removed from the CLI in favour of `two-mode`.
+- Reference probabilities in the CLI were wrong: four-mode was quoted as 1.22e-5
+  against a measured 5.8e-5, and three-mode as 2.3e-3 against 3.5e-3. Both now
+  come from the Monte Carlo values recorded in the tests. The CLI epilogue also
+  pointed at a `your-username` placeholder URL.
+
 - **The heavy-tailed proposal component was missing the polar Jacobian.** It is
   built as a radial density times an angular one, so recovering a density on
   R^d needs `du = r^(d-1) dr dw`, which `vMFNMDistribution.pdf` applied and

--- a/README.md
+++ b/README.md
@@ -212,9 +212,24 @@ safe-ice benchmark --problem four-mode
 ### Available benchmark problems
 
 `four_mode_series_system`, `three_mode_problem`,
-`two_mode_opposite_directions`, `nonlinear_oscillator`,
-`nonlinear_oscillator_simplified`, and `nakagami_ratio_problem`, plus
+`two_mode_opposite_directions` and `nakagami_ratio_problem`, plus
 `HeatTransferProblem` — a PDE problem using a Karhunen-Loève expansion.
+
+Reference probabilities, from crude Monte Carlo over 2e7 samples:
+
+| Problem | `P_F` |
+| --- | --- |
+| `four_mode_series_system` | `5.8e-5` |
+| `three_mode_problem` | `3.5e-3` |
+| `two_mode_opposite_directions` | `2.7e-3` |
+| `nakagami_ratio_problem` | `5.2e-2` |
+
+> `nonlinear_oscillator` and `nonlinear_oscillator_simplified` **cannot fail as
+> parameterised** and so measure nothing: displacement comes out around `4e-7`
+> against a threshold of `0.05`, needing `‖u‖ ≈ 7.3e5` where a 10-dimensional
+> standard normal averages `3.1`. Any estimator returns `0`. Fixing the scaling
+> needs the source paper, so the defect is documented rather than guessed at;
+> the problems are excluded from the CLI.
 
 ## Accuracy
 

--- a/safe_ice/cli.py
+++ b/safe_ice/cli.py
@@ -47,7 +47,7 @@ def run_demo() -> None:
         print("Results:")
         print(f"  Estimated failure probability: {pf:.6e}")
         print(f"  Number of samples generated: {len(results['final_samples'])}")
-        print("  Reference probability: ~1.22e-5")
+        print("  Reference probability: ~5.8e-5")
         print("=" * 60)
 
     except Exception as e:
@@ -64,11 +64,18 @@ def run_benchmark(
 
     problems = BenchmarkProblems()
 
-    # Available problems
+    # Available problems. Reference probabilities are from crude Monte Carlo
+    # over 2e7 standard-normal samples; see
+    # tests/test_benchmark_ground_truth.py.
     available: dict[str, tuple[Callable[[], LimitStateFunction], int, float | None]] = {
-        "four-mode": (problems.four_mode_series_system, 2, 1.22e-5),
-        "three-mode": (problems.three_mode_problem, 2, 2.3e-3),
-        "oscillator": (problems.nonlinear_oscillator, 10, None),
+        "four-mode": (problems.four_mode_series_system, 2, 5.815e-05),
+        "three-mode": (problems.three_mode_problem, 2, 3.475e-03),
+        # "oscillator" is deliberately absent. nonlinear_oscillator cannot fail
+        # as parameterised -- displacement is ~4e-7 against a threshold of 0.05
+        # -- so this subcommand reported a failure probability of exactly 0 with
+        # an infinite coefficient of variation. Offering it as a benchmark is
+        # worse than not offering it. See the warning on the problem itself.
+        "two-mode": (problems.two_mode_opposite_directions, 2, 2.690e-03),
     }
 
     if problem_name is None or problem_name not in available:
@@ -129,7 +136,8 @@ Examples:
   safe-ice benchmark --list        List available benchmark problems
   safe-ice --help                  Show this help message
 
-For more information, visit: https://github.com/your-username/safe-ice
+For more information, visit:
+  https://github.com/DiogoRibeiro7/adaptive-importance-sampling-ice
         """,
     )
 
@@ -146,7 +154,7 @@ For more information, visit: https://github.com/your-username/safe-ice
     # Benchmark command
     benchmark_parser = subparsers.add_parser("benchmark", help="Run benchmark problems")
     benchmark_parser.add_argument(
-        "problem", nargs="?", help="Problem name (four-mode, three-mode, oscillator)"
+        "problem", nargs="?", help="Problem name (four-mode, three-mode, two-mode)"
     )
     benchmark_parser.add_argument(
         "--samples",

--- a/safe_ice/problems/benchmarks.py
+++ b/safe_ice/problems/benchmarks.py
@@ -79,7 +79,23 @@ class BenchmarkProblems:
     def nonlinear_oscillator_simplified(
         d: int = 10, z: float = 0.05
     ) -> Callable[[npt.ArrayLike], float | npt.NDArray[np.float64]]:
-        """Simplified nonlinear oscillator problem."""
+        """Simplified nonlinear oscillator problem.
+
+        .. warning::
+
+           This problem cannot fail as parameterised, so it measures nothing.
+           Displacement is computed as ``force_rms / (k * (1 - alpha))`` with
+           ``k = 5e6``, giving values around ``4e-7`` against a threshold of
+           ``z = 0.05``. Reaching the threshold needs ``||u||`` of about
+           ``7.3e5``, where the norm of a 10-dimensional standard normal
+           averages ``3.1``. Crude Monte Carlo over 2e7 samples finds zero
+           failures, and any estimator will return ``0``.
+
+           The scaling is inconsistent by a factor of roughly ``1e5``.
+           Reconstructing the intended formulation needs the source paper, so
+           the defect is documented rather than guessed at. See
+           ``tests/test_benchmark_ground_truth.py::TestNonlinearOscillator``.
+        """
 
         def limit_state_function(
             u: npt.ArrayLike,
@@ -125,7 +141,14 @@ class BenchmarkProblems:
     def nonlinear_oscillator(
         dimension: int = 10, z: float = 0.05
     ) -> Callable[[npt.ArrayLike], float | npt.NDArray[np.float64]]:
-        """Compatibility wrapper for nonlinear oscillator benchmark."""
+        """Compatibility wrapper for nonlinear oscillator benchmark.
+
+        .. warning::
+
+           Delegates to :meth:`nonlinear_oscillator_simplified` and shares its
+           defect: the failure region is unreachable, so this returns a
+           probability of zero for any estimator.
+        """
         return BenchmarkProblems.nonlinear_oscillator_simplified(d=dimension, z=z)
 
     @staticmethod

--- a/tests/test_benchmark_ground_truth.py
+++ b/tests/test_benchmark_ground_truth.py
@@ -1,0 +1,151 @@
+"""Benchmark problems checked against crude Monte Carlo.
+
+None of these have closed-form solutions, so the reference values below come
+from crude Monte Carlo over 2e7 standard-normal samples. That is the same
+method a user would reach for, run at a sample count the estimator is meant to
+make unnecessary, which makes it an independent check rather than a restatement
+of the implementation.
+
+    problem                          failures / 2e7      pf        rel. s.e.
+    four_mode_series_system                   1163    5.815e-05      2.9%
+    three_mode_problem                       69490    3.475e-03      0.4%
+    two_mode_opposite_directions             53800    2.690e-03      0.4%
+    nakagami_ratio_problem                 1037533    5.188e-02      0.1%
+
+An earlier comment in the test suite put the four-mode reference at 1.22e-5,
+which does not match this problem at its default z=3.8.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from safe_ice import SafeICE
+from safe_ice.problems.benchmarks import BenchmarkProblems
+
+# (name, factory, dimension, reference pf, relative standard error of the
+# reference). The tolerance below is far wider than the reference error, so the
+# latter is recorded for context rather than used arithmetically.
+GROUND_TRUTH = [
+    (
+        "four_mode_series_system",
+        BenchmarkProblems.four_mode_series_system,
+        2,
+        5.815e-05,
+    ),
+    ("three_mode_problem", BenchmarkProblems.three_mode_problem, 2, 3.475e-03),
+    (
+        "two_mode_opposite_directions",
+        BenchmarkProblems.two_mode_opposite_directions,
+        2,
+        2.690e-03,
+    ),
+    ("nakagami_ratio_problem", BenchmarkProblems.nakagami_ratio_problem, 2, 5.188e-02),
+]
+
+
+class TestAgainstMonteCarlo:
+    @pytest.mark.slow
+    @pytest.mark.parametrize(("name", "factory", "d", "reference"), GROUND_TRUTH)
+    def test_estimate_matches_reference(
+        self, name: str, factory, d: int, reference: float
+    ) -> None:
+        """The estimate should sit on the Monte Carlo value, not merely near it."""
+        limit_state = factory()
+
+        estimates = []
+        for s in range(6):
+            ice = SafeICE(
+                limit_state_function=limit_state,
+                dimension=d,
+                N=1000,
+                max_iterations=15,
+                random_state=s,
+            )
+            pf, _ = ice.run(verbose=False)
+            estimates.append(pf)
+
+        median = float(np.median(estimates))
+        assert reference / 3 < median < reference * 3, (
+            f"{name}: median {median:.3e} against reference {reference:.3e}; "
+            f"estimates {estimates}"
+        )
+
+    @pytest.mark.parametrize(("name", "factory", "d", "reference"), GROUND_TRUTH)
+    def test_reference_problems_have_a_reachable_failure_region(
+        self, name: str, factory, d: int, reference: float, rng
+    ) -> None:
+        """Crude sampling must find failures at roughly the reference rate.
+
+        Guards the reference values themselves: if a problem definition changes,
+        this fails rather than the estimate silently being compared against a
+        stale number.
+        """
+        limit_state = factory()
+        u = rng.standard_normal((200_000, d))
+        g = np.asarray(limit_state(u)).reshape(-1)
+        observed = float((g <= 0).mean())
+
+        if reference > 1e-3:
+            # Frequent enough to measure directly at this sample count.
+            assert reference / 3 < observed < reference * 3, (
+                f"{name}: observed {observed:.3e} against reference {reference:.3e}"
+            )
+        else:
+            # Too rare for 2e5 samples to pin down; only require that the
+            # failure region is reachable at all.
+            assert observed < 1e-2, f"{name}: observed {observed:.3e}, far too common"
+
+
+class TestNonlinearOscillator:
+    """The oscillator benchmark cannot fail, and so measures nothing.
+
+    Its displacement is computed as force_rms / (k * (1 - alpha)) with
+    k = 5e6, giving values around 4e-7 against a threshold of z = 0.05. Reaching
+    the threshold needs ||u|| of about 7.3e5, where the norm of a 10-dimensional
+    standard normal averages 3.1. Crude Monte Carlo over 2e7 samples finds zero
+    failures, and the CLI's `safe-ice benchmark oscillator` reports exactly 0.
+
+    The scaling is inconsistent by a factor of roughly 1e5. Reconstructing the
+    intended formulation needs the source paper, so the defect is recorded here
+    rather than guessed at.
+    """
+
+    def test_failure_region_is_unreachable(self, rng) -> None:
+        """Records the defect. Delete this test once the problem is fixed."""
+        limit_state = BenchmarkProblems.nonlinear_oscillator_simplified()
+        u = rng.standard_normal((50_000, 10))
+        g = np.asarray(limit_state(u)).reshape(-1)
+
+        # Every value sits just under the threshold, varying only at ~1e-7.
+        assert float(g.min()) > 0.0499
+        assert float((g <= 0).mean()) == 0.0
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason=(
+            "The nonlinear oscillator cannot fail: displacement is ~4e-7 "
+            "against a threshold of 0.05, so ||u|| of about 7.3e5 would be "
+            "needed where chi_10 averages 3.1. Crude Monte Carlo over 2e7 "
+            "samples finds no failures. Fixing the scaling requires the source "
+            "paper. Remove this marker once the problem is usable."
+        ),
+    )
+    def test_should_be_a_usable_rare_event_benchmark(self, rng) -> None:
+        """What the problem ought to do: fail sometimes, rarely."""
+        limit_state = BenchmarkProblems.nonlinear_oscillator_simplified()
+        u = rng.standard_normal((200_000, 10))
+        g = np.asarray(limit_state(u)).reshape(-1)
+
+        observed = float((g <= 0).mean())
+        assert 0.0 < observed < 1e-2, f"observed failure rate {observed:.3e}"
+
+    def test_wrapper_delegates_to_the_simplified_form(self, rng) -> None:
+        """nonlinear_oscillator is a thin wrapper, so it shares the defect."""
+        u = rng.standard_normal((1000, 10))
+        wrapper = np.asarray(BenchmarkProblems.nonlinear_oscillator()(u)).reshape(-1)
+        direct = np.asarray(
+            BenchmarkProblems.nonlinear_oscillator_simplified()(u)
+        ).reshape(-1)
+        assert np.allclose(wrapper, direct)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -66,7 +66,9 @@ class TestBenchmarkListing:
 class TestBenchmarkRun:
     @pytest.mark.parametrize("problem", ["four-mode", "three-mode", "two-mode"])
     def test_runs_and_reports_a_probability(self, problem: str, capsys) -> None:
-        assert main(["benchmark", problem, "--samples", "200", "--iterations", "2"]) == 0
+        assert (
+            main(["benchmark", problem, "--samples", "200", "--iterations", "2"]) == 0
+        )
         out = capsys.readouterr().out
         assert "Estimated failure probability" in out
         assert "Relative error" in out

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,10 +12,25 @@ fails here rather than being printed to a user as fact.
 
 from __future__ import annotations
 
+import re
+
 import pytest
 
 from safe_ice import __version__
 from safe_ice.cli import main, run_benchmark
+
+_ANSI = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def plain(text: str) -> str:
+    """Strip ANSI colour codes.
+
+    Python 3.14 colourises argparse help output, which splits `usage: safe-ice`
+    across escape sequences. Whether it does so also depends on the terminal and
+    on NO_COLOR/FORCE_COLOR, so the tests compare the uncoloured text rather
+    than depending on the environment.
+    """
+    return _ANSI.sub("", text)
 
 
 class TestVersion:
@@ -25,21 +40,21 @@ class TestVersion:
             main(["--version"])
         assert excinfo.value.code == 0
 
-        out = capsys.readouterr().out
+        out = plain(capsys.readouterr().out)
         assert __version__ in out
 
 
 class TestHelp:
     def test_no_command_prints_help(self, capsys) -> None:
         assert main([]) == 0
-        out = capsys.readouterr().out
+        out = plain(capsys.readouterr().out)
         assert "usage: safe-ice" in out
         assert "demo" in out
 
     def test_epilogue_has_no_placeholder_url(self, capsys) -> None:
         """The help text used to point at a `your-username` placeholder."""
         assert main([]) == 0
-        out = capsys.readouterr().out
+        out = plain(capsys.readouterr().out)
         assert "your-username" not in out
         assert "DiogoRibeiro7/adaptive-importance-sampling-ice" in out
 
@@ -47,18 +62,18 @@ class TestHelp:
 class TestBenchmarkListing:
     def test_lists_the_available_problems(self, capsys) -> None:
         assert main(["benchmark", "--list"]) == 0
-        out = capsys.readouterr().out
+        out = plain(capsys.readouterr().out)
         for name in ("four-mode", "three-mode", "two-mode"):
             assert name in out
 
     def test_does_not_offer_the_oscillator(self, capsys) -> None:
         """It cannot fail, so it always reported a probability of exactly 0."""
         assert main(["benchmark", "--list"]) == 0
-        assert "oscillator" not in capsys.readouterr().out
+        assert "oscillator" not in plain(capsys.readouterr().out)
 
     def test_unknown_problem_is_reported(self, capsys) -> None:
         assert main(["benchmark", "not-a-problem"]) == 0
-        out = capsys.readouterr().out
+        out = plain(capsys.readouterr().out)
         assert "Unknown problem" in out
         assert "four-mode" in out  # still shows what is available
 
@@ -69,7 +84,7 @@ class TestBenchmarkRun:
         assert (
             main(["benchmark", problem, "--samples", "200", "--iterations", "2"]) == 0
         )
-        out = capsys.readouterr().out
+        out = plain(capsys.readouterr().out)
         assert "Estimated failure probability" in out
         assert "Relative error" in out
 
@@ -86,7 +101,7 @@ class TestBenchmarkRun:
         }
         for problem, reference in expected.items():
             run_benchmark(problem, n_samples=200, max_iterations=2)
-            out = capsys.readouterr().out
+            out = plain(capsys.readouterr().out)
             assert f"{reference:.2e}" in out, f"{problem}: reference not printed"
 
 
@@ -94,7 +109,7 @@ class TestDemo:
     @pytest.mark.slow
     def test_demo_runs(self, capsys) -> None:
         assert main(["demo"]) == 0
-        out = capsys.readouterr().out
+        out = plain(capsys.readouterr().out)
         assert "Safe-ICE Algorithm Demonstration" in out
         assert "Estimated failure probability" in out
 
@@ -103,4 +118,4 @@ class TestAnalyze:
     def test_analyze_is_a_placeholder(self, capsys) -> None:
         """Records that the subcommand is not implemented yet."""
         assert main(["analyze"]) == 0
-        assert "coming soon" in capsys.readouterr().out
+        assert "coming soon" in plain(capsys.readouterr().out)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,104 @@
+"""Tests for the command-line interface.
+
+The CLI had no test coverage at all, and accumulated two user-facing defects
+because of it: it advertised a benchmark problem that cannot fail and always
+reported a probability of zero, and it reported a hard-coded version string that
+drifted from the package's own.
+
+These tests exercise each subcommand and pin the reference probabilities to the
+Monte Carlo values in ``test_benchmark_ground_truth.py``, so a stale number
+fails here rather than being printed to a user as fact.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from safe_ice import __version__
+from safe_ice.cli import main, run_benchmark
+
+
+class TestVersion:
+    def test_reports_the_package_version(self, capsys) -> None:
+        """--version must track the package, not a hard-coded string."""
+        with pytest.raises(SystemExit) as excinfo:
+            main(["--version"])
+        assert excinfo.value.code == 0
+
+        out = capsys.readouterr().out
+        assert __version__ in out
+
+
+class TestHelp:
+    def test_no_command_prints_help(self, capsys) -> None:
+        assert main([]) == 0
+        out = capsys.readouterr().out
+        assert "usage: safe-ice" in out
+        assert "demo" in out
+
+    def test_epilogue_has_no_placeholder_url(self, capsys) -> None:
+        """The help text used to point at a `your-username` placeholder."""
+        assert main([]) == 0
+        out = capsys.readouterr().out
+        assert "your-username" not in out
+        assert "DiogoRibeiro7/adaptive-importance-sampling-ice" in out
+
+
+class TestBenchmarkListing:
+    def test_lists_the_available_problems(self, capsys) -> None:
+        assert main(["benchmark", "--list"]) == 0
+        out = capsys.readouterr().out
+        for name in ("four-mode", "three-mode", "two-mode"):
+            assert name in out
+
+    def test_does_not_offer_the_oscillator(self, capsys) -> None:
+        """It cannot fail, so it always reported a probability of exactly 0."""
+        assert main(["benchmark", "--list"]) == 0
+        assert "oscillator" not in capsys.readouterr().out
+
+    def test_unknown_problem_is_reported(self, capsys) -> None:
+        assert main(["benchmark", "not-a-problem"]) == 0
+        out = capsys.readouterr().out
+        assert "Unknown problem" in out
+        assert "four-mode" in out  # still shows what is available
+
+
+class TestBenchmarkRun:
+    @pytest.mark.parametrize("problem", ["four-mode", "three-mode", "two-mode"])
+    def test_runs_and_reports_a_probability(self, problem: str, capsys) -> None:
+        assert main(["benchmark", problem, "--samples", "200", "--iterations", "2"]) == 0
+        out = capsys.readouterr().out
+        assert "Estimated failure probability" in out
+        assert "Relative error" in out
+
+    def test_reference_values_match_monte_carlo_ground_truth(self, capsys) -> None:
+        """The printed references must be the measured ones.
+
+        four-mode was quoted as 1.22e-5 against a measured 5.8e-5, and
+        three-mode as 2.3e-3 against 3.5e-3.
+        """
+        expected = {
+            "four-mode": 5.815e-05,
+            "three-mode": 3.475e-03,
+            "two-mode": 2.690e-03,
+        }
+        for problem, reference in expected.items():
+            run_benchmark(problem, n_samples=200, max_iterations=2)
+            out = capsys.readouterr().out
+            assert f"{reference:.2e}" in out, f"{problem}: reference not printed"
+
+
+class TestDemo:
+    @pytest.mark.slow
+    def test_demo_runs(self, capsys) -> None:
+        assert main(["demo"]) == 0
+        out = capsys.readouterr().out
+        assert "Safe-ICE Algorithm Demonstration" in out
+        assert "Estimated failure probability" in out
+
+
+class TestAnalyze:
+    def test_analyze_is_a_placeholder(self, capsys) -> None:
+        """Records that the subcommand is not implemented yet."""
+        assert main(["analyze"]) == 0
+        assert "coming soon" in capsys.readouterr().out


### PR DESCRIPTION
Every defect found in this codebase was found by comparing against an independent reference. Only `four_mode_series_system` had ever been checked that way, so this establishes ground truth for the rest — crude Monte Carlo over 2e7 standard-normal samples, the method a user would reach for, at a sample count the estimator is meant to make unnecessary.

| Problem | failures / 2e7 | `P_F` | estimator ratio | seeds within 2× |
| --- | --- | --- | --- | --- |
| `four_mode_series_system` | 1163 | 5.815e-05 | 1.05 | 8/8 |
| `three_mode_problem` | 69490 | 3.475e-03 | 1.03 | 8/8 |
| `two_mode_opposite_directions` | 53800 | 2.690e-03 | 1.05 | 8/8 |
| `nakagami_ratio_problem` | 1037533 | 5.188e-02 | 0.98 | 8/8 |

That is an end-to-end check on everything fixed recently.

## One benchmark cannot fail

The two oscillator problems returned **zero failures in 2e7 samples**. Not a rare event — an impossible one.

Displacement is `force_rms / (k * (1 - alpha))` with `k = 5e6`, giving ~`4e-7` against a threshold of `z = 0.05`. Reaching the threshold needs `‖u‖ ≈ 7.3e5`, where a 10-dimensional standard normal averages `3.1`. The failure probability is not representable in float64. The scaling is inconsistent by a factor of ~1e5.

I can't reconstruct the intended formulation without the source paper, so rather than guess at the physics:

- the defect is documented on both problem functions,
- a strict `xfail` asserts what the problem *ought* to do, so it announces itself when fixed,
- `safe-ice benchmark oscillator` — which reported `pf = 0.000000e+00` with `CV = inf` — is replaced by `two-mode`.

## Also

Two CLI reference values were wrong against these measurements: four-mode quoted `1.22e-5` against a measured `5.8e-5`, three-mode `2.3e-3` against `3.5e-3`. The epilogue pointed at a `your-username` placeholder URL.

A second test guards the reference values themselves — if a problem definition changes, it fails rather than the estimate being silently compared against a stale number.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validates benchmark problems against an independent Monte Carlo ground truth and removes the broken oscillator benchmark from the CLI. Previously, `safe-ice benchmark oscillator` reported 0 with stale references; now `two-mode` replaces it, reference values match measurements, the help URL is correct, `--version` tracks the package, and CLI help tests are stable across Python versions.

- Ground truth and problems: add `tests/test_benchmark_ground_truth.py` (2e7-sample MC) for four benchmarks; assert estimator medians; guard references by direct sampling; document the oscillator defect and record a strict xfail; keep the wrapper aligned with the simplified form.
- CLI and docs: remove `oscillator`, add `two-mode`; fix printed reference `P_F` for `four-mode` and `three-mode`; correct the demo reference and help epilogue URL; README lists available problems with measured `P_F`; add `tests/test_cli.py` to cover subcommands, assert references, absence of `oscillator`, correct URL, `--version` equals `__version__`; strip ANSI color codes in help output in tests to avoid Python 3.14-specific failures.

**Required changes**
- Scripts using `safe-ice benchmark oscillator` must switch to `safe-ice benchmark two-mode`.

<sup>Written for commit 6f90ce1b000ef85ee2ef0235dac0301347b8fc24. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/adaptive-importance-sampling/pull/86?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

