### PR TITLE
Implement the penalty coefficient and pruning from the paper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The penalty coefficient did not follow equation (23).** `_update_beta`
+  called itself a "simple adaptive heuristic" and was one: it measured each
+  weight's deviation from the mean rather than its change since the previous
+  iteration, scaled that by the number of components rather than the number of
+  samples, replaced equation (24)'s entropy term with `(1 - max pi) / min pi`,
+  and blended the result with the previous beta. Beta governs how aggressively
+  redundant components are pruned, which is one of the paper's two headline
+  contributions. It now implements equations (23) and (24).
+- **Component pruning did not follow equation (22).** Components were dropped
+  at `pi > 1e-4` after clamping negatives to zero and renormalising. Equation
+  (21) is a zero-sum redistribution, so it already preserves the normalisation
+  and can drive a weight negative; the paper prunes exactly those. It now does.
+- **The stopping rule of section 3.2 was missing.** The criterion reads the
+  vMFNM samples, so when `lambda` is 0 there are none and the CV is set to
+  infinity to force another iteration. This was approximated by an ad-hoc
+  "at least two iterations" guard, which is now unnecessary: `lambda_0` is
+  always 0 because `M = sigma0`.
+- `em_max_iter` now defaults to 20, the value stated in section 4, rather
+  than 100.
+
+Accuracy is unchanged to slightly better, and pruning now does what it is for:
+the mixture settles at K=1 for the unimodal sphere at d=50 and for the
+oscillator, K=8 for the four-mode problem, from K0=20.
+
+| Problem | reference | median | ratio |
+| --- | --- | --- | --- |
+| four-mode `z=1.0` | `6.465e-05` | `6.446e-05` | 1.00x |
+| three-mode `z=3.0` | `3.475e-03` | `3.641e-03` | 1.05x |
+| two-mode `z=3.0` | `2.700e-03` | `2.879e-03` | 1.07x |
+| oscillator `z=0.05` | `1.798e-03` | `1.773e-03` | 0.99x |
+| sphere `d=10` | `5.346e-03` | `5.410e-03` | 1.01x |
+| sphere `d=50` | `3.610e-03` | `3.565e-03` | 0.99x |
+
+### Documented
+
+- The `lambda_max` cap is recorded as a deliberate divergence from equation
+  (35), which reaches exactly 1. Section 3.2 relies on that to argue the final
+  estimate is sound, but it removes the heavy-tailed component that makes the
+  method "safe" and leaves the weights unbounded.
+- `nakagami_ratio_problem` is not one of the paper's benchmarks. Sections 4.1
+  to 4.5 cover the four-mode, three-mode, oscillator, two-mode and heat
+  transfer problems; this is an extra exercise for the Nakagami code.
+
 - **The four-mode benchmark had the wrong constant, and every reference
   measured against it was wrong too.** The last two branches of equation (37)
   are `u1 - u2 + 7/sqrt(2)`; the code had `sqrt(3.5)`, reading the fraction

--- a/safe_ice/core/safe_ice.py
+++ b/safe_ice/core/safe_ice.py
@@ -93,7 +93,7 @@ class SafeICE:
         max_iterations: int = 20,
         N: int = 1000,
         sigma0: float = 1.0,
-        em_max_iter: int = 100,
+        em_max_iter: int = 20,
         cv_tolerance: float = 0.01,
         lambda_max: float = 0.95,
         random_state: int | np.random.Generator | None = None,
@@ -182,6 +182,13 @@ class SafeICE:
             )
             cv_w_star: float = self._coefficient_of_variation(stopping_weights)
 
+            # Section 3.2: the stopping criterion reads the vMFNM samples, so
+            # when lambda is 0 there are none and the CV is set to infinity to
+            # force another iteration. lambda_0 is always 0 because M = sigma0,
+            # so this is what guarantees at least two iterations.
+            if lambda_t <= 0.0:
+                cv_w_star = float("inf")
+
             # Record history
             self.history["sigma"].append(float(sigma_t))
             self.history["cv"].append(float(cv_w_star))
@@ -202,7 +209,7 @@ class SafeICE:
                 print(f"           CV={cv_w_star:.4f}")
 
             # Convergence check using delta_star
-            if cv_w_star <= self.delta_star and (t + 1) >= 2:
+            if cv_w_star <= self.delta_star:
                 if verbose:
                     print(
                         f"  Converged: CV {cv_w_star:.4f} "
@@ -345,15 +352,16 @@ class SafeICE:
         return vMFNMParameters(pi=pi, m=m, Omega=Omega, mu=mu, kappa=kappa)
 
     def _cosine_annealing_schedule(self, sigma: float, M: float) -> float:
-        """Cosine annealing schedule for lambda parameter.
+        """Cosine annealing schedule for lambda, equation (35).
 
-        The raw schedule reaches exactly 1 as sigma goes to 0, which drops the
-        heavy-tailed component from the proposal altogether. That component is
-        the "safe" part of Safe-ICE: it keeps the proposal's tails heavier than
-        the target so the importance weights stay bounded. Without it a single
-        sample from the tail can carry essentially the whole estimate. The
-        result is capped at ``lambda_max`` so some heavy-tailed mass always
-        remains.
+        A deliberate divergence from the paper: lambda is capped at
+        ``lambda_max``. Equation (35) reaches exactly 1 as sigma goes to 0, and
+        section 3.2 relies on that -- it argues the final estimate is sound
+        because the last iteration samples only the light-tailed family. In
+        practice that removes the heavy-tailed component which makes the method
+        "safe", and the weights are then unbounded: on one seed a single tail
+        sample carried 99.5% of an estimate. The cap keeps a 5% heavy-tailed
+        share, so the proposal always has heavier tails than the target.
         """
         if sigma > M:
             return 0.0

--- a/safe_ice/core/safe_ice_optimized.py
+++ b/safe_ice/core/safe_ice_optimized.py
@@ -75,7 +75,7 @@ class OptimizedSafeICE(SafeICE):
         max_iterations: int = 20,
         N: int = 1000,
         sigma0: float = 1.0,
-        em_max_iter: int = 100,
+        em_max_iter: int = 20,
         enable_caching: bool = True,
         enable_parallel: bool = True,
         batch_size: int | None = None,

--- a/safe_ice/optimization/penalized_em.py
+++ b/safe_ice/optimization/penalized_em.py
@@ -17,9 +17,7 @@ NDArrayF = npt.NDArray[np.float64]
 class PenalizedEMOptimizer:
     """Penalized EM algorithm for automatic component selection."""
 
-    def __init__(
-        self, max_em_iterations: int = 100, em_tolerance: float = 1e-6
-    ) -> None:
+    def __init__(self, max_em_iterations: int = 20, em_tolerance: float = 1e-6) -> None:
         self.max_em_iterations = int(max_em_iterations)
         self.em_tolerance = float(em_tolerance)
 
@@ -72,13 +70,11 @@ class PenalizedEMOptimizer:
                 data, radii, directions, params, weights
             )
 
-            # M-step with penalization
-            params, K = self._penalized_m_step(
+            # M-step with penalization, which also returns the next penalty
+            # coefficient: equation (23) needs the pre-pruning weight vectors.
+            params, K, beta = self._penalized_m_step(
                 data, radii, directions, responsibilities, weights, params, beta
             )
-
-            # Update penalty parameter
-            beta = self._update_beta(params, beta, K)
 
             # Check convergence
             current_log_likelihood: float = self._weighted_log_likelihood(
@@ -153,8 +149,12 @@ class PenalizedEMOptimizer:
         weights: NDArrayF,
         params: vMFNMParameters,
         beta: float,
-    ) -> tuple[vMFNMParameters, int]:
-        """Penalized M-step with automatic component removal."""
+    ) -> tuple[vMFNMParameters, int, float]:
+        """Penalized M-step with automatic component removal.
+
+        Returns the updated parameters, the surviving component count, and the
+        penalty coefficient for the next iteration (equation 23).
+        """
         _n, d = data.shape
         int(params.K)
 
@@ -163,18 +163,26 @@ class PenalizedEMOptimizer:
             np.float64, copy=False
         )
 
-        # Update mixture weights with penalization
-        new_pi: NDArrayF = self._update_mixture_weights_penalized(
+        # Update mixture weights with penalization, equation (21)
+        new_pi, pi_em = self._update_mixture_weights_penalized(
             weighted_resp, params.pi, beta
         )
 
-        # Remove components with negligible weights
-        active_components = new_pi > 1e-4
+        # The next penalty coefficient, equation (23), is computed before
+        # pruning: it compares the weights component by component against the
+        # previous iterate, so both vectors must still have K_j entries.
+        next_beta = self._update_beta(params.pi, new_pi, pi_em, int(_n), int(d))
+
+        # Equation (22): discard the components driven to zero by the penalty.
+        active_components = new_pi > 0.0
         K_new: int = int(np.sum(active_components))
 
         if K_new == 0:
+            # Everything was pruned at once; keep the largest so the mixture
+            # stays well formed.
             K_new = 1
-            active_components[0] = True
+            active_components = np.zeros_like(active_components)
+            active_components[int(np.argmax(new_pi))] = True
 
         # Extract active components
         active_indices = np.where(active_components)[0]
@@ -212,18 +220,23 @@ class PenalizedEMOptimizer:
             pi=new_pi, m=new_m, Omega=new_Omega, mu=new_mu, kappa=new_kappa
         )
 
-        return new_params, K_new
+        return new_params, K_new, next_beta
 
     def _update_mixture_weights_penalized(
         self, weighted_resp: NDArrayF, old_pi: NDArrayF, beta: float
-    ) -> NDArrayF:
-        """Update mixture weights with cross-entropy-like penalty."""
+    ) -> tuple[NDArrayF, NDArrayF]:
+        """Equation (21): the EM weight update plus the cross-entropy penalty.
+
+        Returns the penalised weights and the unpenalised EM weights of
+        equation (19); equation (23) needs both to set the next beta.
+        """
         # Standard EM update
         total_weight: float = float(np.sum(weighted_resp))
         if total_weight <= 0.0:
             # fallback uniform
             K = int(weighted_resp.shape[1])
-            return np.full(K, 1.0 / float(K), dtype=np.float64)
+            uniform = np.full(K, 1.0 / float(K), dtype=np.float64)
+            return uniform, uniform
 
         pi_em: NDArrayF = (np.sum(weighted_resp, axis=0) / total_weight).astype(
             np.float64, copy=False
@@ -246,23 +259,21 @@ class PenalizedEMOptimizer:
         safe_old = np.maximum(old_pi.astype(np.float64, copy=False), 1e-15)
         mean_log_pi: float = float(np.sum(safe_old * np.log(safe_old)))
 
-        # Normalize factor (total_weight/total_weight == 1), kept explicit for clarity
+        # Normalize factor (total_weight/total_weight == 1), kept explicit for
+        # clarity. Equation (21) writes it as
+        # sum_i W_i / sum_i sum_s gamma_s^(i) W_i, and the responsibilities sum
+        # to one over components, so the two sums are equal.
         norm_factor: float = 1.0
         penalty_term: NDArrayF = (
             float(beta) * norm_factor * safe_old * (np.log(safe_old) - mean_log_pi)
         ).astype(np.float64, copy=False)
 
+        # Equation (21). The penalty is a zero-sum redistribution -- summing it
+        # over k gives E - E = 0 -- so this still sums to one and needs no
+        # renormalisation. Entries may be negative; equation (22) prunes those.
         new_pi: NDArrayF = (pi_em + penalty_term).astype(np.float64, copy=False)
 
-        # Ensure non-negativity and renormalization
-        new_pi = np.maximum(new_pi, 0.0)
-        s = float(np.sum(new_pi))
-        if s > 0.0:
-            new_pi = (new_pi / s).astype(np.float64, copy=False)
-        else:
-            new_pi = np.full(K, 1.0 / float(K), dtype=np.float64)
-
-        return new_pi
+        return new_pi, pi_em
 
     def _update_nakagami_parameters(
         self, radii: NDArrayF, responsibilities: NDArrayF
@@ -351,29 +362,57 @@ class PenalizedEMOptimizer:
         """von Mises–Fisher PDF for a batch of unit rows w.r.t. surface area measure."""
         return vmf_pdf_batch(X, mu, kappa)
 
-    def _update_beta(self, params: vMFNMParameters, beta: float, K: int) -> float:
-        """Update penalty parameter beta (simple adaptive heuristic)."""
-        # Use mixture spread as a guide; keep bounded in [0, 1].
-        min_pi: float = float(np.min(params.pi))
-        max_pi: float = float(np.max(params.pi))
+    @staticmethod
+    def _update_beta(
+        pi_old: NDArrayF,
+        pi_new: NDArrayF,
+        pi_em: NDArrayF,
+        n_samples: int,
+        d: int,
+    ) -> float:
+        """Next penalty coefficient, equations (23) and (24).
 
-        # Dimension based factor (similar spirit to paper’s dependence on d)
-        d: int = int(params.mu.shape[1])
-        eta: float = float(min(1.0, 0.5 ** (max(0, int(d / 2) - 1))))
+            beta = min{ (1/K) sum_k exp(-eta N |pi_k(j+1) - pi_k(j)|),
+                        (1 - max_k pi_em_k) / (-max_k pi_k(j) * E) }
 
-        # Heuristic terms
-        # Encourage spreading when weights are peaky (max_pi large, min_pi small)
-        term1: float = float(
-            (1.0 / float(K))
-            * np.sum(
-                np.exp(-eta * float(K) * np.abs(params.pi - float(np.mean(params.pi))))
-            )
-        )
-        term2: float = float((1.0 - max_pi) / max(min_pi, 1e-15))
+        with ``eta = min(1, 0.5^(floor(d/2) - 1))`` and
+        ``E = sum_k pi_k(j) ln pi_k(j)``, which is negative, so the second
+        denominator is positive.
 
-        new_beta: float = float(min(term1, term2))
-        # Blend with previous beta to avoid oscillations
-        return float(0.5 * beta + 0.5 * max(0.0, min(1.0, new_beta)))
+        The first term falls towards zero while the weights are still moving,
+        which keeps the penalty from pruning during the unsettled early
+        iterations; the second caps it so at least one component survives.
+
+        This was previously an unrelated heuristic: it measured each weight's
+        deviation from the mean rather than its change since the last
+        iteration, scaled by the number of components rather than the number of
+        samples, replaced the entropy term with ``(1 - max pi) / min pi``, and
+        blended the result with the previous beta.
+        """
+        K = int(pi_old.shape[0])
+        if K == 0:
+            return 0.0
+        if K == 1:
+            # E = 1 * ln 1 = 0, so the second term is undefined. With a single
+            # component there is nothing left to prune.
+            return 0.0
+
+        eta = min(1.0, 0.5 ** max(0, d // 2 - 1))
+
+        drift = np.abs(np.asarray(pi_new, dtype=np.float64) - pi_old)
+        term1 = float(np.mean(np.exp(-eta * float(n_samples) * drift)))
+
+        safe_old = np.clip(np.asarray(pi_old, dtype=np.float64), 1e-300, None)
+        entropy_sum = float(np.sum(safe_old * np.log(safe_old)))  # E, negative
+        largest_old = float(np.max(safe_old))
+        denominator = -largest_old * entropy_sum
+
+        if denominator <= 0.0:
+            # Reachable only if every weight is 1, i.e. E == 0.
+            return float(min(term1, 1.0))
+
+        term2 = (1.0 - float(np.max(pi_em))) / denominator
+        return float(max(0.0, min(term1, term2)))
 
     def _weighted_log_likelihood(
         self, data: NDArrayF, params: vMFNMParameters, weights: NDArrayF

--- a/safe_ice/problems/benchmarks.py
+++ b/safe_ice/problems/benchmarks.py
@@ -291,7 +291,16 @@ class BenchmarkProblems:
     def nakagami_ratio_problem(
         threshold: float = 0.1,
     ) -> Callable[[npt.ArrayLike], float | npt.NDArray[np.float64]]:
-        """Simple ratio-style benchmark using two transformed standard normals."""
+        """Ratio of Nakagami-distributed variables.
+
+        .. note::
+
+           Not one of the paper's benchmarks. Sections 4.1 to 4.5 cover the
+           four-mode series system, the three-mode problem, the nonlinear
+           oscillator, the two-mode system and the heat transfer problem; this
+           is an extra exercise for the Nakagami machinery. Its reference value
+           comes from crude Monte Carlo here, not from the paper.
+        """
 
         def limit_state_function(
             u: npt.ArrayLike,

--- a/tests/test_probability_clamp.py
+++ b/tests/test_probability_clamp.py
@@ -113,19 +113,36 @@ class TestTheRawValueSurvives:
     """The point of option three: nothing is hidden."""
 
     def test_unclamped_value_is_reported_unchanged(self) -> None:
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always")
-            pf, results = SafeICE(
-                limit_state_function=always_fails,
-                dimension=2,
-                N=100,
-                max_iterations=2,
-                random_state=10,
-            ).run(verbose=False)
+        """On whichever seeds overshoot, the raw value and warning must appear.
 
-        raw = results["pf_unclamped"]
-        assert raw > 1.0, "this seed is chosen because it overshoots"
-        assert pf == 1.0
-        assert any("clamped" in str(w.message) for w in caught)
-        # The raw value is the diagnostic; it must not itself be clamped.
-        assert raw == pytest.approx(1.159, abs=0.01)
+        Which seeds overshoot depends on the sampling path, so this scans a
+        range rather than pinning one. Hard-coding a seed and its exact value
+        made this test fail whenever an unrelated change moved the stream.
+        """
+        overshooting = 0
+
+        for seed in range(15):
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                pf, results = SafeICE(
+                    limit_state_function=always_fails,
+                    dimension=2,
+                    N=100,
+                    max_iterations=2,
+                    random_state=seed,
+                ).run(verbose=False)
+
+            raw = results["pf_unclamped"]
+            warned = any("clamped" in str(w.message) for w in caught)
+
+            if raw > 1.0:
+                overshooting += 1
+                assert pf == 1.0, f"seed {seed}: raw {raw} was not clamped"
+                assert warned, f"seed {seed}: clamped {raw} silently"
+            else:
+                assert pf == raw, f"seed {seed}: altered an in-range estimate"
+                assert not warned, f"seed {seed}: warned without clamping"
+
+        assert overshooting > 0, (
+            "no seed overshot 1, so the clamp path was never exercised"
+        )

--- a/tests/test_proposal_normalisation.py
+++ b/tests/test_proposal_normalisation.py
@@ -208,7 +208,7 @@ class TestPenalizedWeightUpdate:
         # the weights untouched, so any change is entirely the penalty.
         weighted_resp = np.full((n, K), 1.0 / K)
 
-        new_pi = PenalizedEMOptimizer()._update_mixture_weights_penalized(
+        new_pi, _pi_em = PenalizedEMOptimizer()._update_mixture_weights_penalized(
             weighted_resp, uniform, beta=1.0
         )
 
@@ -221,12 +221,14 @@ class TestPenalizedWeightUpdate:
         old_pi = np.array([0.7, 0.1, 0.1, 0.1])
         weighted_resp = np.tile(old_pi, (200, 1))
 
-        new_pi = PenalizedEMOptimizer()._update_mixture_weights_penalized(
+        new_pi, _pi_em = PenalizedEMOptimizer()._update_mixture_weights_penalized(
             weighted_resp, old_pi, beta=1.0
         )
 
         assert new_pi[0] > old_pi[0]
         assert np.all(new_pi[1:] < old_pi[1:])
+        # Equation (21) is a zero-sum redistribution, so it preserves the
+        # normalisation without a renormalising step.
         assert new_pi.sum() == pytest.approx(1.0)
 
     def test_mixture_is_not_collapsed_on_the_first_step(self) -> None:
@@ -238,11 +240,11 @@ class TestPenalizedWeightUpdate:
         rng = np.random.default_rng(7)
         weighted_resp = rng.dirichlet(np.ones(n_components), size=n_samples)
 
-        new_pi = PenalizedEMOptimizer()._update_mixture_weights_penalized(
+        new_pi, _pi_em = PenalizedEMOptimizer()._update_mixture_weights_penalized(
             weighted_resp, uniform, beta=1.0
         )
 
-        assert int(np.sum(new_pi > 1e-4)) > 1
+        assert int(np.sum(new_pi > 0.0)) > 1  # equation (22) prunes at zero
 
 
 class TestInitialisationScalesWithDimension:
@@ -304,3 +306,65 @@ class TestInitialisationScalesWithDimension:
 
         within = sum(1 for pf in estimates if true / 4 < pf < true * 4)
         assert within >= 3, f"only {within}/4 seeds usable: {estimates}"
+
+
+class TestPenaltyCoefficientSchedule:
+    """Equation (23) sets beta; it used to be an unrelated heuristic.
+
+    The replaced version measured each weight's deviation from the mean rather
+    than its change since the previous iteration, scaled by the number of
+    components rather than the number of samples, substituted
+    ``(1 - max pi) / min pi`` for the entropy term of equation (24), and
+    blended the result with the previous beta. Its own docstring called it a
+    "simple adaptive heuristic".
+    """
+
+    @staticmethod
+    def beta_of(pi_old, pi_new, pi_em, n, d):
+        """Equation (23) as implemented."""
+        from safe_ice.optimization.penalized_em import PenalizedEMOptimizer
+
+        return PenalizedEMOptimizer._update_beta(
+            np.asarray(pi_old), np.asarray(pi_new), np.asarray(pi_em), n, d
+        )
+
+    def test_settled_weights_give_the_largest_penalty(self) -> None:
+        """The first term is 1 when nothing moved, and falls as drift grows."""
+        pi = np.full(4, 0.25)
+        settled = self.beta_of(pi, pi, pi, 1000, 2)
+        drifting = self.beta_of(
+            pi, pi + np.array([0.1, -0.1, 0.05, -0.05]), pi, 1000, 2
+        )
+        assert settled > drifting
+
+    def test_drift_is_scaled_by_the_sample_count(self) -> None:
+        """Equation (23) uses N, not K: more samples means less tolerance."""
+        pi = np.full(4, 0.25)
+        moved = pi + np.array([0.01, -0.01, 0.005, -0.005])
+        assert self.beta_of(pi, moved, pi, 10_000, 2) < self.beta_of(
+            pi, moved, pi, 100, 2
+        )
+
+    def test_eta_shrinks_with_dimension(self) -> None:
+        """eta = min(1, 0.5^(floor(d/2) - 1)) damps the drift term as d grows."""
+        pi = np.full(4, 0.25)
+        moved = pi + np.array([0.02, -0.02, 0.01, -0.01])
+        low_d = self.beta_of(pi, moved, pi, 1000, 2)
+        high_d = self.beta_of(pi, moved, pi, 1000, 20)
+        assert high_d > low_d  # weaker damping term -> closer to 1
+
+    def test_beta_is_bounded_and_finite(self) -> None:
+        rng = np.random.default_rng(3)
+        for _ in range(50):
+            k = int(rng.integers(2, 12))
+            pi_old = rng.dirichlet(np.ones(k))
+            pi_em = rng.dirichlet(np.ones(k))
+            pi_new = rng.dirichlet(np.ones(k))
+            beta = self.beta_of(pi_old, pi_new, pi_em, 1000, int(rng.integers(2, 40)))
+            assert np.isfinite(beta)
+            assert beta >= 0.0
+
+    def test_single_component_has_nothing_to_prune(self) -> None:
+        """E = 1*ln 1 = 0 there, so equation (24)'s denominator vanishes."""
+        one = np.array([1.0])
+        assert self.beta_of(one, one, one, 1000, 2) == 0.0


### PR DESCRIPTION
Second of three PRs from reviewing the implementation against the paper.

**Equation (23) was not implemented.** `_update_beta`'s own docstring called it a "simple adaptive heuristic". Against the paper it:

- used each weight's deviation from the mean, not its change since the previous iteration
- scaled by the number of components `K`, not the number of samples `N`
- replaced equation (24)'s entropy term `(1 - max pi_em) / (-max pi * E)` with `(1 - max pi) / min pi`
- blended `0.5 * beta_old`, which appears nowhere in the paper

Beta controls how aggressively redundant components are pruned — one of the paper's two headline contributions. It now implements equations (23) and (24).

**Equation (22) was not implemented.** Components were dropped at `pi > 1e-4`, after clamping negatives to zero and renormalising. Equation (21) turns out to be a zero-sum redistribution — summing the penalty over `k` gives `E - E = 0` — so it already preserves normalisation and can legitimately drive a weight negative. The paper prunes exactly those, and now so does this.

**The section 3.2 stopping rule was missing.** The criterion reads the vMFNM samples, so when `lambda` is 0 there are none and the CV is set to infinity to force another iteration. This had been approximated with an ad-hoc "at least two iterations" guard, now removed as redundant: `lambda_0` is always 0 because `M = sigma0`.

`em_max_iter` also drops from 100 to the 20 stated in section 4.

Accuracy is unchanged to slightly better, and pruning now does its job — K settles at 1 for the unimodal cases, from `K0=20`:

| Problem | reference | median | ratio | final K |
| --- | --- | --- | --- | --- |
| four-mode `z=1.0` | `6.465e-05` | `6.446e-05` | 1.00x | 8 |
| three-mode `z=3.0` | `3.475e-03` | `3.641e-03` | 1.05x | 7 |
| two-mode `z=3.0` | `2.700e-03` | `2.879e-03` | 1.07x | 7 |
| oscillator `z=0.05` | `1.798e-03` | `1.773e-03` | 0.99x | 1 |
| sphere `d=10` | `5.346e-03` | `5.410e-03` | 1.01x | 4 |
| sphere `d=50` | `3.610e-03` | `3.565e-03` | 0.99x | 1 |

Two intentional divergences are now recorded rather than left implicit: the `lambda_max` cap (equation 35 reaches exactly 1, which removes the component that makes the method "safe"), and that `nakagami_ratio_problem` is not one of the paper's benchmarks.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements the paper’s penalty coefficient and pruning: replaces the heuristic beta update with equations (23) and (24), applies equation (21) without renormalizing, and prunes per equation (22). Adds the §3.2 stopping rule and lowers the EM default to 20; pruning now removes redundant components without hurting accuracy.

- Updates beta using pre-pruning weights and sample count: computes beta from `(pi_old, pi_new, pi_em, N, d)` as in (23–24); previously used a mean-deviation heuristic scaled by `K` and blended with `0.5*beta`.
- Applies the zero-sum penalty (21) directly and prunes at `pi <= 0` (22); previously clamped negatives, renormalized, and dropped at `pi > 1e-4`.
- Uses the §3.2 CV-based stopping rule; when `lambda=0`, sets CV=∞ to force another iteration and removes the “at least two iterations” guard. Sets `em_max_iter` default to 20.
- Documents a deliberate divergence: caps `lambda` at `lambda_max` to retain a heavy-tailed share.

**Reviewer focus**
- `_penalized_m_step` now returns `(params, K, beta)`; `_update_mixture_weights_penalized` returns `(new_pi, pi_em)`; `_update_beta` is a static method taking `(pi_old, pi_new, pi_em, N, d)`.
- Pruning uses `pi > 0.0`; if all are pruned, the argmax component is kept to maintain a valid mixture.
- Tests assert zero-threshold pruning, the beta schedule, and make overshoot checks seed-robust.
- No external API changes. If you relied on `em_max_iter=100`, pass it explicitly.

<sup>Written for commit 7470eb5beebcbaca0298a4d4c05d8bcd0728fad1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/adaptive-importance-sampling/pull/93?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

