### PR TITLE
Clamp the returned failure probability to [0, 1]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`run()` now returns a value constrained to `[0, 1]`.** The estimator is
+  unbiased but unconstrained -- the weights `p(u)/q_safe(u)` are a ratio of
+  densities and nothing bounds them by 1 -- so a single run could return a
+  value above 1. Callers expect a probability, so the returned value is
+  clamped.
+
+  Clamping truncates overshoots without touching undershoots, which biases the
+  mean downwards: on a limit state that fails everywhere, the mean over 40 runs
+  goes from 1.0163 raw to 0.8811 clamped. It never fires in the rare-event
+  regime this package is for, where estimates sit two to four orders of
+  magnitude below 1.
+
+  An estimate above 1 is therefore treated as a diagnostic rather than a
+  nuisance: it means the proposal is not covering the target and the weights
+  have gone degenerate, so a few samples carry the whole sum. Returning `1.0`
+  silently would present such a run as converged. The raw value is kept in
+  `results["pf_unclamped"]` and a `RuntimeWarning` explains the cause.
+
+  `test_certain_failure` was a non-strict `xfail` because of this; it is now a
+  real test.
+
 ## [0.2.0] - 2026-08-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ vectorised function.
 
 | Key                   | Type             | Meaning                                           |
 | --------------------- | ---------------- | ------------------------------------------------- |
+| `pf_unclamped`        | `float`          | The estimate before clamping to `[0, 1]`          |
 | `iterations`          | `list[dict]`     | One record per iteration (`K`, `sigma`, `lambda`) |
 | `final_components`    | `int`            | Mixture components remaining at convergence       |
 | `final_samples`       | `ndarray (n, d)` | Samples from the final proposal                   |
@@ -284,10 +285,17 @@ proposal component numerically and fails if the Jacobian is dropped again.
 
 ### Remaining limitations
 
-- **Estimates are not constrained to `[0, 1]`.** The estimator is unbiased but
-  unconstrained, so for a limit state that fails everywhere (true probability
-  exactly 1) it scatters around 1 and can land slightly above. Clamping would
-  fix it, but that is a modelling decision rather than a bug.
+- **Estimates are clamped to `[0, 1]`, and an overshoot warns.** The estimator
+  is unbiased but unconstrained: the weights are a ratio of densities and
+  nothing bounds them by 1, so on a limit state that fails everywhere (true
+  probability exactly 1) a run can land above it. The returned value is
+  clamped so it is always a probability. Clamping truncates overshoots without
+  touching undershoots, which biases the mean down by about 12% in that
+  degenerate case, but it never fires on a rare-event problem: estimates there
+  sit two to four orders of magnitude below 1. An overshoot means the proposal
+  is not covering the target and the weights have gone degenerate, so it is
+  reported rather than hidden -- `results["pf_unclamped"]` holds the raw value
+  and a `RuntimeWarning` explains it.
 - **High dimensions now work.** The apparent ceiling above `d=20` was a fixed
   `1e-15` floor applied to the proposal density before dividing it into the
   prior. Densities on `R^d` shrink geometrically with dimension, so that floor

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,16 +15,16 @@ The estimator now agrees with closed-form answers to within a few percent from
 problems. See [Accuracy](README.md#accuracy) for the measured numbers and
 [CHANGELOG.md](CHANGELOG.md) for the full list.
 
+### Decided: estimates are clamped to `[0, 1]`
+
+Returned values are clamped, so `run()` always yields a probability. The raw
+estimate stays in `results["pf_unclamped"]` and an overshoot raises a
+`RuntimeWarning`, because a value above 1 means the proposal is not covering
+the target and the run should be treated as unconverged rather than as a
+probability of 1. Clamping never fires in the rare-event regime, where
+estimates sit two to four orders of magnitude below 1.
+
 ## Next
-
-### Decide whether estimates should be clamped to `[0, 1]`
-
-The estimator is unbiased but unconstrained, so on a limit state that fails
-everywhere (true probability exactly 1) it scatters around 1 and can land above
-it. Clamping would make every return value a valid probability, at the cost of
-making the estimator biased. This is a modelling decision rather than a bug, so
-it is recorded as an `xfail` on `test_certain_failure` rather than silently
-resolved either way.
 
 ### Fix or remove the nonlinear oscillator benchmark
 

--- a/safe_ice/core/safe_ice.py
+++ b/safe_ice/core/safe_ice.py
@@ -226,9 +226,10 @@ class SafeICE:
         # --- Final estimate via importance sampling (not crude MC) ---
         final_samples: NDArrayF = self._generate_safe_mixture_samples(phi_t, lambda_t)
         final_g_values: NDArrayF = self._evaluate_limit_state(final_samples)
-        pf_estimate: float = self._estimate_failure_probability(
+        pf_unclamped: float = self._estimate_failure_probability(
             final_samples, final_g_values, phi_t, lambda_t
         )
+        pf_estimate: float = self._clamp_to_probability(pf_unclamped)
 
         self.history["pf_estimates"].append(float(pf_estimate))
 
@@ -238,6 +239,7 @@ class SafeICE:
 
         results: dict[str, Any] = {
             "failure_probability": float(pf_estimate),
+            "pf_unclamped": float(pf_unclamped),
             "iterations": iteration_records,
             "final_components": int(phi_t.K),
             "final_sigma": float(sigma_t),
@@ -610,6 +612,54 @@ class SafeICE:
         # Monte Carlo estimate
         pf_estimate: float = float(np.mean(indicators * importance_weights))
         return pf_estimate
+
+    @staticmethod
+    def _clamp_to_probability(pf_estimate: float) -> float:
+        """Constrain the estimate to [0, 1], warning if that changed anything.
+
+        The importance-sampling estimator is unbiased but unconstrained: the
+        weights p(u)/q_safe(u) are a ratio of densities and nothing bounds them
+        by 1, so a single run can return a value above 1 even though the mean
+        over runs is exactly right. Callers expect a probability, so the
+        returned value is clamped.
+
+        Clamping is not free in principle -- truncating the overshoots without
+        touching the undershoots biases the mean downwards, by about 12% on a
+        limit state that fails everywhere. In the rare-event regime this
+        package is for it never fires at all: estimates there sit two to four
+        orders of magnitude below 1.
+
+        That makes an estimate above 1 a useful signal rather than a nuisance.
+        It means the proposal is not covering the target, so the weights have
+        gone degenerate and a few samples are carrying the whole sum. Silently
+        returning 1.0 would present such a run as a converged one, so the raw
+        value is kept in ``results["pf_unclamped"]`` and a warning is issued.
+        """
+        if 0.0 <= pf_estimate <= 1.0:
+            return float(pf_estimate)
+
+        clamped = min(max(pf_estimate, 0.0), 1.0)
+        if pf_estimate > 1.0:
+            detail = (
+                "A value above 1 means the proposal does not cover the target: "
+                "the importance weights are degenerate and a few samples carry "
+                "the whole estimate. Treat the run as unconverged rather than "
+                "as a probability of 1."
+            )
+        else:
+            # Unreachable: the estimate is a mean of an indicator times a
+            # non-negative weight. Kept so a future change cannot make a
+            # negative probability pass silently.
+            detail = "A negative value indicates a bug in the weight computation."
+
+        warnings.warn(
+            f"Failure probability estimate {pf_estimate:.6g} is outside [0, 1] "
+            f"and has been clamped to {clamped:g}. {detail} The raw value is "
+            "available as results['pf_unclamped'].",
+            RuntimeWarning,
+            stacklevel=3,
+        )
+        return float(clamped)
 
     def _evaluate_prior_density(self, samples: NDArrayF) -> NDArrayF:
         """Evaluate standard Gaussian prior density p(u) = N(0, I_d)."""

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import time
+import warnings
 
 import numpy as np
 import pytest
@@ -401,34 +402,58 @@ class TestEdgeCases:
         # Should give very small probability
         assert pf < 1e-6
 
-    @pytest.mark.xfail(
-        strict=False,
-        reason=(
-            "Degenerate problem: the limit state fails everywhere, so the "
-            "true probability is exactly 1. The importance-sampling estimator "
-            "is unbiased but unconstrained, so with N=100 it scatters around "
-            "1 and lands either side of the 0.99 threshold; across seeds the "
-            "median is about 1.07. Not strict, because which side it falls on "
-            "depends on the platform and NumPy version. Clamping the estimate "
-            "to [0, 1] would fix this, but that is a modelling decision rather "
-            "than a bug."
-        ),
-    )
-    def test_certain_failure(self, seed):
-        """Test with certain failure (large failure probability)."""
+    def test_certain_failure(self):
+        """Test with certain failure (large failure probability).
+
+        This was an ``xfail`` asserting ``pf > 0.99`` on a single seed. The
+        limit state fails everywhere, so the true probability is exactly 1, but
+        this is the estimator's worst case: with no failure boundary anywhere
+        there is nothing for the smoothing parameter to concentrate on, and the
+        proposal never sharpens. Over 200 seeds at N=100 the estimate ranges
+        from 0.20 to 1.00 with a median of 1.00, so no single run clears any
+        useful lower threshold reliably.
+
+        What does hold is the upper bound, which is the clamp's guarantee, and
+        the median over seeds. Both are asserted below.
+        """
 
         def certain_failure_limit_state(u):
             return -1.0 - np.linalg.norm(u, axis=-1)  # Always negative
 
-        ice = SafeICE(
-            limit_state_function=certain_failure_limit_state,
-            dimension=2,
-            N=100,
-            max_iterations=2,
-            random_state=seed,
-        )
+        estimates = []
+        clamped_runs = 0
 
-        pf, _results = ice.run(verbose=False)
+        for s in range(9):
+            ice = SafeICE(
+                limit_state_function=certain_failure_limit_state,
+                dimension=2,
+                N=100,
+                max_iterations=2,
+                random_state=s,
+            )
+            # Overshooting 1 is expected here and warns; capture rather than
+            # let the suite's filterwarnings=error turn it into a failure.
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                pf, results = ice.run(verbose=False)
 
-        # Should give probability close to 1
-        assert pf > 0.99
+            # The returned value is always a probability, whatever the run did.
+            assert 0.0 <= pf <= 1.0, f"seed {s} returned {pf}"
+            # The unclamped estimate is kept so a degenerate run stays visible.
+            assert results["pf_unclamped"] >= pf
+
+            if results["pf_unclamped"] > 1.0:
+                clamped_runs += 1
+                assert pf == 1.0
+                assert any("clamped" in str(w.message) for w in caught), (
+                    f"seed {s} clamped {results['pf_unclamped']} silently"
+                )
+            else:
+                assert pf == results["pf_unclamped"]
+                assert not any("clamped" in str(w.message) for w in caught)
+
+            estimates.append(pf)
+
+        assert float(np.median(estimates)) > 0.9, f"estimates: {estimates}"
+        # If none overshot, the clamp path above was never exercised.
+        assert clamped_runs > 0, "expected at least one run above 1 at N=100"

--- a/tests/test_probability_clamp.py
+++ b/tests/test_probability_clamp.py
@@ -1,0 +1,131 @@
+"""The returned failure probability must be a probability.
+
+The importance-sampling estimator is unbiased but unconstrained: the weights
+``p(u) / q_safe(u)`` are a ratio of densities and nothing bounds them by 1, so
+a single run can return a value above 1 even though the mean over runs is
+exactly right. Callers expect a probability, so the returned value is clamped.
+
+Clamping is not free in principle. Truncating the overshoots without touching
+the undershoots biases the mean downwards -- by about 12% on a limit state that
+fails everywhere, where the estimator scatters either side of a true value of
+1. It is free in practice for the problems this package exists for: rare-event
+estimates sit two to four orders of magnitude below 1 and never reach the
+clamp at all.
+
+That makes an overshoot worth surfacing rather than hiding. It means the
+proposal is not covering the target, so the weights are degenerate and a few
+samples carry the whole sum. Returning 1.0 silently would present such a run as
+a converged one, so the raw value stays in ``results["pf_unclamped"]`` and a
+warning is issued.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import numpy as np
+import pytest
+
+from safe_ice import AdaptiveSafeICE, OptimizedSafeICE, SafeICE
+from safe_ice.problems.benchmarks import BenchmarkProblems
+
+
+def always_fails(u: np.ndarray) -> np.ndarray:
+    """True failure probability of exactly 1, the estimator's worst case."""
+    return np.full(u.shape[0], -1.0)
+
+
+class TestTheClampItself:
+    """Unit-level behaviour of the bound, independent of any run."""
+
+    @pytest.mark.parametrize("value", [0.0, 1e-9, 0.5, 1.0])
+    def test_values_inside_the_range_pass_through(self, value: float) -> None:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            assert SafeICE._clamp_to_probability(value) == value
+
+    @pytest.mark.parametrize("value", [1.0000001, 1.07, 4.15])
+    def test_values_above_one_are_clamped_and_warned(self, value: float) -> None:
+        with pytest.warns(RuntimeWarning, match="clamped"):
+            assert SafeICE._clamp_to_probability(value) == 1.0
+
+    def test_the_warning_explains_the_diagnosis(self) -> None:
+        """A bare "clamped" message would not tell a user what went wrong."""
+        with pytest.warns(RuntimeWarning) as record:
+            SafeICE._clamp_to_probability(2.5)
+
+        message = str(record[0].message)
+        assert "does not cover the target" in message
+        assert "degenerate" in message
+        assert "pf_unclamped" in message
+
+    def test_negative_values_are_clamped_too(self) -> None:
+        """Unreachable in practice, but must not pass through if it happens."""
+        with pytest.warns(RuntimeWarning, match="clamped"):
+            assert SafeICE._clamp_to_probability(-0.5) == 0.0
+
+
+class TestRareEventsAreUnaffected:
+    """The regime the package is for never reaches the clamp."""
+
+    @pytest.mark.slow
+    @pytest.mark.parametrize("seed", range(4))
+    def test_estimates_are_far_below_one(self, seed: int) -> None:
+        with warnings.catch_warnings():
+            # Any clamp warning here would mean the estimator is degenerate on
+            # an ordinary rare-event problem, which is a failure, not a pass.
+            warnings.simplefilter("error")
+            pf, results = SafeICE(
+                limit_state_function=BenchmarkProblems.four_mode_series_system(),
+                dimension=2,
+                N=1000,
+                max_iterations=10,
+                random_state=seed,
+            ).run(verbose=False)
+
+        assert pf < 1e-3
+        assert pf == results["pf_unclamped"], "clamping altered a rare-event estimate"
+
+
+class TestEveryVariantClamps:
+    """OptimizedSafeICE and AdaptiveSafeICE inherit run(), so they must agree."""
+
+    @pytest.mark.parametrize(
+        "cls", [SafeICE, OptimizedSafeICE, AdaptiveSafeICE], ids=lambda c: c.__name__
+    )
+    def test_returned_value_is_a_probability(self, cls) -> None:
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            pf, results = cls(
+                limit_state_function=always_fails,
+                dimension=2,
+                N=100,
+                max_iterations=2,
+                random_state=2,
+            ).run(verbose=False)
+
+        assert 0.0 <= pf <= 1.0, f"{cls.__name__} returned {pf}"
+        assert "pf_unclamped" in results, f"{cls.__name__} dropped the raw value"
+        assert results["pf_unclamped"] >= pf
+
+
+class TestTheRawValueSurvives:
+    """The point of option three: nothing is hidden."""
+
+    def test_unclamped_value_is_reported_unchanged(self) -> None:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            pf, results = SafeICE(
+                limit_state_function=always_fails,
+                dimension=2,
+                N=100,
+                max_iterations=2,
+                random_state=10,
+            ).run(verbose=False)
+
+        raw = results["pf_unclamped"]
+        assert raw > 1.0, "this seed is chosen because it overshoots"
+        assert pf == 1.0
+        assert any("clamped" in str(w.message) for w in caught)
+        # The raw value is the diagnostic; it must not itself be clamped.
+        assert raw == pytest.approx(1.159, abs=0.01)

--- a/tests/test_safe_ice.py
+++ b/tests/test_safe_ice.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import warnings
+
 import numpy as np
 import pytest
 
@@ -330,10 +332,15 @@ class TestErrorHandling:
             random_state=seed,
         )
 
-        pf, _results = ice.run(verbose=False)
+        # True P_f is 1.0, which is the estimator's worst case: with no failure
+        # boundary anywhere there is nothing for sigma to concentrate on, so the
+        # raw estimate scatters either side of 1 and an overshoot warns.
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            pf, results = ice.run(verbose=False)
 
-        # Should give high probability (IS estimate may be < 1 due to
-        # weight mismatch when the true P_f is 1.0)
+        assert 0.0 <= pf <= 1.0
+        assert results["pf_unclamped"] >= pf
         assert pf > 0.5
 
     def test_no_samples_fail(self, seed):


### PR DESCRIPTION
`run()` could return a value above 1. The estimator is unbiased but unconstrained — the weights `p(u)/q_safe(u)` are a ratio of densities and nothing bounds them by 1 — so a single run can overshoot even though the mean over runs is exactly right. Callers expect a probability, so the returned value is now clamped.

**The cost, measured.** Clamping truncates overshoots without touching undershoots, so it biases the mean down. On a limit state that fails everywhere (true probability exactly 1), over 40 runs:

| | mean |
| --- | --- |
| raw | 1.0163 |
| clamped | 0.8811 |

**Why it is free in practice.** That bias only appears when the true probability is near 1, which is the one regime this package is not for. On rare-event problems the clamp never activates:

| Problem | max over 12 runs | clamp fires |
| --- | --- | --- |
| four-mode (pf 5.8e-05) | 6.85e-05 | 0/12 |
| sphere d=10 (pf 5.3e-03) | 5.55e-03 | 0/12 |
| sphere d=50 (pf 3.6e-03) | 3.83e-03 | 0/12 |

**Why it warns rather than clamping silently.** An estimate above 1 means the proposal is not covering the target: the weights have gone degenerate and a few samples carry the whole sum. Silently returning `1.0` would present a broken run as a converged one. So `results["pf_unclamped"]` keeps the raw value and a `RuntimeWarning` states the cause.

Note the lower bound is unreachable — the estimate is a mean of an indicator times a non-negative weight — but it is clamped anyway so a future change cannot make a negative probability pass silently.

`test_certain_failure` was a non-strict `xfail` for exactly this reason. It is now a real test. Its old `pf > 0.99` assertion would not have held even with clamping: over 200 seeds at N=100 the estimate ranges from 0.20 to 1.00, because with no failure boundary anywhere there is nothing for sigma to concentrate on. It now asserts the clamp guarantee per run and the median across seeds.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clamp returned failure probabilities to [0, 1] and surface overshoots as diagnostics. Previously `run()` could return >1; now it returns a probability in `[0, 1]`, stores the raw value in `results["pf_unclamped"]`, and emits a `RuntimeWarning` when clamping.

- Behavior change: `failure_probability` is always clamped; overshoots warn and leave the raw estimate in `results["pf_unclamped"]`. Negative values also clamp (defensive).
- Impact: Clamping biases means downward only when the true probability is near 1; it does not trigger on rare-event problems.
- Migration: If your tests treat warnings as errors, allow the `RuntimeWarning` or assert it where certain-failure cases are exercised. Read `results["pf_unclamped"]` if you need the raw estimate.
- Test/docs: Converted the previous `xfail` into assertions on the clamp and median; added `tests/test_probability_clamp.py`; updated `README`, `CHANGELOG`, and `ROADMAP`. Behavior applies to `SafeICE`, `OptimizedSafeICE`, and `AdaptiveSafeICE`.

<sup>Written for commit 9f6ea4580c2b9549954131ce47db8e133a5d797c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/adaptive-importance-sampling/pull/90?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

