### PR TITLE
Bracket the sigma search instead of minimising a mostly-infinite objective

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The search for sigma in equation (10) was ill-posed, and runs collapsed
+  because of it.** The equation minimises `(CV(W_t(sigma)) - delta_target)^2`
+  over `(0, sigma_prev)`, and the whole interval was handed to a bounded
+  minimiser. Below some sigma the smoothed indicator `Phi(-g/sigma)` underflows
+  to zero for every sample, so the weights all vanish and the CV is undefined;
+  on a rare-event problem that is most of the interval, and a minimiser given a
+  mostly-infinite objective returns arbitrary points. On the heat transfer
+  problem it took sigma from 1 to 0.373, where the CV is 18.75, when 0.999 was
+  available at 9.5 against a target of 4. Sigma then fell faster than the
+  proposal could follow, the CV never recovered, and two of six seeds ended at
+  1e-27 and 1e-34 against a reference of 4.69e-07.
+
+  Simply fixing the search to find the true global minimum is worse. Just above
+  the underflow region only a handful of samples still carry weight, and the CV
+  of one surviving sample out of N is about `sqrt(N)`, so it sweeps through the
+  target on its way to infinity. Those spurious minima sit at a sigma hundreds
+  of times too small, and are what the old minimiser was accidentally missing.
+
+  The CV rises monotonically as sigma falls, so the minimiser is the largest
+  sigma at which it reaches the target. That is now bracketed from above and
+  found by bisection. The densities in `W_t` do not depend on sigma, so they
+  are hoisted out of the search, which costs about as much as the single
+  objective evaluation it replaces.
+
+  Accuracy is unchanged and robustness is much better. Across nine problems the
+  median estimate is within 0.93x to 1.07x of its reference, and the *worst
+  individual seed* is 0.83x:
+
+  | Problem | reference | median | worst seed |
+  | --- | --- | --- | --- |
+  | four-mode `z=1.0` | `6.465e-05` | 1.00x | 0.83x |
+  | three-mode `z=3.0` | `3.475e-03` | 1.05x | 0.96x |
+  | two-mode `z=3.0` | `2.700e-03` | 1.07x | 0.95x |
+  | oscillator `z=0.05` | `1.798e-03` | 0.98x | 0.88x |
+  | nakagami ratio | `5.188e-02` | 1.00x | 0.98x |
+  | sphere `d=2` | `2.187e-03` | 1.02x | 1.00x |
+  | sphere `d=10` | `5.346e-03` | 1.01x | 1.01x |
+  | sphere `d=50` | `3.610e-03` | 0.99x | 0.95x |
+  | sphere `d=200` | `4.565e-03` | 0.93x | 0.85x |
+
+  The heat transfer estimate is now `3.07e-07` against the paper's `4.69e-07`
+  on every seed, where before the median hid two collapsed runs.
+
 - **The heat transfer problem did not work, and no test would have noticed.**
   It was the least covered module in the package and had never been checked
   against an independent answer. The temperature field came from an explicit

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -39,24 +39,16 @@ Its field solver diverged and the limit state ignored its input entirely. It
 now uses a direct sparse solve, verified against an analytic solution, and
 Safe-ICE estimates `2.83e-07` against the paper's `4.69e-07`.
 
+### Done: the sigma schedule no longer collapses
+
+Equation (10)'s search was ill-posed. Below some sigma the smoothed indicator
+underflows for every sample and the CV is undefined, which on a rare-event
+problem is most of the interval; a bounded minimiser handed a mostly-infinite
+objective returned arbitrary points. It is now bracketed from above, and the
+worst individual seed across nine problems sits at 0.83x its reference, where
+two of six seeds on the heat transfer problem previously returned 1e-27.
+
 ## Next
-
-### Make the sigma schedule robust on smooth high-dimensional problems
-
-On the heat transfer problem the estimator collapses on a minority of seeds:
-sigma falls too far in the first two iterations, from 1 to 0.37 to 0.13, then
-stalls, and the weight coefficient of variation never comes down from 6-8
-against a target of 4. Those runs end many orders of magnitude low -- 1e-27
-rather than 3e-07. Two of six seeds did this in one measurement, and the median
-is unaffected, which is why the reference test takes one.
-
-Equation (10) chooses sigma by minimising `(CV - delta_target)^2` over
-`(0, sigma_prev)`. When no sigma in that interval achieves the target the
-minimiser returns a point near the boundary, and the proposal never catches up.
-A floor on how far sigma may fall in one step, or a retry when the CV worsens,
-would likely fix it, but both are departures from the paper and need measuring
-across the whole benchmark set before being adopted.
-
 
 ### Cover the untested modules
 

--- a/safe_ice/core/safe_ice.py
+++ b/safe_ice/core/safe_ice.py
@@ -17,7 +17,6 @@ from typing import Any, TypedDict
 import numpy as np
 import numpy.typing as npt
 import scipy.stats as stats
-from scipy.optimize import minimize_scalar
 from scipy.special import loggamma
 
 from ..distributions._numeric import radii_and_directions, vmf_pdf_batch
@@ -522,31 +521,82 @@ class SafeICE:
         lambda_val: float,
         sigma_prev: float,
     ) -> float:
-        """Determine next smoothing parameter σ by solving the 1-D problem (10)."""
+        """Determine the next smoothing parameter sigma, equation (10).
 
-        def cv_objective(sigma: float) -> float:
-            """Objective: (δ_W_t(σ) - δ_target)^2 for 0 < σ < σ_prev."""
-            if sigma >= sigma_prev or sigma <= 0.0:
-                return 1e10  # reject invalid region
-            weights = self._calculate_intermediate_weights(
-                samples, g_values, sigma, params, lambda_val
+        Equation (10) minimises ``(CV(W_t(sigma)) - delta_target)^2`` over
+        ``(0, sigma_prev)``. The CV rises monotonically as sigma falls -- a
+        sharper indicator concentrates the weights on fewer samples -- so the
+        minimiser is the sigma at which the CV first reaches the target, and
+        this brackets it from above rather than searching the whole interval.
+
+        Searching the whole interval does not work, in two different ways.
+        Below some sigma the smoothed indicator ``Phi(-g/sigma)`` underflows to
+        zero for every sample, the weights all vanish and the CV is undefined;
+        on a rare-event problem that is most of the interval, and a bounded
+        minimiser handed a mostly-infinite objective returns arbitrary points.
+        That took sigma from 1 to 0.373 on the heat transfer problem, where the
+        CV is 18.75, when 0.999 was available at 9.5 against a target of 4;
+        sigma then fell faster than the proposal could follow and the run ended
+        twenty orders of magnitude low. Fixing the search to find the true
+        global minimum is worse still: just above the underflow region only a
+        handful of samples carry any weight, and the CV of one surviving sample
+        out of N is about sqrt(N), so it sweeps through the target on its way
+        to infinity. Those spurious minima sit at a sigma hundreds of times too
+        small, and are exactly what the old minimiser was accidentally missing.
+
+        The densities in ``W_t`` do not depend on sigma, so they are evaluated
+        once and only the smoothed indicator is recomputed per candidate.
+        """
+        upper = float(sigma_prev) * 0.999
+        if upper <= 0.0:
+            return 1e-8
+
+        # Sigma-independent part of W_t = h(u; sigma) * p(u) / q_safe(u).
+        prior_densities = self._evaluate_prior_density(samples)
+        safe_densities = self._evaluate_safe_mixture_density(
+            samples, params, lambda_val
+        )
+        density_ratio = prior_densities / np.maximum(safe_densities, DENSITY_FLOOR)
+
+        def cv_at(sigma: float) -> float:
+            h_values = np.asarray(
+                stats.norm.cdf(-g_values / float(sigma)), dtype=np.float64
             )
-            cv = self._coefficient_of_variation(weights)
-            return float((cv - self.delta_target) ** 2)
+            return self._coefficient_of_variation(h_values * density_ratio)
 
-        # Minimize over (tiny, sigma_prev)
-        try:
-            result = minimize_scalar(
-                cv_objective,
-                bounds=(1e-8, float(sigma_prev) * 0.999),
-                method="bounded",
-            )
-            new_sigma = float(result.x)
-        except Exception:
-            # Fallback: conservative reduction
-            new_sigma = float(sigma_prev) * 0.8
+        def too_degenerate(sigma: float) -> bool:
+            """Has the CV reached the target, or stopped being computable?"""
+            cv = cv_at(sigma)
+            return (not np.isfinite(cv)) or cv >= self.delta_target
 
-        return float(max(new_sigma, 1e-8))
+        # Already at or past the target: sigma cannot usefully fall yet. Hold
+        # it and let the EM update improve the proposal first.
+        if too_degenerate(upper):
+            return upper
+
+        # Walk down until the target is crossed, then bisect on that bracket.
+        lower = upper
+        bracket_found = False
+        for candidate in np.geomspace(upper, upper * 1e-6, 32)[1:]:
+            if too_degenerate(float(candidate)):
+                lower = float(candidate)
+                bracket_found = True
+                break
+
+        if not bracket_found:
+            # The target is out of reach across the scanned range; take the
+            # smallest sigma still known to be well behaved.
+            return float(max(upper * 1e-6, 1e-8))
+
+        high = upper
+        for _ in range(40):
+            mid = float(np.sqrt(lower * high))
+            if too_degenerate(mid):
+                lower = mid
+            else:
+                high = mid
+
+        return float(min(max(high, 1e-8), upper))
 
     def _calculate_intermediate_weights(
         self,

--- a/tests/test_heat_transfer_reference.py
+++ b/tests/test_heat_transfer_reference.py
@@ -196,13 +196,9 @@ class TestLimitState:
         this is second-order finite differences on 21x21. The median over
         seeds is about 3e-07 against the paper's 4.69e-07.
 
-        The median rather than each run: on this problem the estimator
-        collapses on a minority of seeds. Sigma falls too far in the first two
-        iterations -- 1 to 0.37 to 0.13 -- and then stalls, the weight CV never
-        comes down from 6-8 against a target of 4, and the run ends many orders
-        of magnitude low. Two of six seeds did that in one measurement. It is
-        a property of the sigma schedule of equation (10) on a 10-dimensional
-        problem with a smooth limit state, not of this module; see ROADMAP.md.
+        Every seed lands in range. Two of six used to collapse to 1e-27 and
+        1e-34, which was the sigma search of equation (10) rather than anything
+        in this module.
         """
         limit_state = HeatTransferProblem().create_limit_state_function()
 
@@ -218,8 +214,8 @@ class TestLimitState:
             pf, _ = ice.run(verbose=False)
             estimates.append(pf)
 
-        median = float(np.median(estimates))
-        assert PAPER_REFERENCE_PF / 10 < median < PAPER_REFERENCE_PF * 10, (
-            f"median {median:.3e} against the paper's {PAPER_REFERENCE_PF:.3e}; "
-            f"estimates {estimates}"
-        )
+        for seed, pf in enumerate(estimates):
+            assert PAPER_REFERENCE_PF / 10 < pf < PAPER_REFERENCE_PF * 10, (
+                f"seed {seed} returned {pf:.3e} against the paper's "
+                f"{PAPER_REFERENCE_PF:.3e}"
+            )

--- a/tests/test_proposal_normalisation.py
+++ b/tests/test_proposal_normalisation.py
@@ -15,6 +15,8 @@ dropped.
 
 from __future__ import annotations
 
+from itertools import pairwise
+
 import numpy as np
 import pytest
 from scipy import stats
@@ -368,3 +370,104 @@ class TestPenaltyCoefficientSchedule:
         """E = 1*ln 1 = 0 there, so equation (24)'s denominator vanishes."""
         one = np.array([1.0])
         assert self.beta_of(one, one, one, 1000, 2) == 0.0
+
+
+class TestSigmaSchedule:
+    """Equation (10) picks sigma; the search for it has to be well posed.
+
+    The CV of the intermediate weights rises monotonically as sigma falls, so
+    the minimiser is the largest sigma at which it reaches the target. Two
+    things make a naive search on the whole interval fail:
+
+    * below some sigma the smoothed indicator underflows for every sample, the
+      weights all vanish and the CV is undefined -- on a rare-event problem
+      that is most of the interval, and a bounded minimiser handed a
+      mostly-infinite objective returns arbitrary points;
+    * just above that region only a handful of samples still carry weight, and
+      the CV of one surviving sample out of N is about sqrt(N), so it sweeps
+      through the target on its way to infinity. Those spurious minima sit at a
+      sigma hundreds of times too small.
+    """
+
+    @staticmethod
+    def estimator(seed, dimension=2, **kwargs):
+        from safe_ice.problems.benchmarks import BenchmarkProblems
+
+        return SafeICE(
+            limit_state_function=BenchmarkProblems.four_mode_series_system(),
+            dimension=dimension,
+            N=1000,
+            max_iterations=12,
+            random_state=seed,
+            **kwargs,
+        )
+
+    def test_sigma_decreases_monotonically(self) -> None:
+        ice = self.estimator(0)
+        ice.run(verbose=False)
+        sigmas = ice.history["sigma"]
+
+        assert len(sigmas) >= 2
+        assert all(later <= earlier for earlier, later in pairwise(sigmas)), (
+            f"sigma did not decrease monotonically: {sigmas}"
+        )
+
+    def test_first_step_does_not_overshoot(self) -> None:
+        """It fell from 1 to 0.373 in one step where 0.999 was the minimiser.
+
+        The proposal is still the initial one at that point, so a large drop
+        leaves it unable to follow, and the weight CV never recovers.
+        """
+        ice = self.estimator(0)
+        ice.run(verbose=False)
+        sigmas = ice.history["sigma"]
+
+        assert sigmas[1] > 0.5 * sigmas[0], (
+            f"sigma fell from {sigmas[0]} to {sigmas[1]} on the first step"
+        )
+
+    def test_returned_sigma_is_inside_the_interval(self) -> None:
+        """Equation (10) minimises over the open interval (0, sigma_prev)."""
+        ice = self.estimator(3)
+        params = ice._initialize_vmfnm_parameters()
+        samples = ice._generate_safe_mixture_samples(params, 0.0)
+        g_values = ice._evaluate_limit_state(samples)
+
+        for sigma_prev in (1.0, 0.5, 0.01):
+            chosen = ice._determine_next_sigma(
+                samples, g_values, params, 0.0, sigma_prev
+            )
+            assert 0.0 < chosen <= sigma_prev
+
+    def test_target_is_met_when_it_is_reachable(self) -> None:
+        """Where a root exists, the chosen sigma should sit on it."""
+        ice = self.estimator(1)
+        params = ice._initialize_vmfnm_parameters()
+        samples = ice._generate_safe_mixture_samples(params, 0.0)
+        g_values = ice._evaluate_limit_state(samples)
+
+        chosen = ice._determine_next_sigma(samples, g_values, params, 0.0, 1.0)
+        weights = ice._calculate_intermediate_weights(
+            samples, g_values, chosen, params, 0.0
+        )
+        cv = ice._coefficient_of_variation(weights)
+
+        if chosen < 0.999:  # a root was found rather than the interval held
+            assert cv == pytest.approx(ice.delta_target, rel=0.25), (
+                f"CV {cv} at sigma {chosen} against target {ice.delta_target}"
+            )
+
+    def test_no_seed_collapses_on_a_smooth_problem(self) -> None:
+        """The failure this guards against was a run twenty orders of magnitude low.
+
+        On the heat transfer problem two of six seeds returned 1e-27 and 1e-34
+        against a reference of 4.69e-07. The four-mode problem is cheap enough
+        to check every seed here.
+        """
+        reference = 6.465e-05
+        estimates = [self.estimator(seed).run(verbose=False)[0] for seed in range(8)]
+
+        for seed, pf in enumerate(estimates):
+            assert reference / 5 < pf < reference * 5, (
+                f"seed {seed} returned {pf:.3e} against {reference:.3e}"
+            )


### PR DESCRIPTION
The collapse recorded in the roadmap turned out to be a defect in the search for sigma, not a limitation of the paper's rule.

**The objective is undefined over most of its domain.** Equation (10) minimises `(CV(W_t(sigma)) - delta_target)^2` over `(0, sigma_prev)`, and the whole interval was handed to `minimize_scalar`. Below some sigma the smoothed indicator `Phi(-g/sigma)` underflows to zero for *every* sample, so the weights all vanish and the CV is undefined. On a rare-event problem that is most of the interval:

```
CV over sigma:  inf inf inf inf inf inf inf inf inf inf 31.6 31.6 19.7 9.5
```

A bounded minimiser cannot bracket anything across that. It took sigma from 1 to 0.373, where the CV is 18.75, when 0.999 was available at 9.5 against a target of 4. Sigma then fell faster than the proposal could follow, the CV never came back below 6–8, and two of six seeds on the heat transfer problem ended at `1e-27` and `1e-34` against a reference of `4.69e-07`.

**Fixing the search naively is worse.** I tried a grid scan for the true global minimum first. Just above the underflow region only a handful of samples still carry weight, and the CV of one surviving sample out of N is about `sqrt(N)`, so it sweeps through the target on its way to infinity. Those spurious minima sit at a sigma hundreds of times too small — exactly what the old minimiser was accidentally missing. That made things worse: seed 0 went to `pf = 0`.

**The fix.** The CV rises monotonically as sigma falls, so the minimiser is the *largest* sigma at which it reaches the target. That is now bracketed from above and found by bisection. The densities in `W_t` do not depend on sigma, so they are hoisted out, and the search costs about as much as the single objective evaluation it replaces.

Accuracy is unchanged; robustness is much better. Note the last column — previously the worst seed on heat transfer was off by twenty orders of magnitude:

| Problem | reference | median | worst seed |
| --- | --- | --- | --- |
| four-mode `z=1.0` | `6.465e-05` | 1.00x | 0.83x |
| three-mode `z=3.0` | `3.475e-03` | 1.05x | 0.96x |
| two-mode `z=3.0` | `2.700e-03` | 1.07x | 0.95x |
| oscillator `z=0.05` | `1.798e-03` | 0.98x | 0.88x |
| nakagami ratio | `5.188e-02` | 1.00x | 0.98x |
| sphere `d=2` | `2.187e-03` | 1.02x | 1.00x |
| sphere `d=10` | `5.346e-03` | 1.01x | 1.01x |
| sphere `d=50` | `3.610e-03` | 0.99x | 0.95x |
| sphere `d=200` | `4.565e-03` | 0.93x | 0.85x |

The heat transfer test now asserts every seed rather than a median that was hiding two collapsed runs.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Brackets the sigma search in equation (10) and finds the largest sigma that reaches the CV target by bisection, replacing a bounded minimization over (0, sigma_prev) that often evaluated an undefined objective. This avoids underflow-induced collapses on rare-event problems and stabilizes early iterations without changing accuracy.

- Replaces `scipy.optimize.minimize_scalar` with a bracketed search in `_determine_next_sigma` (`safe_ice/core/safe_ice.py`): precomputes the sigma-independent density ratio, scans down to bracket the target, holds sigma if CV already ≥ target, bisects on the bracket, and clamps to `(0, sigma_prev]` with a `1e-8` floor.
- Improves behavior on smooth, high-dimensional cases: sigma no longer overshoots on the first step, CV hits the target when reachable, and runs do not collapse; performance is ~unchanged since densities are hoisted.
- Tests: `tests/test_heat_transfer_reference.py` now asserts every seed; new `TestSigmaSchedule` in `tests/test_proposal_normalisation.py` checks monotonic sigma, no overshoot, bracket correctness, and robustness.
- Docs: `CHANGELOG.md` and `ROADMAP.md` record the defect and the fix.

<sup>Written for commit 34b5abf4b20b85af2b416d717746cc71fd50e937. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/adaptive-importance-sampling/pull/95?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

