### PR TITLE
Release 0.3.0

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "Safe-ICE: Safe Cross-Entropy-Based Importance Sampling for rare event simulation",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "upload_type": "software",
   "creators": [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-08-18
+
 ### Removed
 
 - `safe_ice.utils`. Nothing in the package imported it, and where it overlapped
@@ -545,5 +547,6 @@ quoted as `1.22e-5` against a measured `5.815e-05`.
   Karhunen-Loève expansion.
 - Performance evaluation and convergence analysis utilities.
 
-[Unreleased]: https://github.com/DiogoRibeiro7/adaptive-importance-sampling-ice/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/DiogoRibeiro7/adaptive-importance-sampling-ice/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/DiogoRibeiro7/adaptive-importance-sampling-ice/releases/tag/v0.3.0
 [0.2.0]: https://github.com/DiogoRibeiro7/adaptive-importance-sampling-ice/releases/tag/v0.2.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -24,7 +24,7 @@ keywords:
   - cross-entropy method
   - structural reliability
 license: MIT
-version: 0.2.0
+version: 0.3.0
 references:
   - type: article
     title: >-

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,12 +3,21 @@
 Where the project is and what is planned next. Items are listed in the order
 they are likely to be worked on, not by importance.
 
-## Now: 0.2.0
+## Now: 0.3.0
 
-The first release since the package was reorganised. It is a correctness
-release: eight bugs that biased or broke every estimate were found by comparing
-against independent references, and the packaging, CI and test suite were
-rebuilt around catching that class of problem earlier.
+0.3.0 is a second correctness release, and the one that checked the
+implementation against the source paper equation by equation. It fixed the
+four-mode limit state, which had `sqrt(3.5)` where equation (37) has
+`7/sqrt(2)`; implemented the nonlinear oscillator and the heat transfer
+problem, neither of which worked; replaced the penalty coefficient with
+equations (23) and (24); and repaired the search for sigma in equation (10),
+which had been minimising an objective that is undefined over most of its
+domain. Coverage went from 53% to 85%.
+
+0.2.0 was the first release since the package was reorganised, also a
+correctness release: eight bugs that biased or broke every estimate were found
+by comparing against independent references, and the packaging, CI and test
+suite were rebuilt around catching that class of problem earlier.
 
 The estimator now agrees with closed-form answers to within a few percent from
 `d=2` through `d=200`, and with 2e7-sample Monte Carlo on the benchmark
@@ -65,6 +74,108 @@ tests for whatever was there:
   by design.
 
 ## Next
+
+These are the next items from a repository review on 2026-08-18. The estimator
+core is in much better shape than the surrounding product surface; the highest
+return is now to make the public API, docs, visualisation tools and release
+metadata line up with the corrected implementation.
+
+### Fix the result object contract
+
+`run()` currently returns internally useful data under names that promise
+something narrower than they contain. `results["final_samples"]` and
+`results["final_g_values"]` are all iteration samples, not the separate sample
+set used for the final probability estimate, and `results["final_weights"]` is
+an array of ones rather than the final importance weights. That is harmless for
+tests that only check shape and non-negativity, but it makes downstream plots
+and user analyses compute the wrong thing while looking plausible.
+
+Define the result schema explicitly before adding more analysis features:
+
+* keep per-iteration proposal samples separate from final-estimator samples;
+* expose the actual final importance weights used in equation (36);
+* record `n_failures`, `parameters`, `sigma`, `lambda`, `cv` and the current
+  estimate consistently for each iteration, or remove consumers that expect
+  them;
+* update README, Sphinx docs and tests to assert semantics, not just key
+  presence.
+
+### Repair the analysis and visualisation layer
+
+The numerical core is now covered; the plotting layer mostly has smoke tests.
+Several functions still depend on stale result fields:
+
+* `AdvancedAnalysis.analyze_component_evolution` reads `history["lambda"]`,
+  but `SafeICE` records `history["lambda_val"]`;
+* the Plotly convergence view hard-codes a target CV of `0.05`, while the
+  algorithm default is `delta_star = 1.5`;
+* the failure-count plot reads `n_failures`, which `run()` never records;
+* the mixture-evolution animation expects per-iteration `parameters`, which are
+  not stored;
+* the dashboard computes a displayed probability from placeholder weights
+  rather than from the importance-sampling estimator.
+
+Fix these after the result schema is settled. Tests should check plotted values
+against a small deterministic run, not only that a figure object exists.
+
+### Refresh the public documentation
+
+The docs build cleanly, but some examples still describe the pre-0.3 API and
+old benchmark state. In particular, `docs/source/quickstart.rst` still cites
+the old four-mode reference (`1.22e-5`), reads `iter_data["delta"]` although
+iteration records expose `sigma`, and imports `VisualizationTools`, which is
+not part of the package. The install docs also still recommend Poetry commands
+even though project metadata and development groups now live in PEP 621/735.
+
+Bring README, Sphinx docs and examples back into one story: corrected
+benchmarks, current result keys, current dependency installation, and the
+actual analysis API.
+
+### Normalise repository identity before release
+
+GitHub reports that the repository has moved from
+`adaptive-importance-sampling-ice` to `adaptive-importance-sampling`. The old
+URL still appears in package metadata, docs, badges, Docker labels, citation
+metadata, Zenodo metadata and the CLI epilogue. Either keep the old URL
+deliberately as a redirect, or update all public links in one release-prep
+commit so badges, installation snippets, citation metadata and changelog links
+point at the canonical repository.
+
+### Finish 0.3.0 release hygiene
+
+The release branch already bumps `pyproject.toml`, `CITATION.cff`,
+`.zenodo.json` and the conda recipe to `0.3.0`, and the version-bump tooling
+now knows about `.zenodo.json`. Before tagging:
+
+* move the populated `CHANGELOG.md` `0.3.0` section out of any local-only state;
+* verify `python scripts/pyproject_editor.py --check bump-version patch`
+  reports companion-file changes without writing them;
+* run the full CI-equivalent suite with an installed package:
+  `ruff check .`, `ruff format --check .`, `mypy`,
+  `pytest -m "" -n auto`, Sphinx with `-W`, build, and `twine check`;
+* decide whether `.zenodo.json` should carry `version` even though Zenodo's
+  legacy JSON schema does not list it. Zenodo's GitHub integration documents
+  version metadata, but editor schema validation may complain if a strict
+  legacy schema is attached.
+
+### Preserve benchmark evidence outside the tests
+
+The package now relies on independent references: closed forms, 2e7-sample
+Monte Carlo for 2D benchmarks, 2e6-sample Monte Carlo for the oscillator, and a
+paper comparison for heat transfer. Those numbers are too expensive to
+regenerate in normal CI, so the project should keep the scripts, seeds,
+sample counts and resulting confidence intervals as auditable artefacts under
+`benchmarks/` or `paper/`. That makes future correctness releases easier to
+review and keeps README/CHANGELOG claims reproducible.
+
+### Improve local validation ergonomics
+
+`ruff` and formatting are fast, mypy passes, and docs build with warnings as
+errors. The default local test run is still long enough that it is easy to hit
+tooling timeouts, while CI gets parallelism from `pytest -n auto`. Make the
+local workflow clearer by documenting the intended quick, full and release
+commands, and consider adding a Makefile target that mirrors CI exactly after
+installing the dev group.
 
 ## Later
 

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "safe-ice" %}
-{% set version = "0.2.0" %}
+{% set version = "0.3.0" %}
 
 package:
   name: {{ name|lower }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "safe-ice"
-version = "0.2.0"
+version = "0.3.0"
 description = "Safe Cross-Entropy-Based Importance Sampling for rare event simulation"
 readme = "README.md"
 license = "MIT"

--- a/scripts/pyproject_editor.py
+++ b/scripts/pyproject_editor.py
@@ -233,6 +233,7 @@ def _bump_semver(v: str, level: VersionBump) -> str:
 # Each entry is (path relative to the project root, regex, replacement template).
 VERSION_COMPANIONS: tuple[tuple[str, str, str], ...] = (
     ("CITATION.cff", r"(?m)^version: .+$", "version: {version}"),
+    (".zenodo.json", r'(?m)^  "version": "[^"]+",$', '  "version": "{version}",'),
     (
         "conda.recipe/meta.yaml",
         r'(?m)^\{% set version = "[^"]+" %\}$',

--- a/tests/test_version_bump.py
+++ b/tests/test_version_bump.py
@@ -30,6 +30,14 @@ requires_tomlkit = pytest.mark.skipif(
 )
 
 
+ZENODO_TEMPLATE = """{{
+  "title": "Safe-ICE",
+  "version": "{version}",
+  "upload_type": "software"
+}}
+"""
+
+
 @pytest.fixture
 def project(tmp_path: Path) -> Path:
     """A miniature copy of the files a bump has to keep in step."""
@@ -40,6 +48,10 @@ def project(tmp_path: Path) -> Path:
     )
     (tmp_path / "CITATION.cff").write_text(
         "cff-version: 1.2.0\ntitle: Safe-ICE\nversion: 1.2.3\nlicense: MIT\n",
+        encoding="utf-8",
+    )
+    (tmp_path / ".zenodo.json").write_text(
+        ZENODO_TEMPLATE.format(version="1.2.3"),
         encoding="utf-8",
     )
     (tmp_path / "conda.recipe" / "meta.yaml").write_text(
@@ -68,10 +80,22 @@ class TestBumpKeepsMetadataInStep:
 
         assert 'version = "1.3.0"' in (project / "pyproject.toml").read_text()
         assert "version: 1.3.0" in (project / "CITATION.cff").read_text()
+        assert '"version": "1.3.0"' in (project / ".zenodo.json").read_text()
         assert (
             '{% set version = "1.3.0" %}'
             in (project / "conda.recipe" / "meta.yaml").read_text()
         )
+
+    def test_the_zenodo_record_stays_valid_json(self, project: Path) -> None:
+        """A regex rewrite must not corrupt the surrounding document."""
+        import json
+
+        run_editor(project, "bump-version", "patch")
+
+        record = json.loads((project / ".zenodo.json").read_text(encoding="utf-8"))
+        assert record["version"] == "1.2.4"
+        assert record["title"] == "Safe-ICE"
+        assert record["upload_type"] == "software"
 
     def test_the_recipe_keeps_its_jinja_syntax(self, project: Path) -> None:
         """The replacement is a template, so a stray brace would corrupt it."""
@@ -96,6 +120,7 @@ class TestBumpKeepsMetadataInStep:
             for path in (
                 project / "pyproject.toml",
                 project / "CITATION.cff",
+                project / ".zenodo.json",
                 project / "conda.recipe" / "meta.yaml",
             )
         }
@@ -124,6 +149,9 @@ class TestTheRealRepositoryStaysConsistent:
 
         citation = (REPO_ROOT / "CITATION.cff").read_text(encoding="utf-8")
         assert f"version: {pyproject_version}" in citation
+
+        zenodo = (REPO_ROOT / ".zenodo.json").read_text(encoding="utf-8")
+        assert f'"version": "{pyproject_version}"' in zenodo
 
         recipe_path = REPO_ROOT / "conda.recipe" / "meta.yaml"
         if recipe_path.exists():


### PR DESCRIPTION
Cuts 0.3.0. Minor rather than patch: `safe_ice.utils` and `nonlinear_oscillator_simplified` are gone, `run()` now clamps its return value, and several problem defaults changed because they were wrong.

This is the release that checked the implementation against the source paper equation by equation:

| | was | paper |
| --- | --- | --- |
| four-mode, eq (37) | `sqrt(3.5)` | `7/sqrt(2)` |
| nonlinear oscillator, eqs (39)–(42) | a closed form found nowhere in the paper | Bouc-Wen, integrated |
| heat transfer, §4.5 | diverging relaxation, 4 wrong parameters | direct solve |
| penalty coefficient, eqs (23)–(24) | "simple adaptive heuristic" | implemented |
| pruning, eq (22) | `pi > 1e-4` | `pi <= 0` |
| sigma search, eq (10) | minimised a mostly-undefined objective | bracketed from above |

Measured against independent references, every problem now lands — and the worst *individual seed*, not just the median, is 0.83x:

| Problem | reference | median | worst seed |
| --- | --- | --- | --- |
| four-mode `z=1.0` | `6.465e-05` | 1.00x | 0.83x |
| three-mode `z=3.0` | `3.475e-03` | 1.05x | 0.96x |
| two-mode `z=3.0` | `2.700e-03` | 1.07x | 0.95x |
| oscillator `z=0.05` | `1.798e-03` | 0.98x | 0.88x |
| sphere `d=2` … `d=200` | closed form | 0.93–1.02x | 0.85–1.01x |
| heat transfer | `4.69e-07` (paper) | 0.66x | every seed in range |

Coverage 53% → 85%, and every module in the package is now exercised.

**`.zenodo.json` joins the version companions.** You opened it, which was the right instinct — it carries a version and was not in the bump script's list, so it would have shipped claiming 0.2.0. That is the same drift the script already prevents for `CITATION.cff` and the conda recipe. There is now a test asserting the file still parses as JSON after the rewrite, and one asserting all four declarations in the real repository agree.

After merge I will tag `v0.3.0`, which triggers the release workflow.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cuts the 0.3.0 release and aligns all version metadata. The bump tool now updates `.zenodo.json` (previously missed), preventing version drift and enforcing valid JSON.

- Versions set to 0.3.0 in `pyproject.toml`, `CITATION.cff`, `.zenodo.json`, and `conda.recipe/meta.yaml`; changelog links updated. `.zenodo.json` added to the bump script with tests for JSON validity and cross-file agreement. No runtime code changes in this PR. After merge, tag `v0.3.0` to trigger the release workflow.

**Required migration for 0.3.0**
- Remove imports of `safe_ice.utils` and `nonlinear_oscillator_simplified`.
- If you used the unclamped probability from `run()`, read `results["pf_unclamped"]`; the returned value is now clamped to [0, 1] and emits a warning on clamp.
- Expect different outputs for several problems due to corrected defaults and paper-aligned implementations.

<sup>Written for commit 473b0108372fbbea12dc92049925919570aaf564. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/adaptive-importance-sampling/pull/98?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

