### PR TITLE
Implement the nonlinear oscillator benchmark from the paper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The nonlinear oscillator benchmark now implements the paper's model.** It
+  computed the displacement as `force_rms / (k * (1 - alpha))`, a closed form
+  appearing nowhere in the source and which never integrated the equations of
+  motion. It produced values around `4e-07` against a threshold of `0.05`, so
+  the problem could not fail: crude Monte Carlo over 2e7 samples found zero
+  failures and every estimator returned exactly `0`. It was recorded as a
+  strict `xfail` and withdrawn from the CLI.
+
+  It now integrates the Bouc-Wen hysteretic oscillator of Section 4.3
+  (equations 39-42) with fourth-order Runge-Kutta at `dt = 0.01`, and
+  reproduces Figure 7 of the paper:
+
+  | `z` | this implementation | paper |
+  | --- | --- | --- |
+  | 0.05 | `1.798e-03` | ~`1.5e-03` |
+  | 0.06 | `1.475e-04` | ~`1.2e-04` |
+  | 0.07 | `4.5e-06` | ~`5e-06` |
+
+  Safe-ICE estimates the first at `1.797e-03`, within 1% of the Monte Carlo
+  value, from 1000 samples per iteration against 2e6 for crude Monte Carlo.
+  The benchmark is available from the CLI again.
+
+  The limit-state function now rejects input of the wrong dimension instead of
+  zero-padding it, which had been hiding a test that passed 2-column input to
+  a 10-dimensional problem.
+
+### Removed
+
+- `BenchmarkProblems.nonlinear_oscillator_simplified`. It existed only as the
+  closed-form approximation described above; there is no simplified variant in
+  the paper. Use `nonlinear_oscillator`.
+
 ### Changed
 
 - **`run()` now returns a value constrained to `[0, 1]`.** The estimator is

--- a/README.md
+++ b/README.md
@@ -225,13 +225,12 @@ Reference probabilities, from crude Monte Carlo over 2e7 samples:
 | `three_mode_problem` | `3.5e-3` |
 | `two_mode_opposite_directions` | `2.7e-3` |
 | `nakagami_ratio_problem` | `5.2e-2` |
+| `nonlinear_oscillator` | `1.8e-3` |
 
-> `nonlinear_oscillator` and `nonlinear_oscillator_simplified` **cannot fail as
-> parameterised** and so measure nothing: displacement comes out around `4e-7`
-> against a threshold of `0.05`, needing `‖u‖ ≈ 7.3e5` where a 10-dimensional
-> standard normal averages `3.1`. Any estimator returns `0`. Fixing the scaling
-> needs the source paper, so the defect is documented rather than guessed at;
-> the problems are excluded from the CLI.
+All are 2-dimensional except `nonlinear_oscillator`, which is 10-dimensional
+and takes its threshold from `z` (the paper sweeps `0.05` to `0.08`, giving
+`1.8e-3` down to `1.5e-7`). Its reference comes from 2e6 samples rather than
+2e7, because each evaluation integrates the equations of motion.
 
 ## Accuracy
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -24,18 +24,16 @@ the target and the run should be treated as unconverged rather than as a
 probability of 1. Clamping never fires in the rare-event regime, where
 estimates sit two to four orders of magnitude below 1.
 
+### Done: the nonlinear oscillator benchmark works
+
+It previously computed the displacement in closed form and never integrated the
+equations of motion, so it could not fail and every estimator returned 0. It
+now implements the paper's Bouc-Wen model (equations 39-42) with fourth-order
+Runge-Kutta, and reproduces Figure 7: 1.798e-03 at `z=0.05`, 1.475e-04 at
+`0.06` and 4.5e-06 at `0.07`. Safe-ICE estimates the first to within 1% of the
+Monte Carlo value. It is available from the CLI again.
+
 ## Next
-
-### Fix or remove the nonlinear oscillator benchmark
-
-`nonlinear_oscillator` and `nonlinear_oscillator_simplified` cannot fail as
-parameterised: displacement comes out around `4e-7` against a threshold of
-`0.05`, so reaching failure needs a norm of about `7.3e5` where a
-10-dimensional standard normal averages `3.1`. Crude Monte Carlo over 2e7
-samples finds zero failures. The scaling is inconsistent by roughly `1e5`.
-Reconstructing the intended formulation needs the source paper, so the defect
-is recorded (`test_should_be_a_usable_rare_event_benchmark`, a strict `xfail`)
-rather than guessed at. It has been withdrawn from the CLI in the meantime.
 
 ### Cover the untested modules
 

--- a/safe_ice/cli.py
+++ b/safe_ice/cli.py
@@ -70,12 +70,8 @@ def run_benchmark(
     available: dict[str, tuple[Callable[[], LimitStateFunction], int, float | None]] = {
         "four-mode": (problems.four_mode_series_system, 2, 5.815e-05),
         "three-mode": (problems.three_mode_problem, 2, 3.475e-03),
-        # "oscillator" is deliberately absent. nonlinear_oscillator cannot fail
-        # as parameterised -- displacement is ~4e-7 against a threshold of 0.05
-        # -- so this subcommand reported a failure probability of exactly 0 with
-        # an infinite coefficient of variation. Offering it as a benchmark is
-        # worse than not offering it. See the warning on the problem itself.
         "two-mode": (problems.two_mode_opposite_directions, 2, 2.690e-03),
+        "oscillator": (problems.nonlinear_oscillator, 10, 1.798e-03),
     }
 
     if problem_name is None or problem_name not in available:
@@ -154,7 +150,9 @@ For more information, visit:
     # Benchmark command
     benchmark_parser = subparsers.add_parser("benchmark", help="Run benchmark problems")
     benchmark_parser.add_argument(
-        "problem", nargs="?", help="Problem name (four-mode, three-mode, two-mode)"
+        "problem",
+        nargs="?",
+        help="Problem name (four-mode, three-mode, two-mode, oscillator)",
     )
     benchmark_parser.add_argument(
         "--samples",

--- a/safe_ice/problems/benchmarks.py
+++ b/safe_ice/problems/benchmarks.py
@@ -76,80 +76,168 @@ class BenchmarkProblems:
         return limit_state_function
 
     @staticmethod
-    def nonlinear_oscillator_simplified(
-        d: int = 10, z: float = 0.05
+    def nonlinear_oscillator(
+        dimension: int = 10, z: float = 0.05, t_end: float = 8.0, dt: float = 0.01
     ) -> Callable[[npt.ArrayLike], float | npt.NDArray[np.float64]]:
-        """Simplified nonlinear oscillator problem.
+        r"""Hysteretic single-degree-of-freedom oscillator, Section 4.3.
 
-        .. warning::
+        A Bouc-Wen oscillator (equation 39) driven by white-noise ground
+        acceleration discretised in the frequency domain (equation 41):
 
-           This problem cannot fail as parameterised, so it measures nothing.
-           Displacement is computed as ``force_rms / (k * (1 - alpha))`` with
-           ``k = 5e6``, giving values around ``4e-7`` against a threshold of
-           ``z = 0.05``. Reaching the threshold needs ``||u||`` of about
-           ``7.3e5``, where the norm of a 10-dimensional standard normal
-           averages ``3.1``. Crude Monte Carlo over 2e7 samples finds zero
-           failures, and any estimator will return ``0``.
+        .. math::
 
-           The scaling is inconsistent by a factor of roughly ``1e5``.
-           Reconstructing the intended formulation needs the source paper, so
-           the defect is documented rather than guessed at. See
-           ``tests/test_benchmark_ground_truth.py::TestNonlinearOscillator``.
+            m\ddot{x} + c\dot{x} + k[\alpha x + (1-\alpha) x_y z] = f(t)
+
+        with the hysteretic variable following the Bouc-Wen law (equation 40).
+        The equations of motion are integrated with the classical fourth-order
+        Runge-Kutta method, and the limit state (equation 42) is
+
+        .. math::
+
+            g(u) = z - x(t_{end})
+
+        so failure is a displacement at ``t_end`` exceeding the threshold.
+
+        Parameters
+        ----------
+        dimension:
+            Number of frequency components, which is also the dimension of
+            ``u``. Must be even; the paper uses 10.
+        z:
+            Displacement threshold in metres. The paper varies it from 0.05 to
+            0.08, giving failure probabilities from about 1.8e-03 to 1.5e-07.
+        t_end:
+            Time at which the displacement is compared against ``z``.
+        dt:
+            Runge-Kutta step. The paper uses 0.01 s.
+
+        Notes
+        -----
+        This previously computed the displacement as
+        ``force_rms / (k * (1 - alpha))``, a closed form that appears nowhere
+        in the paper and never integrated the equations of motion. It returned
+        values around 4e-07 against a threshold of 0.05, so the problem could
+        not fail and every estimator returned exactly 0. Crude Monte Carlo over
+        the implementation below gives 1.798e-03 at ``z=0.05``, 1.475e-04 at
+        ``0.06`` and 4.5e-06 at ``0.07``, matching the paper's Figure 7.
         """
+        d = int(dimension)
+        if d < 2 or d % 2 != 0:
+            raise ValueError(
+                f"nonlinear_oscillator needs an even dimension of at least 2, got {d}."
+            )
+
+        # Structural parameters (Section 4.3). SI units throughout.
+        mass = 6e4  # kg
+        stiffness = 5e6  # N/m
+        damping_ratio = 0.05
+        yield_displacement = 0.04  # m
+        alpha = 0.1  # elastic / hysteretic split of the restoring force
+        damping = 2.0 * mass * damping_ratio * float(np.sqrt(stiffness / mass))
+
+        # Bouc-Wen law (equation 40).
+        bw_a, bw_beta, bw_gamma, bw_n = 1.0, 0.5, 0.5, 3
+        # The exact solution satisfies |z| <= (A / (beta + gamma))^(1/n); the
+        # hysteretic variable saturates there. Measured peaks are 0.9264 for
+        # ordinary samples and 0.9993 in the failure region, so enforcing the
+        # bound changes nothing that is sampled. It matters only for extreme
+        # inputs, where discretisation error lets z drift past saturation and
+        # the |z|^3 term then amplifies it until the integration overflows.
+        hyst_bound = (bw_a / (bw_beta + bw_gamma)) ** (1.0 / bw_n)
+
+        # Frequency discretisation of the load (equation 41). The cut-off is
+        # 15*pi, which is exactly the highest retained frequency d/2 * domega.
+        half = d // 2
+        domega = 30.0 * float(np.pi) / d
+        omega = np.arange(1, half + 1, dtype=np.float64) * domega
+        intensity = 0.005  # white-noise intensity S, m^2/s^3
+        sigma = float(np.sqrt(2.0 * intensity * domega))
+
+        # RK4 evaluates the load at t, t + dt/2 and t + dt, so the load is
+        # tabulated once on the half-step grid and reused for every call.
+        n_steps = round(float(t_end) / float(dt))
+        sample_times = np.arange(2 * n_steps + 1, dtype=np.float64) * (float(dt) / 2.0)
+        cos_table = np.cos(np.outer(sample_times, omega))
+        sin_table = np.sin(np.outer(sample_times, omega))
+        force_amplitude = -mass * sigma
 
         def limit_state_function(
             u: npt.ArrayLike,
         ) -> float | npt.NDArray[np.float64]:
-            # Parameters from the paper (kept as floats)
-            k = 5e6  # stiffness
-            alpha = 0.1  # force partition
-            S = 0.005  # white-noise intensity
-
-            # Frequency discretization
-            d_eff = max(int(d), 2)
-            omega_cut = 15.0 * float(np.pi)
-            domega = omega_cut / (d_eff / 2.0)
-
-            # Force amplitude
-            sigma = float(np.sqrt(2.0 * S * domega))
-
-            # Construct force “RMS” proxy from u
             arr, is_single = BenchmarkProblems._as_2d_input(u)
-            if arr.shape[1] < d_eff:
-                padded = np.zeros((arr.shape[0], d_eff), dtype=np.float64)
-                padded[:, : arr.shape[1]] = arr
-                arr_eff = padded
-            else:
-                arr_eff = arr[:, :d_eff]
+            if arr.shape[1] != d:
+                raise ValueError(f"nonlinear_oscillator expects dimension {d}.")
 
-            force_rms = sigma * np.sqrt(np.sum(arr_eff**2, axis=1))
+            u_cos = arr[:, :half]
+            u_sin = arr[:, half:]
 
-            # Simplified response calculation
-            response_scale = force_rms / (k * (1.0 - alpha))
+            def load(index: int) -> npt.NDArray[np.float64]:
+                combined = u_cos @ cos_table[index] + u_sin @ sin_table[index]
+                return np.asarray(force_amplitude * combined, dtype=np.float64)
 
-            # Approximate maximum displacement
-            max_displacement = response_scale * (1.0 + 0.5 * force_rms / (k * 0.04))
-            g_values = z - max_displacement
+            def derivatives(
+                x: npt.NDArray[np.float64],
+                v: npt.NDArray[np.float64],
+                hyst: npt.NDArray[np.float64],
+                f: npt.NDArray[np.float64],
+            ) -> tuple[
+                npt.NDArray[np.float64],
+                npt.NDArray[np.float64],
+                npt.NDArray[np.float64],
+            ]:
+                # Clamp on use, not only on the accepted state: RK4's
+                # intermediate stages are unclamped, and with a large enough
+                # load h * dz overshoots saturation there, after which the
+                # |z|^3 feedback amplifies the overshoot until it overflows.
+                hyst = np.clip(hyst, -hyst_bound, hyst_bound)
+                abs_hyst = np.abs(hyst)
+                d_hyst = (
+                    bw_a * v
+                    - bw_beta * np.abs(v) * abs_hyst ** (bw_n - 1) * hyst
+                    - bw_gamma * v * abs_hyst**bw_n
+                ) / yield_displacement
+                d_v = (
+                    f
+                    - damping * v
+                    - stiffness
+                    * (alpha * x + (1.0 - alpha) * yield_displacement * hyst)
+                ) / mass
+                return v, d_v, d_hyst
 
+            n = arr.shape[0]
+            x = np.zeros(n, dtype=np.float64)
+            v = np.zeros(n, dtype=np.float64)
+            hyst = np.zeros(n, dtype=np.float64)
+            h = float(dt)
+
+            for step in range(n_steps):
+                f_start = load(2 * step)
+                f_mid = load(2 * step + 1)
+                f_end = load(2 * step + 2)
+
+                x1, v1, h1 = derivatives(x, v, hyst, f_start)
+                x2, v2, h2 = derivatives(
+                    x + h / 2 * x1, v + h / 2 * v1, hyst + h / 2 * h1, f_mid
+                )
+                x3, v3, h3 = derivatives(
+                    x + h / 2 * x2, v + h / 2 * v2, hyst + h / 2 * h2, f_mid
+                )
+                x4, v4, h4 = derivatives(x + h * x3, v + h * v3, hyst + h * h3, f_end)
+
+                x = x + h / 6 * (x1 + 2 * x2 + 2 * x3 + x4)
+                v = v + h / 6 * (v1 + 2 * v2 + 2 * v3 + v4)
+                hyst = np.clip(
+                    hyst + h / 6 * (h1 + 2 * h2 + 2 * h3 + h4),
+                    -hyst_bound,
+                    hyst_bound,
+                )
+
+            g_values = float(z) - x
             if is_single:
                 return float(g_values[0])
             return np.asarray(g_values, dtype=np.float64)
 
         return limit_state_function
-
-    @staticmethod
-    def nonlinear_oscillator(
-        dimension: int = 10, z: float = 0.05
-    ) -> Callable[[npt.ArrayLike], float | npt.NDArray[np.float64]]:
-        """Compatibility wrapper for nonlinear oscillator benchmark.
-
-        .. warning::
-
-           Delegates to :meth:`nonlinear_oscillator_simplified` and shares its
-           defect: the failure region is unreachable, so this returns a
-           probability of zero for any estimator.
-        """
-        return BenchmarkProblems.nonlinear_oscillator_simplified(d=dimension, z=z)
 
     @staticmethod
     def two_mode_opposite_directions(

--- a/tests/test_benchmark_ground_truth.py
+++ b/tests/test_benchmark_ground_truth.py
@@ -99,53 +99,91 @@ class TestAgainstMonteCarlo:
 
 
 class TestNonlinearOscillator:
-    """The oscillator benchmark cannot fail, and so measures nothing.
+    """The Bouc-Wen oscillator of Section 4.3, checked against crude MC.
 
-    Its displacement is computed as force_rms / (k * (1 - alpha)) with
-    k = 5e6, giving values around 4e-7 against a threshold of z = 0.05. Reaching
-    the threshold needs ||u|| of about 7.3e5, where the norm of a 10-dimensional
-    standard normal averages 3.1. Crude Monte Carlo over 2e7 samples finds zero
-    failures, and the CLI's `safe-ice benchmark oscillator` reports exactly 0.
+    This benchmark used to compute the displacement as
+    ``force_rms / (k * (1 - alpha))``, a closed form appearing nowhere in the
+    paper, which never integrated the equations of motion. It produced values
+    around 4e-07 against a threshold of 0.05, so the problem could not fail and
+    every estimator returned exactly 0. The tests here recorded that defect as
+    a strict xfail; they now check the real model.
 
-    The scaling is inconsistent by a factor of roughly 1e5. Reconstructing the
-    intended formulation needs the source paper, so the defect is recorded here
-    rather than guessed at.
+    Crude Monte Carlo over 2e6 samples of the implementation gives:
+
+        z       failures      pf          rel. s.e.    paper, Figure 7
+        0.05    3597          1.798e-03   1.7%         ~1.5e-03
+        0.06     295          1.475e-04   5.8%         ~1.2e-04
+        0.07       9          4.500e-06   33%          ~5e-06
     """
 
-    def test_failure_region_is_unreachable(self, rng) -> None:
-        """Records the defect. Delete this test once the problem is fixed."""
-        limit_state = BenchmarkProblems.nonlinear_oscillator_simplified()
-        u = rng.standard_normal((50_000, 10))
-        g = np.asarray(limit_state(u)).reshape(-1)
+    REFERENCE_PF = 1.798e-03  # z = 0.05
 
-        # Every value sits just under the threshold, varying only at ~1e-7.
-        assert float(g.min()) > 0.0499
-        assert float((g <= 0).mean()) == 0.0
+    def test_failure_region_is_reachable(self, rng) -> None:
+        """Crude sampling must find failures at roughly the reference rate."""
+        limit_state = BenchmarkProblems.nonlinear_oscillator(z=0.05)
+        u = rng.standard_normal((60_000, 10))
+        observed = float((np.asarray(limit_state(u)) <= 0).mean())
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason=(
-            "The nonlinear oscillator cannot fail: displacement is ~4e-7 "
-            "against a threshold of 0.05, so ||u|| of about 7.3e5 would be "
-            "needed where chi_10 averages 3.1. Crude Monte Carlo over 2e7 "
-            "samples finds no failures. Fixing the scaling requires the source "
-            "paper. Remove this marker once the problem is usable."
-        ),
-    )
-    def test_should_be_a_usable_rare_event_benchmark(self, rng) -> None:
-        """What the problem ought to do: fail sometimes, rarely."""
-        limit_state = BenchmarkProblems.nonlinear_oscillator_simplified()
-        u = rng.standard_normal((200_000, 10))
-        g = np.asarray(limit_state(u)).reshape(-1)
+        assert self.REFERENCE_PF / 3 < observed < self.REFERENCE_PF * 3, (
+            f"observed {observed:.3e} against reference {self.REFERENCE_PF:.3e}"
+        )
 
-        observed = float((g <= 0).mean())
-        assert 0.0 < observed < 1e-2, f"observed failure rate {observed:.3e}"
+    @pytest.mark.slow
+    def test_estimate_matches_reference(self) -> None:
+        """The estimator should reproduce the Monte Carlo value."""
+        estimates = []
+        for s in range(4):
+            ice = SafeICE(
+                limit_state_function=BenchmarkProblems.nonlinear_oscillator(z=0.05),
+                dimension=10,
+                N=1000,
+                max_iterations=15,
+                random_state=s,
+            )
+            pf, _ = ice.run(verbose=False)
+            estimates.append(pf)
 
-    def test_wrapper_delegates_to_the_simplified_form(self, rng) -> None:
-        """nonlinear_oscillator is a thin wrapper, so it shares the defect."""
-        u = rng.standard_normal((1000, 10))
-        wrapper = np.asarray(BenchmarkProblems.nonlinear_oscillator()(u)).reshape(-1)
-        direct = np.asarray(
-            BenchmarkProblems.nonlinear_oscillator_simplified()(u)
-        ).reshape(-1)
-        assert np.allclose(wrapper, direct)
+        median = float(np.median(estimates))
+        assert self.REFERENCE_PF / 3 < median < self.REFERENCE_PF * 3, (
+            f"median {median:.3e} against reference {self.REFERENCE_PF:.3e}; "
+            f"estimates {estimates}"
+        )
+
+    @pytest.mark.slow
+    @pytest.mark.parametrize(("z", "reference"), [(0.05, 1.798e-03), (0.06, 1.475e-04)])
+    def test_threshold_controls_rarity(self, z: float, reference: float, rng) -> None:
+        """Raising z must make failure rarer, by the measured amount."""
+        limit_state = BenchmarkProblems.nonlinear_oscillator(z=z)
+        # 100k samples give ~180 failures at z=0.05 and ~15 at z=0.06, so the
+        # 3x band below is comfortable. Each evaluation integrates 800 RK4
+        # steps, so this is the most expensive test in the suite; doubling the
+        # count doubles its runtime for no extra confidence.
+        u = rng.standard_normal((100_000, 10))
+        observed = float((np.asarray(limit_state(u)) <= 0).mean())
+
+        assert reference / 3 < observed < reference * 3, (
+            f"z={z}: observed {observed:.3e} against reference {reference:.3e}"
+        )
+
+    def test_response_is_bounded_for_extreme_inputs(self, rng) -> None:
+        """The |z|^3 term used to overflow once integration error unsaturated z.
+
+        The exact solution obeys |z| <= (A/(beta+gamma))^(1/n) = 1. Enforcing
+        that bound is a no-op for sampled inputs -- peaks are 0.9993 in the
+        failure region -- but keeps absurd ones from producing inf or NaN.
+        """
+        limit_state = BenchmarkProblems.nonlinear_oscillator()
+        for scale in (1e-3, 1.0, 1e3):
+            g = np.asarray(limit_state(rng.standard_normal((20, 10)) * scale))
+            assert np.all(np.isfinite(g)), f"non-finite response at scale {scale}"
+
+    def test_dimension_must_be_even(self) -> None:
+        """d/2 frequency components are drawn from the first and second half."""
+        with pytest.raises(ValueError, match="even dimension"):
+            BenchmarkProblems.nonlinear_oscillator(dimension=7)
+
+    def test_input_dimension_is_checked(self) -> None:
+        """It silently zero-padded mismatched input before, hiding mistakes."""
+        limit_state = BenchmarkProblems.nonlinear_oscillator()
+        with pytest.raises(ValueError, match="expects dimension 10"):
+            limit_state(np.zeros((5, 2)))

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -362,21 +362,21 @@ class TestBenchmarkRobustness:
         """Test numerical stability of limit state functions."""
         problems = BenchmarkProblems()
 
-        # Test all benchmark problems
+        # Each problem with the dimension it expects. This used to compare
+        # `g == problems.nonlinear_oscillator()`, which builds a fresh closure
+        # and so is never equal, meaning the oscillator was always handed
+        # 2-column input.
         test_functions = [
-            problems.four_mode_series_system(),
-            problems.three_mode_problem(),
-            problems.nonlinear_oscillator(),
-            problems.nakagami_ratio_problem(),
+            (problems.four_mode_series_system(), 2),
+            (problems.three_mode_problem(), 2),
+            (problems.nonlinear_oscillator(), 10),
+            (problems.nakagami_ratio_problem(), 2),
         ]
 
-        for g in test_functions:
+        for g, dim in test_functions:
             # Test with various scales of input
             for scale in [1e-3, 1.0, 1e3]:
-                if g == problems.nonlinear_oscillator():
-                    u_test = rng.standard_normal((10, 10)) * scale
-                else:
-                    u_test = rng.standard_normal((10, 2)) * scale
+                u_test = rng.standard_normal((10, dim)) * scale
 
                 results = g(u_test)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,9 +1,9 @@
 """Tests for the command-line interface.
 
 The CLI had no test coverage at all, and accumulated two user-facing defects
-because of it: it advertised a benchmark problem that cannot fail and always
-reported a probability of zero, and it reported a hard-coded version string that
-drifted from the package's own.
+because of it: it advertised a benchmark problem that could not fail and so
+always reported a probability of zero, and it reported a hard-coded version
+string that drifted from the package's own.
 
 These tests exercise each subcommand and pin the reference probabilities to the
 Monte Carlo values in ``test_benchmark_ground_truth.py``, so a stale number
@@ -66,10 +66,10 @@ class TestBenchmarkListing:
         for name in ("four-mode", "three-mode", "two-mode"):
             assert name in out
 
-    def test_does_not_offer_the_oscillator(self, capsys) -> None:
-        """It cannot fail, so it always reported a probability of exactly 0."""
+    def test_offers_the_oscillator(self, capsys) -> None:
+        """Withdrawn while it could not fail; restored with the real model."""
         assert main(["benchmark", "--list"]) == 0
-        assert "oscillator" not in plain(capsys.readouterr().out)
+        assert "oscillator" in plain(capsys.readouterr().out)
 
     def test_unknown_problem_is_reported(self, capsys) -> None:
         assert main(["benchmark", "not-a-problem"]) == 0
@@ -98,6 +98,7 @@ class TestBenchmarkRun:
             "four-mode": 5.815e-05,
             "three-mode": 3.475e-03,
             "two-mode": 2.690e-03,
+            "oscillator": 1.798e-03,
         }
         for problem, reference in expected.items():
             run_benchmark(problem, n_samples=200, max_iterations=2)


### PR DESCRIPTION
The benchmark computed displacement as `force_rms / (k * (1 - alpha))` — a closed form that appears nowhere in the source paper and never integrated the equations of motion. It gave values around `4e-07` against a threshold of `0.05`, so the problem could not fail: crude Monte Carlo over 2e7 samples found zero failures and every estimator returned exactly `0`. It was recorded as a strict `xfail` and withdrawn from the CLI, on the grounds that reconstructing the intended formulation needed the paper.

The paper is `paper/2509.07160v1.pdf`, checked into this repository. Section 4.3 has the model.

It now integrates the Bouc-Wen hysteretic oscillator (equations 39–42) with fourth-order Runge-Kutta at `dt = 0.01`, and reproduces Figure 7:

| `z` | this implementation | paper |
| --- | --- | --- |
| 0.05 | `1.798e-03` | ~`1.5e-03` |
| 0.06 | `1.475e-04` | ~`1.2e-04` |
| 0.07 | `4.5e-06` | ~`5e-06` |

Safe-ICE estimates the first at `1.797e-03` — within 1% of the Monte Carlo value, from 1000 samples per iteration against 2e6 for crude Monte Carlo. That is the benchmark finally doing its job. It is back in the CLI.

**Saturation bound.** The hysteretic variable is clamped to `(A/(beta+gamma))^(1/n) = 1` wherever it is used. The exact solution already obeys this — measured peaks are 0.9264 for ordinary samples and 0.9993 in the failure region, and outputs are bit-identical with and without the clamp — but RK4's intermediate stages can overshoot saturation under an extreme load, after which the `|z|^3` feedback overflows.

**Dimension checking.** The limit state now rejects input of the wrong dimension instead of zero-padding it. That padding was concealing a test which compared `g == problems.nonlinear_oscillator()` — always false, since it builds a fresh closure — and so had been feeding 2-column input to a 10-dimensional problem.

Removes `nonlinear_oscillator_simplified`, which existed only as the closed form above; the paper has no simplified variant.

This clears the last `xfail` in the repository.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the non-functional nonlinear oscillator benchmark with the paper’s Bouc–Wen model integrated via RK4, restoring realistic failure probabilities and re-enabling the CLI benchmark. Previously it used a closed form (force_rms/(k*(1−α))) that never integrated the equations and always returned 0; the new implementation matches Figure 7 of the paper.

- Implements equations 39–42 with RK4 at dt=0.01 and frequency-domain white-noise loading; adds a saturation clamp for the hysteretic variable to prevent numerical overflow while leaving sampled outputs unchanged.
- Ground-truth: pf≈1.798e-03 at z=0.05, 1.475e-04 at 0.06, 4.5e-06 at 0.07; `SafeICE` estimates 1.797e-03 at z=0.05 within 1%.
- Restores `safe-ice benchmark oscillator` with dimension 10 and reference 1.798e-03; updates docs, changelog, and tests (removes strict xfail, adds slow checks, fixes input-dimension testing).

**Migration**
- Remove calls to `BenchmarkProblems.nonlinear_oscillator_simplified`; use `BenchmarkProblems.nonlinear_oscillator`.
- Provide inputs with the exact even dimension requested (default 10). Mismatched input now raises ValueError instead of being zero-padded.

<sup>Written for commit 2ec86698f12529d8027d313bb9409570c11fb7e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/adaptive-importance-sampling/pull/91?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

