### PR TITLE
Drop the changelog link to the untagged 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -273,7 +273,7 @@ on a linear limit state -- were both symptoms of the bugs fixed in this
 release, and no longer occur. The four-mode reference itself was wrong: it was
 quoted as `1.22e-5` against a measured `5.815e-05`.
 
-## [0.1.0] - 2025-01-27
+## 0.1.0 - 2025-01-27
 
 ### Added
 
@@ -286,4 +286,3 @@ quoted as `1.22e-5` against a measured `5.815e-05`.
 
 [Unreleased]: https://github.com/DiogoRibeiro7/adaptive-importance-sampling-ice/compare/v0.2.0...HEAD
 [0.2.0]: https://github.com/DiogoRibeiro7/adaptive-importance-sampling-ice/releases/tag/v0.2.0
-[0.1.0]: https://github.com/DiogoRibeiro7/adaptive-importance-sampling-ice/releases/tag/v0.1.0


### PR DESCRIPTION
0.1.0 was never tagged, so `[0.1.0]: .../releases/tag/v0.1.0` pointed at a 404. Removes the link definition and de-brackets the heading so it is not left as a dangling reference.

The `[Unreleased]` and `[0.2.0]` links both resolve — v0.2.0 exists.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the broken `0.1.0` changelog link and converts its heading to plain text, because v0.1.0 was never tagged. This avoids a 404 and a dangling reference; previous `[0.1.0]` now reads as `0.1.0`.

- Drops the `[0.1.0]: …/releases/tag/v0.1.0` link definition; `[Unreleased]` and `[0.2.0]` remain valid.
- Docs-only; no runtime behavior or release artifacts change.

<sup>Written for commit ab78b72b8f13e39da1b2b07c71149ece3c98861b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/adaptive-importance-sampling/pull/89?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

