### PR TITLE
Fix the four-mode benchmark constant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The four-mode benchmark had the wrong constant, and every reference
+  measured against it was wrong too.** The last two branches of equation (37)
+  are `u1 - u2 + 7/sqrt(2)`; the code had `sqrt(3.5)`, reading the fraction
+  `7/sqrt(2)` as `sqrt(7/2)` -- 1.8708 instead of 4.9497. That placed the
+  failure region far closer to the origin: crude Monte Carlo gives `1.88e-01`
+  at `z=0`, where the paper reports about `1e-03`, which is above the top of
+  its Figure 4 axis. The corrected function gives `2.22e-03` there.
+
+  This invalidates the reference correction recorded below under 0.2.0, which
+  replaced a quoted `1.22e-5` with a measured `5.815e-05`: that measurement was
+  taken against the broken limit state. Corrected values from 2e7 samples:
+
+  | `z` | `pf` | rel. s.e. |
+  | --- | --- | --- |
+  | 0.0 | `2.2188e-03` | 0.5% |
+  | 0.5 | `4.1245e-04` | 1.1% |
+  | 1.0 | `6.4650e-05` | 2.8% |
+  | 1.5 | `9.3500e-06` | 7.3% |
+  | 2.0 | `1.0500e-06` | 21.8% |
+
+  The default `z` moves from 3.8 to 1.0. 3.8 was chosen against the broken
+  function; 1.0 is one of the thresholds tabulated in the paper's Table 1, and
+  is rare enough to be a meaningful benchmark while still having a Monte Carlo
+  reference. Safe-ICE estimates it at `6.543e-05`, 1.01x the reference.
+
 - **The nonlinear oscillator benchmark now implements the paper's model.** It
   computed the displacement as `force_rms / (k * (1 - alpha))`, a closed form
   appearing nowhere in the source and which never integrated the equations of

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ Reference probabilities, from crude Monte Carlo over 2e7 samples:
 
 | Problem | `P_F` |
 | --- | --- |
-| `four_mode_series_system` | `5.8e-5` |
+| `four_mode_series_system` | `6.5e-5` |
 | `three_mode_problem` | `3.5e-3` |
 | `two_mode_opposite_directions` | `2.7e-3` |
 | `nakagami_ratio_problem` | `5.2e-2` |
@@ -277,7 +277,7 @@ Current accuracy against problems with known answers, median over seeds:
 | Sphere `d=20`, closed form | `1.54e-2` | `1.01` |
 | Sphere `d=50`, closed form | `3.61e-3` | `0.98` |
 | Sphere `d=200`, closed form | `4.57e-3` | `1.01` |
-| Four-mode series system, 2e7-sample MC | `5.8e-5` | `1.01` |
+| Four-mode series system, 2e7-sample MC | `6.5e-5` | `1.01` |
 
 `tests/test_proposal_normalisation.py` pins this down: it integrates each
 proposal component numerically and fails if the Jacobian is dropped again.
@@ -302,9 +302,14 @@ proposal component numerically and fails if the Jacobian is dropped again.
   estimate to `~1e-9` against a true `1.6e-2`. With the floor at the smallest
   positive float instead, the sphere problem holds to within a few percent
   through `d=200`.
-- The reference value quoted for the four-mode problem used to be `1.22e-5`.
-  Crude Monte Carlo over 2e7 samples puts it at `5.8e-5 ± 1.7e-6` for the
-  default `z=3.8`.
+- **The four-mode limit state had the wrong constant.** The last two branches
+  of equation (37) are `u1 - u2 + 7/√2`; the code had `√3.5`, reading the
+  fraction as `√(7/2)` — `1.8708` instead of `4.9497`. That put the failure
+  region far closer to the origin: `1.88e-1` at `z=0` where the paper reports
+  about `1e-3`, above the top of its Figure 4 axis. Any reference measured
+  against it was measuring the wrong problem, including the `5.8e-5` that
+  replaced an earlier `1.22e-5` here. The corrected function gives `2.22e-3` at
+  `z=0` and `6.465e-5` at the new default `z=1.0`, a threshold from Table 1.
 
 What is planned about these, and which modules are not yet covered by tests,
 is in [ROADMAP.md](ROADMAP.md).

--- a/safe_ice/cli.py
+++ b/safe_ice/cli.py
@@ -47,7 +47,7 @@ def run_demo() -> None:
         print("Results:")
         print(f"  Estimated failure probability: {pf:.6e}")
         print(f"  Number of samples generated: {len(results['final_samples'])}")
-        print("  Reference probability: ~5.8e-5")
+        print("  Reference probability: ~6.5e-5")
         print("=" * 60)
 
     except Exception as e:
@@ -68,7 +68,7 @@ def run_benchmark(
     # over 2e7 standard-normal samples; see
     # tests/test_benchmark_ground_truth.py.
     available: dict[str, tuple[Callable[[], LimitStateFunction], int, float | None]] = {
-        "four-mode": (problems.four_mode_series_system, 2, 5.815e-05),
+        "four-mode": (problems.four_mode_series_system, 2, 6.465e-05),
         "three-mode": (problems.three_mode_problem, 2, 3.475e-03),
         "two-mode": (problems.two_mode_opposite_directions, 2, 2.690e-03),
         "oscillator": (problems.nonlinear_oscillator, 10, 1.798e-03),

--- a/safe_ice/problems/benchmarks.py
+++ b/safe_ice/problems/benchmarks.py
@@ -24,9 +24,30 @@ class BenchmarkProblems:
 
     @staticmethod
     def four_mode_series_system(
-        z: float = 3.8,
+        z: float = 1.0,
     ) -> Callable[[npt.ArrayLike], float | npt.NDArray[np.float64]]:
-        """Four-mode series system from Section 4.1 (Equation 37)."""
+        """Four-mode series system from Section 4.1 (Equation 37).
+
+        Failure is ``g(u) + z <= 0``, so larger ``z`` makes it rarer. Crude
+        Monte Carlo over 2e7 samples, against the paper's Figure 4:
+
+            z      failures        pf        rel. s.e.
+            0.0       44376    2.2188e-03      0.5%
+            0.5        8249    4.1245e-04      1.1%
+            1.0        1293    6.4650e-05      2.8%
+            1.5         187    9.3500e-06      7.3%
+            2.0          21    1.0500e-06     21.8%
+
+        Notes
+        -----
+        The last two branches of equation (37) are ``u1 - u2 + 7/sqrt(2)``.
+        They were written as ``sqrt(3.5)``, reading the fraction ``7/sqrt(2)``
+        as ``sqrt(7/2)``: 1.8708 instead of 4.9497. That put the failure region
+        far closer to the origin, giving 1.88e-01 at ``z=0`` where the paper
+        reports about 1e-03 -- above the top of Figure 4's axis. The default
+        ``z`` was 3.8, chosen against the broken function; 1.0 is one of the
+        thresholds tabulated in the paper's Table 1.
+        """
 
         def limit_state_function(
             u: npt.ArrayLike,
@@ -40,8 +61,8 @@ class BenchmarkProblems:
 
             g1 = 0.1 * (u1 - u2) ** 2 - (u1 + u2) / np.sqrt(2.0) + 3.0
             g2 = 0.1 * (u1 - u2) ** 2 + (u1 + u2) / np.sqrt(2.0) + 3.0
-            g3 = u1 - u2 + np.sqrt(3.5)
-            g4 = u2 - u1 + np.sqrt(3.5)
+            g3 = u1 - u2 + 7.0 / np.sqrt(2.0)
+            g4 = u2 - u1 + 7.0 / np.sqrt(2.0)
 
             g_min = np.minimum(np.minimum(g1, g2), np.minimum(g3, g4)) + z
             if is_single:

--- a/tests/test_benchmark_ground_truth.py
+++ b/tests/test_benchmark_ground_truth.py
@@ -7,13 +7,16 @@ make unnecessary, which makes it an independent check rather than a restatement
 of the implementation.
 
     problem                          failures / 2e7      pf        rel. s.e.
-    four_mode_series_system                   1163    5.815e-05      2.9%
+    four_mode_series_system                   1293    6.4650e-05     2.8%
     three_mode_problem                       69490    3.475e-03      0.4%
     two_mode_opposite_directions             53800    2.690e-03      0.4%
     nakagami_ratio_problem                 1037533    5.188e-02      0.1%
 
-An earlier comment in the test suite put the four-mode reference at 1.22e-5,
-which does not match this problem at its default z=3.8.
+The four-mode reference was previously recorded here as 5.815e-05. That was
+measured against a limit-state function whose last two branches used sqrt(3.5)
+where equation (37) has 7/sqrt(2), which placed the failure region far closer
+to the origin. The value above is for the corrected function at its new default
+of z=1.0, one of the thresholds tabulated in the paper's Table 1.
 """
 
 from __future__ import annotations
@@ -32,7 +35,7 @@ GROUND_TRUTH = [
         "four_mode_series_system",
         BenchmarkProblems.four_mode_series_system,
         2,
-        5.815e-05,
+        6.465e-05,
     ),
     ("three_mode_problem", BenchmarkProblems.three_mode_problem, 2, 3.475e-03),
     (

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -91,11 +91,11 @@ class TestBenchmarkRun:
     def test_reference_values_match_monte_carlo_ground_truth(self, capsys) -> None:
         """The printed references must be the measured ones.
 
-        four-mode was quoted as 1.22e-5 against a measured 5.8e-5, and
-        three-mode as 2.3e-3 against 3.5e-3.
+        four-mode is 6.465e-05 at the default z=1.0, and three-mode
+        3.475e-03 at z=3.0.
         """
         expected = {
-            "four-mode": 5.815e-05,
+            "four-mode": 6.465e-05,
             "three-mode": 3.475e-03,
             "two-mode": 2.690e-03,
             "oscillator": 1.798e-03,

--- a/tests/test_optimized_variants.py
+++ b/tests/test_optimized_variants.py
@@ -34,7 +34,7 @@ from safe_ice import AdaptiveSafeICE, OptimizedSafeICE, SafeICE
 from safe_ice.problems.benchmarks import BenchmarkProblems
 
 # From crude Monte Carlo over 2e7 samples; see test_benchmark_ground_truth.py.
-FOUR_MODE_PF = 5.815e-05
+FOUR_MODE_PF = 6.465e-05
 
 VARIANTS = [SafeICE, OptimizedSafeICE, AdaptiveSafeICE]
 

--- a/tests/test_safe_ice.py
+++ b/tests/test_safe_ice.py
@@ -226,8 +226,7 @@ class TestBenchmarkProblems:
         pf, _results = ice.run(verbose=False)
 
         # Crude Monte Carlo over 2e7 samples puts the reference at
-        # 5.8e-5 +/- 1.7e-6 for the default z=3.8. (An earlier comment here
-        # claimed 1.22e-5, which does not match this problem's parameters.)
+        # 6.465e-05 +/- 2.8% for the default z=1.0.
         assert pf > 1e-6
         assert pf < 1e-4
 


### PR DESCRIPTION
Equation (37)'s last two branches are `u1 - u2 + 7/√2`. The code had `np.sqrt(3.5)` — the fraction `7/√2` read as `√(7/2)`, giving `1.8708` instead of `4.9497`.

That placed the failure region far closer to the origin:

| `z` | code's constant | paper's constant | paper, Figure 4 |
| --- | --- | --- | --- |
| 0.0 | `1.88e-01` | `2.22e-03` | ~`1e-03` |

`0.19` is not just off, it is above the top of Figure 4's axis.

**This invalidates a correction I made earlier in 0.2.0.** I replaced the CLI's quoted `1.22e-5` with a "measured" `5.815e-05` and documented that in the README, the changelog and three test files. That measurement was of the broken limit state.

Corrected references, 2e7 samples:

| `z` | `pf` | rel. s.e. |
| --- | --- | --- |
| 0.0 | `2.2188e-03` | 0.5% |
| 0.5 | `4.1245e-04` | 1.1% |
| 1.0 | `6.4650e-05` | 2.8% |
| 1.5 | `9.3500e-06` | 7.3% |
| 2.0 | `1.0500e-06` | 21.8% |

The default `z` moves from `3.8` to `1.0`. `3.8` was chosen against the broken function and yields about `1e-9` with the correct one — too rare for a crude Monte Carlo reference. `1.0` is one of the thresholds in the paper's Table 1. Safe-ICE estimates it at `6.543e-05`, 1.01x the reference.

First of three PRs from a review of the implementation against the paper; the penalised-EM β schedule and the heat-transfer problem follow.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrects the four-mode benchmark constant to match Equation (37) and updates references and defaults. The old code used sqrt(3.5) instead of 7/√2, placing the failure region too close to the origin; the new constant restores the paper’s behavior. Default z moves from 3.8 to 1.0. References change from ~5.815e-05 to 6.465e-05.

- Updates the limit-state branches to use 7/√2. At z=0, pf changes from ~1.88e-01 (wrong) to ~2.22e-03 (paper-consistent). At the new default z=1.0, pf is 6.465e-05.
- Revises CLI printed reference, README tables/text, and tests to the corrected value.
- Adds notes and corrected MC figures in `BenchmarkProblems.four_mode_series_system` docstring and in `CHANGELOG.md`.

**Review notes**
- Validate the constant change in `problems/benchmarks.py` (g3/g4 now use 7/√2).
- Check updated reference values in CLI output, README, and tests align with 2e7-sample MC numbers.
- Confirm default z=1.0 flows through the CLI and tests.

**Migration**
- If you relied on the old default z=3.8 or the previous reference (~5.815e-05), set z explicitly. z=3.8 remains allowed but now yields ~1e-9 and is not used as the default.

<sup>Written for commit 6e984006c6a35b10ab9c13f33341920514928bf6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/adaptive-importance-sampling/pull/92?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

