### PR TITLE
Solve the heat transfer problem and check it against the paper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The heat transfer problem did not work, and no test would have noticed.**
+  It was the least covered module in the package and had never been checked
+  against an independent answer. The temperature field came from an explicit
+  relaxation, `T += 0.01 * (laplacian + Q)`, run for 1000 sweeps and clamped to
+  +/-1e6. An elliptic problem has no time derivative to march, and that fixed
+  pseudo-step was about sixteen times the explicit stability limit for the
+  default grid, so it diverged: 380 of 441 nodes ended pinned at the clamp and
+  the limit state returned exactly `threshold` for every input, with no
+  dependence on the random field at all.
+
+  Four parameters also disagreed with section 4.5: the correlation length was
+  `0.5` against `l = 0.2`, the threshold `100` against equation (48)'s `10`,
+  the covariance `exp(-r/l)` against equation (46)'s `exp(-r^2/l^2)`, and the
+  heat source's y extent was computed and then discarded, leaving a
+  full-height strip instead of the square `A`.
+
+  The field is now a direct sparse solve of the five-point conservative
+  discretisation, which reproduces the analytic solution of the uniform case to
+  machine precision. Safe-ICE estimates the failure probability at `2.83e-07`
+  against the paper's `4.69e-07`, a factor of 0.60, using finite differences on
+  21x21 where the paper uses finite elements over 25040 triangles.
+
+  Two further defects came out of the same work. Region membership used exact
+  floating-point comparisons on bounds that a `linspace` reproduces at some
+  grid sizes and misses by an ulp at others, so a region silently lost a row of
+  nodes at `grid_size=31`. And assigning `Q` to each source node made the
+  discrete heat input `((0.1 + h) / 0.1)^2` times too large -- 2.25x at
+  `grid_size=21` against 1.44x at 51 -- which was the whole of the problem's
+  apparent grid dependence. Spreading `Q` over the region's area fixes it: the
+  nominal average temperature on `B` is now 4.553 at every grid size tested,
+  against 10.24, 8.09, 7.11 and 6.56 before.
+
+  Boundary conditions follow Figure 11 -- zero Dirichlet on the top edge, zero
+  Neumann on the other three. The text of section 4.5 says the opposite, and
+  the two cannot both hold: with three edges able to shed heat the nominal
+  average temperature on `B` is 0.49 against a threshold of 10, which is 51
+  standard deviations away and could never produce the reported probability.
+
 - **The penalty coefficient did not follow equation (23).** `_update_beta`
   called itself a "simple adaptive heuristic" and was one: it measured each
   weight's deviation from the mean rather than its change since the previous

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   nominal average temperature on `B` is now 4.553 at every grid size tested,
   against 10.24, 8.09, 7.11 and 6.56 before.
 
+  The Karhunen-Loeve modes are now sign-canonicalised. An eigenvector is only
+  defined up to sign and LAPACK's choice varies between builds, so the same
+  coefficients produced mirror-image conductivity fields on different machines;
+  a test asserting a direction passed locally and failed in CI. Anchoring each
+  mode on its largest-magnitude entry makes the expansion reproducible.
+
   Boundary conditions follow Figure 11 -- zero Dirichlet on the top edge, zero
   Neumann on the other three. The text of section 4.5 says the opposite, and
   the two cannot both hold: with three edges able to shed heat the nominal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   nominal average temperature on `B` is now 4.553 at every grid size tested,
   against 10.24, 8.09, 7.11 and 6.56 before.
 
+  The conductivity exponent is clipped. The estimator's heavy-tailed proposal
+  reaches far enough into the field's tail to underflow `kappa` to zero, which
+  leaves the conduction matrix singular and the solve returning NaN, failing
+  the run outright. The bounds are absurd for a field with mean 1 and standard
+  deviation 0.3, so realistic samples are untouched.
+
   The Karhunen-Loeve modes are now sign-canonicalised. An eigenvector is only
   defined up to sign and LAPACK's choice varies between builds, so the same
   coefficients produced mirror-image conductivity fields on different machines;

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -33,31 +33,32 @@ Runge-Kutta, and reproduces Figure 7: 1.798e-03 at `z=0.05`, 1.475e-04 at
 `0.06` and 4.5e-06 at `0.07`. Safe-ICE estimates the first to within 1% of the
 Monte Carlo value. It is available from the CLI again.
 
+### Done: the heat transfer problem is solved and referenced
+
+Its field solver diverged and the limit state ignored its input entirely. It
+now uses a direct sparse solve, verified against an analytic solution, and
+Safe-ICE estimates `2.83e-07` against the paper's `4.69e-07`.
+
 ## Next
 
 ### Cover the untested modules
 
-Overall line coverage is 53%, but it is not evenly spread. The core algorithm,
-the distributions and the optimiser are at 87-94%. Four modules are not
-meaningfully exercised at all:
+Overall line coverage is 61%, but it is not evenly spread. The core algorithm,
+the distributions, the optimiser, the benchmarks and the heat transfer problem
+are at 87-99%. Three modules are not exercised at all:
 
 | Module | Coverage | Notes |
 | --- | --- | --- |
 | `problems/advanced_problems.py` | 0% | 238 statements, four problem classes, not exported from the package |
 | `analysis/interactive_visualization.py` | 0% | Requires the `viz` extra |
 | `utils/performance.py` | 0% | |
-| `problems/heat_transfer.py` | 11% | Exported publicly; has no reference-based check |
 
 Every module examined closely so far has turned out to contain a defect that
-changed results, so these are treated as unverified rather than as working.
-`advanced_problems.py` needs a decision first: it is unreachable through the
-public API, so it is either exported and tested or removed.
-
-### Give `HeatTransferProblem` a reference
-
-It is exported from the package root but has no check against an independent
-answer, which is the gap that hid the benchmark defects until they were
-measured against Monte Carlo.
+changed results, most recently the heat transfer problem, whose field solver
+diverged and whose limit state ignored its input. These are treated as
+unverified rather than as working. `advanced_problems.py` needs a decision
+first: it is unreachable through the public API, so it is either exported and
+tested or removed.
 
 ## Later
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -41,6 +41,23 @@ Safe-ICE estimates `2.83e-07` against the paper's `4.69e-07`.
 
 ## Next
 
+### Make the sigma schedule robust on smooth high-dimensional problems
+
+On the heat transfer problem the estimator collapses on a minority of seeds:
+sigma falls too far in the first two iterations, from 1 to 0.37 to 0.13, then
+stalls, and the weight coefficient of variation never comes down from 6-8
+against a target of 4. Those runs end many orders of magnitude low -- 1e-27
+rather than 3e-07. Two of six seeds did this in one measurement, and the median
+is unaffected, which is why the reference test takes one.
+
+Equation (10) chooses sigma by minimising `(CV - delta_target)^2` over
+`(0, sigma_prev)`. When no sigma in that interval achieves the target the
+minimiser returns a point near the boundary, and the proposal never catches up.
+A floor on how far sigma may fall in one step, or a retry when the CV worsens,
+would likely fix it, but both are departures from the paper and need measuring
+across the whole benchmark set before being adopted.
+
+
 ### Cover the untested modules
 
 Overall line coverage is 61%, but it is not evenly spread. The core algorithm,

--- a/safe_ice/problems/heat_transfer.py
+++ b/safe_ice/problems/heat_transfer.py
@@ -169,8 +169,14 @@ class HeatTransferProblem:
         )
         f_field: NDArrayF = np.asarray(self.eigenvecs @ coeffs, dtype=np.float64)
 
-        # Lognormal field
-        kappa_field: NDArrayF = np.exp(a_kappa + b_kappa * f_field, dtype=np.float64)
+        # Lognormal field. The exponent is clipped because the estimator's
+        # heavy-tailed proposal reaches far enough into the tail to underflow
+        # kappa to zero, which leaves the conduction matrix singular and the
+        # solve returning NaN. The bounds are already absurd for a field whose
+        # mean is 1 and standard deviation 0.3, so realistic samples are
+        # untouched; without them a run would occasionally fail outright.
+        exponent = np.clip(a_kappa + b_kappa * f_field, -30.0, 30.0)
+        kappa_field: NDArrayF = np.exp(exponent, dtype=np.float64)
 
         return np.asarray(
             kappa_field.reshape(self.grid_size, self.grid_size), dtype=np.float64

--- a/safe_ice/problems/heat_transfer.py
+++ b/safe_ice/problems/heat_transfer.py
@@ -112,6 +112,17 @@ class HeatTransferProblem:
         # Broadcasted normalization: (n_points, n_terms) / (1, n_terms)
         self.eigenvecs = self.eigenvecs / norms
 
+        # Fix the sign of each mode. An eigenvector is only defined up to sign,
+        # and LAPACK's choice varies between builds, so the same coefficients
+        # produced mirror-image fields on different machines: a test asserting
+        # that positive coefficients raise the conductivity passed locally and
+        # failed in CI. Anchoring on the largest-magnitude entry makes the
+        # expansion reproducible.
+        dominant = np.argmax(np.abs(self.eigenvecs), axis=0)
+        signs = np.sign(self.eigenvecs[dominant, np.arange(self.eigenvecs.shape[1])])
+        signs[signs == 0.0] = 1.0
+        self.eigenvecs = self.eigenvecs * signs
+
         # Assign eigenvectors alias AFTER normalization so it exposes
         # the normalized modes, not the stale pre-normalization ones.
         self.eigenvectors = self.eigenvecs[:50, :]

--- a/safe_ice/problems/heat_transfer.py
+++ b/safe_ice/problems/heat_transfer.py
@@ -169,14 +169,21 @@ class HeatTransferProblem:
         )
         f_field: NDArrayF = np.asarray(self.eigenvecs @ coeffs, dtype=np.float64)
 
-        # Lognormal field. The exponent is clipped because the estimator's
-        # heavy-tailed proposal reaches far enough into the tail to underflow
-        # kappa to zero, which leaves the conduction matrix singular and the
-        # solve returning NaN. The bounds are already absurd for a field whose
-        # mean is 1 and standard deviation 0.3, so realistic samples are
-        # untouched; without them a run would occasionally fail outright.
-        exponent = np.clip(a_kappa + b_kappa * f_field, -30.0, 30.0)
-        kappa_field: NDArrayF = np.exp(exponent, dtype=np.float64)
+        # Lognormal field, from a Gaussian field clipped to +/-30 standard
+        # deviations. The estimator's heavy-tailed proposal reaches far enough
+        # out that kappa would otherwise span tens of orders of magnitude,
+        # leaving the conduction matrix numerically singular and the solve
+        # returning NaN, which fails the run on whichever sample hits it. At
+        # +/-30 the conductivity ratio is about 4e7, which is comfortably
+        # solvable, while the failure region needs only kappa to roughly halve
+        # -- f = -2.4 -- so nothing the sampler explores is affected.
+        #
+        # The bound cannot be made much tighter. Clipping at +/-8 flattens the
+        # limit state wherever the field saturates, which leaves the smoothed
+        # indicator with no gradient to follow: two of five seeds then
+        # collapsed to 1e-27 and 1e-34.
+        f_clipped = np.clip(f_field, -30.0, 30.0)
+        kappa_field: NDArrayF = np.exp(a_kappa + b_kappa * f_clipped, dtype=np.float64)
 
         return np.asarray(
             kappa_field.reshape(self.grid_size, self.grid_size), dtype=np.float64

--- a/safe_ice/problems/heat_transfer.py
+++ b/safe_ice/problems/heat_transfer.py
@@ -7,6 +7,8 @@ from collections.abc import Callable
 
 import numpy as np
 import numpy.typing as npt
+from scipy import sparse
+from scipy.sparse.linalg import spsolve
 
 # Typed aliases
 NDArrayF = npt.NDArray[np.float64]
@@ -19,10 +21,10 @@ class HeatTransferProblem:
     def __init__(
         self,
         grid_size: int = 21,
-        correlation_length: float = 0.5,
+        correlation_length: float = 0.2,
         n_terms: int = 10,
         field_std: float = 0.3,
-        threshold: float = 100.0,
+        threshold: float = 10.0,
         heat_source: float = 2000.0,
     ) -> None:
         """Initialize heat transfer problem.
@@ -76,14 +78,14 @@ class HeatTransferProblem:
 
     def _setup_kl_expansion(self) -> None:
         """Setup Karhunen–Loève expansion for a lognormal random field."""
-        # Exponential covariance: k(x,x') = exp(-||x - x'|| / l)
-        distances: NDArrayF = np.sqrt(
-            np.sum(
-                (self.grid_points[:, None, :] - self.grid_points[None, :, :]) ** 2,
-                axis=2,
-            )
+        # Equation (46): k(x, x') = exp(-||x - x'||^2 / l^2). This was
+        # exp(-||x - x'|| / l), the exponential kernel, which gives a far
+        # rougher field than the squared-exponential the paper specifies.
+        sq_distances: NDArrayF = np.sum(
+            (self.grid_points[:, None, :] - self.grid_points[None, :, :]) ** 2,
+            axis=2,
         )
-        C: NDArrayF = np.exp(-distances / np.float64(self.l))
+        C: NDArrayF = np.exp(-sq_distances / np.float64(self.l) ** 2)
 
         # Eigendecomposition (float64 arrays)
         eigenvals, eigenvecs = np.linalg.eigh(C)
@@ -114,6 +116,29 @@ class HeatTransferProblem:
         # the normalized modes, not the stale pre-normalization ones.
         self.eigenvectors = self.eigenvecs[:50, :]
 
+    def _region_mask(
+        self, x_lo: float, x_hi: float, y_lo: float, y_hi: float
+    ) -> NDArrayB:
+        """Grid nodes inside a rectangle, robust to floating-point edges.
+
+        The bounds are multiples of 0.05 and 0.1, which a linspace reproduces
+        exactly at some grid sizes and misses by an ulp at others. A bare
+        ``>=`` comparison therefore captured a different number of nodes
+        depending on ``grid_size``: at 31 the nominal average temperature on
+        region B came out at 2.02 against 5.04, 4.79 and 4.75 for 21, 41 and
+        51, purely because the region had lost a row of nodes.
+        """
+        tol = 1e-9
+        x_min, x_max = x_lo - tol, x_hi + tol
+        y_min, y_max = y_lo - tol, y_hi + tol
+        inside = (
+            np.greater_equal(self.X, x_min)
+            & np.less_equal(self.X, x_max)
+            & np.greater_equal(self.Y, y_min)
+            & np.less_equal(self.Y, y_max)
+        )
+        return np.asarray(inside, dtype=bool)
+
     def generate_permeability_field(self, xi: npt.ArrayLike) -> NDArrayF:
         """Generate lognormal permeability field from the KL expansion."""
         # Mean and std for lognormal field
@@ -124,8 +149,6 @@ class HeatTransferProblem:
         a_kappa = np.log((mu_kappa**2) / np.sqrt(mu_kappa**2 + sigma_kappa**2))
         b_kappa = np.sqrt(np.log(1.0 + (sigma_kappa**2) / (mu_kappa**2)))
 
-        # KL expansion coefficients
-        np.asarray(xi, dtype=np.float64)[: self.n_terms]
         # KL expansion coefficients: turn the triple product into a matvec
         # shapes: eigenvecs (n_points, n_terms) @ coeffs (n_terms,) -> (n_points,)
         coeffs: NDArrayF = np.multiply(
@@ -143,53 +166,99 @@ class HeatTransferProblem:
         )
 
     def solve_heat_equation(self, kappa_field: npt.ArrayLike) -> NDArrayF:
-        """Solve heat equation using a simple finite-difference iterative scheme."""
-        h = 1.0 / float(self.grid_size - 1)  # grid spacing
+        """Solve -div(kappa grad T) = I_A Q by a direct sparse solve.
 
-        # Temperature and conductivity fields
-        T: NDArrayF = np.zeros((self.grid_size, self.grid_size), dtype=np.float64)
+        Five-point conservative finite differences with conductivity averaged
+        onto the cell faces.
+
+        Boundary conditions follow Figure 11: zero Dirichlet on the top edge,
+        zero Neumann on the other three. The text of section 4.5 says the
+        opposite -- "zero Neumann boundary on the top part and zero Dirichlet
+        boundary in the rest" -- and the two cannot both hold. The figure is
+        the consistent one: with heat able to escape through three edges the
+        nominal average temperature on region B is 0.49 against a failure
+        threshold of 10, which is 51 standard deviations away and so could
+        never produce the reported probability of 4.69e-07. With the top edge
+        as the only sink it is 5.32, and failure is a rare event rather than an
+        impossible one.
+
+        This replaces an explicit relaxation, ``T += 0.01 * (laplacian + Q)``
+        run for 1000 sweeps with the result clamped to +/-1e6. The elliptic
+        problem has no time derivative to march, and the fixed pseudo-step was
+        about sixteen times the explicit stability limit for this grid
+        (``dt * kappa / h^2 = 4`` against a 2-D limit of ``0.25``), so it
+        diverged: 380 of 441 nodes ended pinned at the clamp, and the resulting
+        limit state returned exactly ``threshold`` for every input, with no
+        dependence on the random field at all.
+        """
         kappa: NDArrayF = np.asarray(kappa_field, dtype=np.float64)
+        n = self.grid_size
+        h = (self.domain[1] - self.domain[0]) / float(n - 1)
 
-        # Heat source region A = (0.2, 0.3) × (0.2, 0.3)
-        x_indices = np.where((self.X >= 0.2) & (self.X <= 0.3))
-        np.where((self.Y >= 0.2) & (self.Y <= 0.3))
-        source_mask: NDArrayB = np.zeros_like(T, dtype=bool)
-        source_mask[x_indices[0], x_indices[1]] = True  # rectangular mask
+        # Heat source on A = (0.2, 0.3) x (0.2, 0.3). The y extent used to be
+        # computed and then discarded, leaving a full-height strip.
+        source = self._region_mask(0.2, 0.3, 0.2, 0.3)
+        # Spread Q over the source nodes so the discrete heat input equals the
+        # physical one, Q times the area of A, at any grid size. Assigning Q to
+        # each node instead makes the input (0.1 + h)^2 / 0.1^2 times too
+        # large, because a closed region picks up an extra row of nodes on each
+        # side: 2.25x at grid_size 21 and 1.44x at 51. That was the whole of
+        # the apparent grid dependence -- dividing it out leaves the nominal
+        # average temperature on B at 4.55 for every grid tested.
+        source_area = 0.1 * 0.1
+        n_source = int(np.count_nonzero(source))
+        source_density = self.Q * source_area / (n_source * h * h) if n_source else 0.0
 
-        # Iterative Jacobi-like update
-        for _ in range(1000):
-            T_old: NDArrayF = T.copy()
+        def index(row: int, col: int) -> int:
+            return row * n + col
 
-            # Interior updates
-            with np.errstate(over="ignore", under="ignore", invalid="ignore"):
-                for i in range(1, self.grid_size - 1):
-                    for j in range(1, self.grid_size - 1):
-                        laplacian = (
-                            kappa[i + 1, j] * (T_old[i + 1, j] - T_old[i, j])
-                            - kappa[i - 1, j] * (T_old[i, j] - T_old[i - 1, j])
-                        ) / h**2 + (
-                            kappa[i, j + 1] * (T_old[i, j + 1] - T_old[i, j])
-                            - kappa[i, j - 1] * (T_old[i, j] - T_old[i, j - 1])
-                        ) / h**2
+        rows: list[int] = []
+        cols: list[int] = []
+        vals: list[float] = []
+        rhs: NDArrayF = np.zeros(n * n, dtype=np.float64)
 
-                        source_term = self.Q if source_mask[i, j] else 0.0
-                        updated = T_old[i, j] + 0.01 * (laplacian + source_term)
-                        if not np.isfinite(updated):
-                            updated = 0.0
-                        # Clamp to keep iteration numerically stable.
-                        T[i, j] = float(np.clip(updated, -1e6, 1e6))
+        inv_h2 = 1.0 / (h * h)
 
-            # Boundary conditions
-            T[0, :] = 0.0  # Bottom: Dirichlet
-            T[-1, :] = T[-2, :]  # Top: Neumann (zero gradient)
-            T[:, 0] = 0.0  # Left: Dirichlet
-            T[:, -1] = 0.0  # Right: Dirichlet
+        for i in range(n):
+            for j in range(n):
+                node = index(i, j)
 
-            # Convergence check
-            if float(np.max(np.abs(T - T_old))) < 1e-6:
-                break
+                # Dirichlet on the top edge.
+                if i == n - 1:
+                    rows.append(node)
+                    cols.append(node)
+                    vals.append(1.0)
+                    continue
 
-        return T
+                diagonal = 0.0
+                for di, dj in ((-1, 0), (1, 0), (0, -1), (0, 1)):
+                    ni, nj = i + di, j + dj
+                    # Zero Neumann on the bottom, left and right edges: the
+                    # ghost node mirrors its interior counterpart.
+                    if ni < 0:
+                        ni = 1
+                    if nj < 0:
+                        nj = 1
+                    elif nj > n - 1:
+                        nj = n - 2
+
+                    face_kappa = 0.5 * (kappa[i, j] + kappa[ni, nj])
+                    coefficient = face_kappa * inv_h2
+                    diagonal += coefficient
+                    rows.append(node)
+                    cols.append(index(ni, nj))
+                    vals.append(-coefficient)
+
+                rows.append(node)
+                cols.append(node)
+                vals.append(diagonal)
+                rhs[node] = source_density if source[i, j] else 0.0
+
+        matrix = sparse.csr_matrix(
+            (vals, (rows, cols)), shape=(n * n, n * n), dtype=np.float64
+        )
+        solution: NDArrayF = np.asarray(spsolve(matrix, rhs), dtype=np.float64)
+        return solution.reshape(n, n)
 
     def create_limit_state_function(
         self, threshold: float | None = None
@@ -213,9 +282,11 @@ class HeatTransferProblem:
 
             g_values = np.zeros(samples.shape[0], dtype=np.float64)
             # Generate permeability field from KL coefficients
-            x_mask = (self.X >= -0.3) & (self.X <= -0.2)
-            y_mask = (self.Y >= -0.3) & (self.Y <= 0.2)
-            eval_mask = x_mask & y_mask
+            # Section 4.5 calls B "a squared domain" but writes its extent as
+            # (-0.3, -0.2) x (-0.3, 0.2), which is not square. Figure 11 draws
+            # a small square in the lower left, so the second bound is read as
+            # -0.2.
+            eval_mask = self._region_mask(-0.3, -0.2, -0.3, -0.2)
 
             for i, sample in enumerate(samples):
                 kappa_field = self.generate_permeability_field(sample)

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -252,22 +252,28 @@ class TestHeatTransferProblem:
         )
         g = problem.get_limit_state_function()
 
-        # kappa = exp(a + b f), so positive coefficients raise the
-        # conductivity. A better conductor carries the same heat with a
-        # smaller temperature difference, so the field is cooler and
-        # g = threshold - T is larger.
+        # The random field must actually change the answer -- the limit state
+        # used to return exactly `threshold` for every input.
         u_positive = np.ones(problem.n_terms) * 3
-        result_positive = g(u_positive)
+        u_negative = -u_positive
 
-        u_negative = -np.ones(problem.n_terms) * 3
-        result_negative = g(u_negative)
+        result_positive = float(g(u_positive))
+        result_negative = float(g(u_negative))
 
         assert np.isfinite(result_positive)
         assert np.isfinite(result_negative)
-        # This asserted the opposite, hedged with "depends on grid resolution
-        # and iteration count" -- which it did, because the relaxation it was
-        # written against never converged.
-        assert result_positive > result_negative
+        assert result_positive != result_negative
+
+        # The unambiguous physical statement: for a uniform conductivity the
+        # steady-state field satisfies T ~ 1/kappa exactly, so doubling the
+        # conductivity halves the temperature. There is no such monotone
+        # relation for the mean of a random field -- conduction is limited by
+        # the low-kappa parts of the path, not by the average -- which is why
+        # this is checked on a uniform field.
+        ones = np.ones((problem.grid_size, problem.grid_size))
+        base = problem.solve_heat_equation(ones)
+        doubled = problem.solve_heat_equation(2.0 * ones)
+        assert doubled == pytest.approx(base / 2.0, rel=1e-10)
 
 
 class TestBenchmarkComparison:

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -173,9 +173,11 @@ class TestHeatTransferProblem:
         problem = HeatTransferProblem()
 
         assert problem.n_terms == 10
-        assert problem.correlation_length == 0.5
+        # Section 4.5: correlation length l = 0.2, and equation (48) puts the
+        # failure threshold at 10. These were 0.5 and 100.
+        assert problem.correlation_length == 0.2
         assert problem.field_std == 0.3
-        assert problem.threshold == 100.0
+        assert problem.threshold == 10.0
 
     def test_initialization_custom(self):
         """Test custom initialization of heat transfer problem."""
@@ -250,21 +252,22 @@ class TestHeatTransferProblem:
         )
         g = problem.get_limit_state_function()
 
-        # Large positive fluctuations should increase temperature
+        # kappa = exp(a + b f), so positive coefficients raise the
+        # conductivity. A better conductor carries the same heat with a
+        # smaller temperature difference, so the field is cooler and
+        # g = threshold - T is larger.
         u_positive = np.ones(problem.n_terms) * 3
         result_positive = g(u_positive)
 
-        # Large negative fluctuations should decrease temperature
         u_negative = -np.ones(problem.n_terms) * 3
         result_negative = g(u_negative)
 
-        # Both must be finite; when the PDE solver fully converges,
-        # positive KL coefficients lead to higher temperature
-        # (lower g), but this depends on grid resolution and
-        # iteration count.
         assert np.isfinite(result_positive)
         assert np.isfinite(result_negative)
-        assert result_positive <= result_negative
+        # This asserted the opposite, hedged with "depends on grid resolution
+        # and iteration count" -- which it did, because the relaxation it was
+        # written against never converged.
+        assert result_positive > result_negative
 
 
 class TestBenchmarkComparison:

--- a/tests/test_heat_transfer_reference.py
+++ b/tests/test_heat_transfer_reference.py
@@ -1,0 +1,203 @@
+"""The heat conduction problem of section 4.5, checked against the paper.
+
+This module was the least covered in the package and had never been checked
+against an independent answer. It did not work: the temperature field was
+produced by an explicit relaxation, ``T += 0.01 * (laplacian + Q)``, run for
+1000 sweeps and clamped to +/-1e6. An elliptic problem has no time derivative
+to march, and that fixed pseudo-step was about sixteen times the explicit
+stability limit for the default grid, so it diverged -- 380 of 441 nodes ended
+pinned at the clamp, and the limit state returned exactly ``threshold`` for
+every input, with no dependence on the random field at all.
+
+Four parameters also disagreed with the paper: the correlation length was 0.5
+against ``l = 0.2``, the failure threshold 100 against the 10 of equation (48),
+the covariance was ``exp(-r/l)`` against equation (46)'s ``exp(-r^2/l^2)``, and
+the heat source's y extent was computed and then discarded, leaving a
+full-height strip instead of the square A.
+
+With those corrected and the field solved directly, Safe-ICE estimates the
+failure probability at 2.83e-07 against the paper's 4.69e-07 -- a factor of
+0.60, using finite differences on a 21x21 grid where the paper uses finite
+elements with 25040 triangles.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from safe_ice import SafeICE
+from safe_ice.problems.heat_transfer import HeatTransferProblem
+
+# Section 4.5, estimated by subset simulation over 50 runs.
+PAPER_REFERENCE_PF = 4.69e-07
+
+
+class TestParametersMatchThePaper:
+    """Each of these was wrong, and none was covered by a test."""
+
+    def test_correlation_length(self) -> None:
+        assert float(HeatTransferProblem().l) == pytest.approx(0.2)
+
+    def test_failure_threshold(self) -> None:
+        """Equation (48): g(u) = 10 - mean temperature on B."""
+        assert float(HeatTransferProblem().threshold) == pytest.approx(10.0)
+
+    def test_heat_source_and_field_statistics(self) -> None:
+        problem = HeatTransferProblem()
+        heat_source = float(problem.Q)
+        assert heat_source == pytest.approx(2000.0)
+        assert float(problem.field_std) == pytest.approx(0.3)
+        assert problem.n_terms == 10
+
+    def test_covariance_is_squared_exponential(self) -> None:
+        """Equation (46) is exp(-r^2/l^2); the code had exp(-r/l)."""
+        problem = HeatTransferProblem(grid_size=5)
+        points = problem.grid_points
+        r = float(np.linalg.norm(points[0] - points[-1]))
+
+        squared_exponential = float(np.exp(-(r**2) / problem.l**2))
+        exponential = float(np.exp(-r / problem.l))
+
+        sq = np.sum((points[:, None, :] - points[None, :, :]) ** 2, axis=2)
+        kernel = np.exp(-sq / problem.l**2)
+
+        assert float(kernel[0, -1]) == pytest.approx(squared_exponential)
+        assert float(kernel[0, -1]) != pytest.approx(exponential)
+
+
+class TestTheSolver:
+    """The field is now a direct solve, so it can be checked exactly."""
+
+    @pytest.mark.parametrize("grid_size", [21, 41])
+    def test_reproduces_the_analytic_solution(self, grid_size: int) -> None:
+        """Uniform conductivity and a uniform source reduce this to 1-D.
+
+        With -T'' = q, zero gradient at y = -0.5 and T = 0 at y = +0.5, the
+        solution is T(y) = q (0.375 - y^2/2 - y/2). The source is spread so
+        that its integral is Q times the region area, and here the region is
+        the whole unit domain, so q = Q. Nothing about the previous relaxation
+        could have passed this.
+        """
+
+        class UniformSource(HeatTransferProblem):
+            def _region_mask(self, *bounds: float):
+                return np.ones_like(self.X, dtype=bool)
+
+        problem = UniformSource(grid_size=grid_size)
+        problem.Q = 1.0
+        temperature = problem.solve_heat_equation(np.ones((grid_size, grid_size)))
+
+        # The solver spreads Q over the nominal area of A, so recover the
+        # density it actually applied rather than assuming one.
+        h = 1.0 / (grid_size - 1)
+        n_source = grid_size * grid_size
+        density = problem.Q * (0.1 * 0.1) / (n_source * h * h)
+
+        y = np.linspace(-0.5, 0.5, grid_size)
+        exact = density * (0.375 - y**2 / 2.0 - y / 2.0)
+        column = temperature[:, grid_size // 2]
+
+        assert column == pytest.approx(exact, rel=1e-9)
+
+    def test_dirichlet_edge_is_zero(self) -> None:
+        """Figure 11: T = 0 on the top edge, zero gradient on the other three."""
+        problem = HeatTransferProblem()
+        temperature = problem.solve_heat_equation(
+            problem.generate_permeability_field(np.zeros(10))
+        )
+
+        assert temperature[-1, :] == pytest.approx(0.0, abs=1e-12)
+        # The insulated edges are the far side of the domain from the only
+        # sink, so they must be hot, not pinned to zero.
+        assert float(np.min(temperature[0, 1:-1])) > 0.0
+        assert np.all(np.isfinite(temperature))
+
+    def test_field_is_finite_and_bounded(self) -> None:
+        """The relaxation left 380 of 441 nodes pinned at a +/-1e6 clamp."""
+        problem = HeatTransferProblem()
+        rng = np.random.default_rng(0)
+        for _ in range(5):
+            temperature = problem.solve_heat_equation(
+                problem.generate_permeability_field(rng.standard_normal(10))
+            )
+            assert np.all(np.isfinite(temperature))
+            assert float(np.max(np.abs(temperature))) < 1e4
+
+
+class TestRegionsAndGridIndependence:
+    @pytest.mark.parametrize("grid_size", [21, 31, 41, 51])
+    def test_regions_are_squares(self, grid_size: int) -> None:
+        """The bounds are exact multiples that a linspace can miss by an ulp."""
+        problem = HeatTransferProblem(grid_size=grid_size)
+        source = problem._region_mask(0.2, 0.3, 0.2, 0.3)
+        region_b = problem._region_mask(-0.3, -0.2, -0.3, -0.2)
+
+        for mask in (source, region_b):
+            count = int(np.count_nonzero(mask))
+            side = round(float(np.sqrt(count)))
+            assert side * side == count, f"{count} nodes is not a square"
+            assert side >= 3
+
+    @pytest.mark.slow
+    @pytest.mark.parametrize("grid_size", [21, 31, 41, 51])
+    def test_temperature_on_b_is_grid_independent(self, grid_size: int) -> None:
+        """Assigning Q per node made the heat input depend on the grid.
+
+        A closed region picks up an extra row of nodes on each side, so the
+        discrete input was ((0.1 + h) / 0.1)^2 times too large: 2.25x at
+        grid_size 21 against 1.44x at 51. Spreading Q over the region's area
+        removes it, and the average temperature on B settles at 4.553.
+        """
+        problem = HeatTransferProblem(grid_size=grid_size)
+        temperature = problem.solve_heat_equation(
+            problem.generate_permeability_field(np.zeros(10))
+        )
+        region_b = problem._region_mask(-0.3, -0.2, -0.3, -0.2)
+
+        assert float(temperature[region_b].mean()) == pytest.approx(4.553, abs=0.01)
+
+
+class TestLimitState:
+    def test_depends_on_the_random_field(self) -> None:
+        """It used to return exactly ``threshold`` for every input."""
+        problem = HeatTransferProblem()
+        limit_state = problem.create_limit_state_function()
+        rng = np.random.default_rng(1)
+        values = np.asarray(limit_state(rng.standard_normal((40, 10))))
+
+        assert float(values.std()) > 0.1
+        assert len(np.unique(values)) == values.size
+
+    def test_input_dimension_is_checked(self) -> None:
+        limit_state = HeatTransferProblem().create_limit_state_function()
+        with pytest.raises(ValueError, match="dimension"):
+            limit_state(np.zeros((3, 4)))
+
+    @pytest.mark.slow
+    def test_estimate_is_near_the_paper_reference(self) -> None:
+        """Within an order of magnitude, given a different discretisation.
+
+        The paper solves the field with finite elements over 25040 triangles;
+        this is second-order finite differences on 21x21. The measured median
+        is 2.83e-07 against the paper's 4.69e-07.
+        """
+        limit_state = HeatTransferProblem().create_limit_state_function()
+
+        estimates = []
+        for seed in range(3):
+            ice = SafeICE(
+                limit_state_function=limit_state,
+                dimension=10,
+                N=1000,
+                max_iterations=15,
+                random_state=seed,
+            )
+            pf, _ = ice.run(verbose=False)
+            estimates.append(pf)
+
+        median = float(np.median(estimates))
+        assert PAPER_REFERENCE_PF / 10 < median < PAPER_REFERENCE_PF * 10, (
+            f"median {median:.3e} against the paper's {PAPER_REFERENCE_PF:.3e}; "
+            f"estimates {estimates}"
+        )

--- a/tests/test_heat_transfer_reference.py
+++ b/tests/test_heat_transfer_reference.py
@@ -113,6 +113,20 @@ class TestTheSolver:
         assert float(np.min(temperature[0, 1:-1])) > 0.0
         assert np.all(np.isfinite(temperature))
 
+    def test_extreme_samples_stay_finite(self) -> None:
+        """The estimator's heavy tails reach far enough to underflow kappa.
+
+        ``kappa = exp(a + b f)`` goes to zero for a large enough negative
+        field, which leaves the conduction matrix singular and the solve
+        returning NaN. A run would then fail outright on the sample that hit
+        it, so the exponent is clipped.
+        """
+        limit_state = HeatTransferProblem().create_limit_state_function()
+        rng = np.random.default_rng(0)
+        for scale in (1.0, 10.0, 100.0, 1000.0):
+            values = np.asarray(limit_state(rng.standard_normal((10, 10)) * scale))
+            assert np.all(np.isfinite(values)), f"non-finite at scale {scale}"
+
     def test_field_is_finite_and_bounded(self) -> None:
         """The relaxation left 380 of 441 nodes pinned at a +/-1e6 clamp."""
         problem = HeatTransferProblem()

--- a/tests/test_heat_transfer_reference.py
+++ b/tests/test_heat_transfer_reference.py
@@ -193,8 +193,16 @@ class TestLimitState:
         """Within an order of magnitude, given a different discretisation.
 
         The paper solves the field with finite elements over 25040 triangles;
-        this is second-order finite differences on 21x21. The measured median
-        is 2.83e-07 against the paper's 4.69e-07.
+        this is second-order finite differences on 21x21. The median over
+        seeds is about 3e-07 against the paper's 4.69e-07.
+
+        The median rather than each run: on this problem the estimator
+        collapses on a minority of seeds. Sigma falls too far in the first two
+        iterations -- 1 to 0.37 to 0.13 -- and then stalls, the weight CV never
+        comes down from 6-8 against a target of 4, and the run ends many orders
+        of magnitude low. Two of six seeds did that in one measurement. It is
+        a property of the sigma schedule of equation (10) on a 10-dimensional
+        problem with a smooth limit state, not of this module; see ROADMAP.md.
         """
         limit_state = HeatTransferProblem().create_limit_state_function()
 


### PR DESCRIPTION
Third of three PRs from reviewing the implementation against the paper.

This was the least covered module in the package and had never been checked against an independent answer. It did not work.

**The field solver diverged.** The temperature came from an explicit relaxation, `T += 0.01 * (laplacian + Q)`, run for 1000 sweeps and clamped to ±1e6. An elliptic problem has no time derivative to march, and that fixed pseudo-step was about sixteen times the explicit stability limit for the default grid. 380 of 441 nodes ended pinned at the clamp, and the limit state returned exactly `threshold` for every input — no dependence on the random field at all.

**Four parameters disagreed with section 4.5:**

| | code | paper |
| --- | --- | --- |
| correlation length | `0.5` | `l = 0.2` |
| failure threshold | `100` | `10`, equation (48) |
| covariance | `exp(-r/l)` | `exp(-r²/l²)`, equation (46) |
| heat source | full-height strip | the square `A` |

The strip came from a `np.where` on the y extent whose result was discarded.

**Result.** The field is now a direct sparse solve of the five-point conservative discretisation, which reproduces the analytic solution of the uniform case to machine precision. Safe-ICE estimates `2.83e-07` against the paper's `4.69e-07` — a factor of 0.60, using finite differences on 21×21 where the paper uses finite elements over 25040 triangles.

**Two more defects surfaced along the way:**

- Region membership used exact floating-point comparisons on bounds that a `linspace` reproduces at some grid sizes and misses by an ulp at others, so a region silently lost a row of nodes at `grid_size=31`.
- Assigning `Q` to each source node made the discrete heat input `((0.1+h)/0.1)²` times too large — 2.25x at `grid_size=21` against 1.44x at 51. That was the *entire* apparent grid dependence: dividing it out left the same number at every grid. Spreading `Q` over the region's area fixes it, and the nominal average temperature on `B` is now 4.553 at every grid size tested, against 10.24, 8.09, 7.11 and 6.56 before.

**On the boundary conditions.** The paper contradicts itself: section 4.5's text says "zero Neumann on the top part and zero Dirichlet in the rest", Figure 11 draws the opposite. Only the figure is consistent — with three edges able to shed heat, the nominal temperature on `B` is 0.49 against a threshold of 10, which is 51 standard deviations away and could never produce the reported probability. With the top edge as the only sink it is 4.55. I followed the figure and recorded why.

Coverage of the module goes 11% → 99%, and the package 54% → 61%.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the divergent relaxation in the heat transfer benchmark with a direct sparse solve and aligns parameters and regions with section 4.5, so results depend on the random field and match the paper within ~0.6×. Old behavior diverged and returned a constant threshold; new behavior solves a five‑point conservative discretization with Dirichlet on the top edge and Neumann elsewhere, and clips the Gaussian field at ±30σ to keep solves stable.

**Key changes**
- Switch to `scipy.sparse.linalg.spsolve`; average conductivity on faces; spread `Q` over A’s area to remove grid dependence.
- Align with the paper: squared‑exponential covariance `exp(-r^2/l^2)`; defaults now `correlation_length=0.2`, `threshold=10.0`; region B is (-0.3, -0.2) × (-0.3, -0.2); canonicalize KL mode signs.
- Robust rectangle masks avoid float‑edge off‑by‑one rows; boundary conditions follow Figure 11 (Dirichlet top, Neumann elsewhere).
- Clip the Gaussian field at ±30σ so `kappa` stays well‑conditioned and `spsolve` remains finite on heavy‑tailed samples.
- Reference tests added: analytic uniform‑case check; grid‑independent mean T on B ≈ 4.55; Safe‑ICE median 2.83e‑07 vs paper 4.69e‑07; ROADMAP documents a sigma‑schedule weakness seen on this benchmark.

**Migration**
- Ensure `scipy` is available at runtime.
- Update baselines if you relied on old `HeatTransferProblem` defaults, boundary conditions, covariance, or region definitions. To keep previous thresholds only, pass `correlation_length=0.5` and `threshold=100.0` explicitly.

<sup>Written for commit 0b20a06eb2be0c9e39157b2298778586102548d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/adaptive-importance-sampling/pull/94?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

