### PR TITLE
Add the ICE-vMFNM baseline the paper compares against

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `ICEvMFNM`, the ICE-vMFNM baseline of reference [26] that Safe-ICE is
+  measured against. Safe-ICE is that method plus a heavy-tailed proposal
+  component and a penalised EM step, so it is implemented as exactly that
+  minus the two: `lambda` held at 1, and the penalty coefficient held at 0.
+  Everything else -- the smoothed indicator, the sigma schedule, the weights,
+  the estimator -- is shared, and a test asserts as much, since a comparison
+  only means something if the methods differ in the ways being compared and in
+  no others.
+
+  It reproduces the paper's actual claim, which is not that Safe-ICE is
+  slightly better but that the baseline's accuracy depends on a choice the user
+  has to make blind. Ten runs each on the four-mode problem:
+
+  | Method | rel. err. of mean | CV |
+  | --- | --- | --- |
+  | Safe-ICE | 0.010 | 0.109 |
+  | ICE-vMFNM (K=2) | 0.084 | 0.180 |
+  | ICE-vMFNM (K=4) | 0.276 | 0.366 |
+  | ICE-vMFNM (K=8) | 0.290 | 0.214 |
+
+  Adding components makes it worse, which is what the paper observes.
+
+- `PenalizedEMOptimizer(penalized=False)` holds the penalty coefficient at
+  zero, reducing the M-step to the plain weighted EM update of equation (19).
+
+### Added
+
 - Four notebooks in `notebooks/`, executed with their outputs saved so the
   plots and numbers render on GitHub without running anything: getting started,
   the five benchmark problems against independent references, accuracy from

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -75,6 +75,33 @@ tests for whatever was there:
 
 ## Next
 
+### More estimators, for comparison and cross-checking
+
+`ICEvMFNM` is in, which is the baseline the paper's tables compare against.
+Two more were agreed:
+
+* **Subset simulation** (Au and Beck 2001, reference [13]). A different family
+  entirely -- MCMC through nested intermediate failure levels rather than
+  importance sampling -- so it cross-checks rather than agrees. The paper used
+  it for the heat transfer reference. This is the more valuable of the two,
+  because an independent second opinion is what has actually caught defects
+  here.
+* **Cross-entropy with a Gaussian mixture** (Kurtz and Song 2013, reference
+  [25]), the older variant ICE improved on. A third point of comparison.
+
+### Real data, which needs an isoprobabilistic transform first
+
+The estimator works in standard normal space, and real inputs are not standard
+normal, so there is no way to apply it to measured data at present. The paper
+notes the same thing in its introduction: a Nataf or Rosenblatt transformation
+maps the original distributions to Gaussian ones. That layer has to exist
+before any real-data example can.
+
+Agreed example: river flood exceedance from USGS daily discharge records --
+fit marginals to a real gauge record, transform, and estimate the probability
+of exceeding a flood stage.
+
+
 These are the next items from a repository review on 2026-08-18. The estimator
 core is in much better shape than the surrounding product surface; the highest
 return is now to make the public API, docs, visualisation tools and release

--- a/safe_ice/__init__.py
+++ b/safe_ice/__init__.py
@@ -3,7 +3,13 @@
 from importlib.metadata import PackageNotFoundError, version
 
 from .analysis import AdvancedAnalysis, PerformanceEvaluator
-from .core import AdaptiveSafeICE, OptimizedSafeICE, SafeICE, vMFNMParameters
+from .core import (
+    AdaptiveSafeICE,
+    ICEvMFNM,
+    OptimizedSafeICE,
+    SafeICE,
+    vMFNMParameters,
+)
 from .distributions import (
     InverseNakagamiDistribution,
     NakagamiDistribution,
@@ -31,6 +37,7 @@ __all__ = [
     "AdvancedAnalysis",
     "BenchmarkProblems",
     "HeatTransferProblem",
+    "ICEvMFNM",
     "InverseNakagamiDistribution",
     "NakagamiDistribution",
     "NetworkReliabilityProblem",

--- a/safe_ice/core/__init__.py
+++ b/safe_ice/core/__init__.py
@@ -1,8 +1,15 @@
 """Core Safe-ICE algorithm and parameters."""
 
 from .adaptive_safe_ice import AdaptiveSafeICE
+from .ice_vmfnm import ICEvMFNM
 from .parameters import vMFNMParameters
 from .safe_ice import SafeICE
 from .safe_ice_optimized import OptimizedSafeICE
 
-__all__ = ["AdaptiveSafeICE", "OptimizedSafeICE", "SafeICE", "vMFNMParameters"]
+__all__ = [
+    "AdaptiveSafeICE",
+    "ICEvMFNM",
+    "OptimizedSafeICE",
+    "SafeICE",
+    "vMFNMParameters",
+]

--- a/safe_ice/core/ice_vmfnm.py
+++ b/safe_ice/core/ice_vmfnm.py
@@ -1,0 +1,120 @@
+"""The ICE-vMFNM baseline that Safe-ICE is measured against.
+
+Improved cross-entropy importance sampling with a von Mises-Fisher-Nakagami
+mixture, from
+
+    Papaioannou, Geyer and Straub, "Improved cross entropy-based importance
+    sampling with a flexible mixture model", Reliability Engineering & System
+    Safety 191:106564, 2019
+
+which is reference [26] of the Safe-ICE paper. Safe-ICE is this method plus two
+additions, and the paper's tables are comparisons between the two:
+
+* a heavy-tailed component mixed into the proposal with weight ``1 - lambda``,
+  annealed towards the light-tailed family as sigma falls;
+* a cross-entropy penalty in the M-step that prunes redundant components, so
+  the number of components need not be chosen in advance.
+
+Removing both recovers ICE-vMFNM exactly, which is how it is implemented here:
+``lambda`` is held at 1 so the proposal is the vMFNM mixture alone, and the
+penalty coefficient is held at 0 so the M-step is the plain weighted EM update
+of equation (19). Everything else -- the smoothed indicator, the schedule for
+sigma, the weights and the final estimator -- is shared with
+:class:`~safe_ice.core.safe_ice.SafeICE`.
+
+Sharing it is deliberate. A comparison is only meaningful if the two methods
+differ in the ways being compared and in no others, and reimplementing the
+common parts would leave room for them to differ by accident.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ..optimization.penalized_em import PenalizedEMOptimizer
+from ..typing import LimitStateFunction
+from .safe_ice import SafeICE
+
+
+class ICEvMFNM(SafeICE):
+    """Improved cross-entropy importance sampling with a vMFNM mixture.
+
+    Parameters
+    ----------
+    limit_state_function:
+        Function g(u) such that failure occurs when g(u) <= 0.
+    dimension:
+        Problem dimension.
+    K:
+        Number of mixture components. This method has no mechanism for adapting
+        it, which is the shortcoming Safe-ICE's penalised EM addresses; the
+        paper reports results for several values to show that the choice
+        matters. Its own experiments use 2 and 4 for the four-mode problem, 3
+        and 6 for the three-mode one, and 1 and 3 for the oscillator.
+
+        Nothing here drives components out, so ``K`` normally holds for the
+        whole run. It can still fall if plain EM leaves a component with no
+        responsibility at all, since a component with zero weight cannot be
+        updated and is dropped: asking for 8 components on the four-mode
+        problem ends with 6. That is a different mechanism from Safe-ICE's,
+        which prunes deliberately and from 20 down.
+    delta_target, delta_star, max_iterations, N, sigma0, em_max_iter:
+        As in :class:`SafeICE`.
+    random_state:
+        Seed or generator, for reproducibility.
+
+    Notes
+    -----
+    ``lambda_max`` is not accepted: there is no heavy-tailed component for it to
+    bound. Reading ``self.lambda_max`` still returns 1.0, since that is the
+    weight this method places on the light-tailed family at every iteration.
+    """
+
+    def __init__(
+        self,
+        limit_state_function: LimitStateFunction,
+        dimension: int,
+        K: int = 2,
+        delta_target: float = 4.0,
+        delta_star: float = 1.5,
+        max_iterations: int = 20,
+        N: int = 1000,
+        sigma0: float = 1.0,
+        em_max_iter: int = 20,
+        random_state: int | np.random.Generator | None = None,
+    ) -> None:
+        super().__init__(
+            limit_state_function=limit_state_function,
+            dimension=dimension,
+            K0=K,
+            delta_target=delta_target,
+            delta_star=delta_star,
+            max_iterations=max_iterations,
+            N=N,
+            sigma0=sigma0,
+            em_max_iter=em_max_iter,
+            lambda_max=1.0,
+            random_state=random_state,
+        )
+
+        # The plain weighted EM update of equation (19). With no penalty
+        # nothing drives components out deliberately, though EM can still lose
+        # one that ends up with no responsibility at all.
+        self.em_optimizer = PenalizedEMOptimizer(
+            max_em_iterations=int(em_max_iter), penalized=False
+        )
+
+    @property
+    def K(self) -> int:
+        """The number of mixture components this method was asked for."""
+        return int(self.K0)
+
+    def _cosine_annealing_schedule(self, sigma: float, M: float) -> float:  # noqa: ARG002
+        """Always 1: the proposal is the vMFNM mixture, with no safety component.
+
+        Safe-ICE anneals this from 0 to just under 1 so that early iterations
+        explore with heavy tails. ICE-vMFNM has no such component, so the
+        weight on the light-tailed family is 1 throughout. ``sigma`` and ``M``
+        are accepted to match the signature being overridden.
+        """
+        return 1.0

--- a/safe_ice/optimization/penalized_em.py
+++ b/safe_ice/optimization/penalized_em.py
@@ -17,9 +17,27 @@ NDArrayF = npt.NDArray[np.float64]
 class PenalizedEMOptimizer:
     """Penalized EM algorithm for automatic component selection."""
 
-    def __init__(self, max_em_iterations: int = 20, em_tolerance: float = 1e-6) -> None:
+    def __init__(
+        self,
+        max_em_iterations: int = 20,
+        em_tolerance: float = 1e-6,
+        penalized: bool = True,
+    ) -> None:
+        """Create the optimiser.
+
+        Parameters
+        ----------
+        penalized:
+            Apply the cross-entropy penalty of equation (21). With ``False``
+            the penalty coefficient is held at zero, which reduces the update
+            to the plain weighted EM step of equation (19) and leaves the
+            number of components fixed. That is what the ICE-vMFNM baseline
+            of reference [26] does, and it is the difference this package's
+            :class:`~safe_ice.core.ice_vmfnm.ICEvMFNM` relies on.
+        """
         self.max_em_iterations = int(max_em_iterations)
         self.em_tolerance = float(em_tolerance)
+        self.penalized = bool(penalized)
 
     def fit(
         self,
@@ -48,7 +66,7 @@ class PenalizedEMOptimizer:
         """
         _n, _d = data.shape
         params = self._copy_parameters(initial_params)
-        beta: float = float(beta_init)
+        beta: float = float(beta_init) if self.penalized else 0.0
         K: int = int(params.K)
 
         # Precompute data in polar coordinates
@@ -171,7 +189,11 @@ class PenalizedEMOptimizer:
         # The next penalty coefficient, equation (23), is computed before
         # pruning: it compares the weights component by component against the
         # previous iterate, so both vectors must still have K_j entries.
-        next_beta = self._update_beta(params.pi, new_pi, pi_em, int(_n), int(d))
+        next_beta = (
+            self._update_beta(params.pi, new_pi, pi_em, int(_n), int(d))
+            if self.penalized
+            else 0.0
+        )
 
         # Equation (22): discard the components driven to zero by the penalty.
         active_components = new_pi > 0.0

--- a/tests/test_ice_vmfnm.py
+++ b/tests/test_ice_vmfnm.py
@@ -1,0 +1,191 @@
+"""ICE-vMFNM, the baseline Safe-ICE is measured against.
+
+Safe-ICE is this method plus a heavy-tailed proposal component and a penalised
+EM step, and the paper's tables are comparisons between the two. The tests here
+check both halves of that statement: that the two additions really are absent,
+and that everything else is shared, since a comparison is only meaningful if
+the methods differ in the ways being compared and in no others.
+
+The last test reproduces the paper's qualitative finding, which is not that
+Safe-ICE is a little better but that ICE-vMFNM's accuracy depends on a choice
+the user has to make blind. On the four-mode problem, over ten runs each:
+
+    method             rel. err. of mean      CV
+    Safe-ICE                       0.010   0.109
+    ICE-vMFNM (K=2)                0.084   0.180
+    ICE-vMFNM (K=4)                0.276   0.366
+    ICE-vMFNM (K=8)                0.290   0.214
+
+Adding components makes it worse, which is the paper's own observation.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from safe_ice import ICEvMFNM, SafeICE
+from safe_ice.problems.benchmarks import BenchmarkProblems
+
+FOUR_MODE_PF = 6.465e-05
+
+
+def four_mode():
+    return BenchmarkProblems.four_mode_series_system(z=1.0)
+
+
+def estimator(cls, seed: int, **kwargs):
+    return cls(
+        limit_state_function=four_mode(),
+        dimension=2,
+        N=1000,
+        max_iterations=20,
+        random_state=seed,
+        **kwargs,
+    )
+
+
+class TestTheTwoAdditionsAreAbsent:
+    """What makes this ICE rather than Safe-ICE."""
+
+    def test_no_heavy_tailed_component(self) -> None:
+        """lambda is the weight on the light-tailed family, and stays at 1."""
+        ice = estimator(ICEvMFNM, 0, K=3)
+
+        for sigma in (10.0, 1.0, 0.5, 1e-3, 1e-9, 0.0):
+            assert ice._cosine_annealing_schedule(sigma, ice.sigma0) == 1.0
+
+    def test_safe_ice_does_anneal_by_contrast(self) -> None:
+        """The same call on Safe-ICE sweeps from 0 up to its cap."""
+        safe = estimator(SafeICE, 0)
+
+        assert safe._cosine_annealing_schedule(safe.sigma0, safe.sigma0) == 0.0
+        assert safe._cosine_annealing_schedule(1e-9, safe.sigma0) == safe.lambda_max
+
+    def test_penalty_is_disabled(self) -> None:
+        assert estimator(ICEvMFNM, 0, K=3).em_optimizer.penalized is False
+        assert estimator(SafeICE, 0).em_optimizer.penalized is True
+
+    @pytest.mark.parametrize("k", [2, 4])
+    def test_component_count_holds(self, k: int) -> None:
+        """Nothing drives components out, so a sensible K survives intact."""
+        ice = estimator(ICEvMFNM, 0, K=k)
+        _pf, results = ice.run(verbose=False)
+
+        components = ice.K
+        assert components == k
+        assert results["final_components"] == k
+        assert set(ice.history["components"]) == {k}
+
+    def test_components_can_still_die_of_starvation(self) -> None:
+        """Not every drop is a penalty.
+
+        Ask for more components than the problem supports and plain EM leaves
+        some with no responsibility at all. A component of zero weight cannot
+        be updated, so it is dropped -- 8 ends at 6 on the four-mode problem.
+        This is worth separating from Safe-ICE's pruning, which is deliberate
+        and starts from 20.
+        """
+        ice = estimator(ICEvMFNM, 0, K=8)
+        _pf, results = ice.run(verbose=False)
+
+        assert results["final_components"] <= 8
+        assert results["final_components"] >= 4, "should not collapse like Safe-ICE"
+        assert all(k <= 8 for k in ice.history["components"])
+
+    def test_safe_ice_prunes_by_contrast(self) -> None:
+        _pf, results = estimator(SafeICE, 0).run(verbose=False)
+        assert results["final_components"] < 20
+
+
+class TestEverythingElseIsShared:
+    """The comparison is only fair if the common parts really are common."""
+
+    SHARED = (
+        "_determine_next_sigma",
+        "_calculate_intermediate_weights",
+        "_calculate_stopping_weights",
+        "_estimate_failure_probability",
+        "_evaluate_safe_mixture_density",
+        "_initialize_vmfnm_parameters",
+        "run",
+    )
+
+    @pytest.mark.parametrize("method", SHARED)
+    def test_not_reimplemented(self, method: str) -> None:
+        assert getattr(ICEvMFNM, method) is getattr(SafeICE, method), (
+            f"ICEvMFNM overrides {method}; then a difference in results could "
+            "come from that rather than from the two additions under comparison"
+        )
+
+    def test_only_the_schedule_is_overridden(self) -> None:
+        """The one deliberate override, plus the constructor."""
+        overridden = {
+            name
+            for name in vars(ICEvMFNM)
+            if not name.startswith("__") and hasattr(SafeICE, name)
+        }
+        assert overridden == {"_cosine_annealing_schedule"}
+
+
+class TestItWorks:
+    """A baseline still has to produce the right answer."""
+
+    @pytest.mark.parametrize("k", [2, 4])
+    def test_estimate_matches_the_reference(self, k: int) -> None:
+        estimates = [
+            estimator(ICEvMFNM, s, K=k).run(verbose=False)[0] for s in range(6)
+        ]
+        median = float(np.median(estimates))
+
+        assert FOUR_MODE_PF / 3 < median < FOUR_MODE_PF * 3, (
+            f"K={k}: median {median:.3e} against {FOUR_MODE_PF:.3e}; {estimates}"
+        )
+
+    def test_returns_a_probability_with_the_same_result_keys(self) -> None:
+        pf, results = estimator(ICEvMFNM, 0, K=2).run(verbose=False)
+        _safe_pf, safe_results = estimator(SafeICE, 0).run(verbose=False)
+
+        assert 0.0 <= pf <= 1.0
+        assert set(results) == set(safe_results)
+
+
+class TestThePaperComparison:
+    """Safe-ICE should be the more accurate and the more stable of the two."""
+
+    @staticmethod
+    def accuracy(cls, seeds, **kwargs):
+        """Relative error of the mean and coefficient of variation, as in the paper."""
+        estimates = np.array(
+            [estimator(cls, s, **kwargs).run(verbose=False)[0] for s in seeds]
+        )
+        rel_error = abs(float(estimates.mean()) - FOUR_MODE_PF) / FOUR_MODE_PF
+        cv = float(estimates.std() / estimates.mean())
+        return rel_error, cv
+
+    @pytest.mark.slow
+    def test_safe_ice_is_more_accurate_than_the_baseline(self) -> None:
+        seeds = range(10)
+        safe_error, safe_cv = self.accuracy(SafeICE, seeds)
+        ice_error, ice_cv = self.accuracy(ICEvMFNM, seeds, K=4)
+
+        assert safe_error < ice_error, (
+            f"Safe-ICE relative error {safe_error:.3f} against "
+            f"ICE-vMFNM(K=4) {ice_error:.3f}"
+        )
+        assert safe_cv < ice_cv, f"CV {safe_cv:.3f} against {ice_cv:.3f}"
+
+    @pytest.mark.slow
+    def test_the_baseline_depends_on_a_blind_choice_of_k(self) -> None:
+        """More components makes it worse here, which is the paper's point.
+
+        The user has no way to know the right K in advance; that is what the
+        penalised EM removes.
+        """
+        seeds = range(10)
+        error_small, _cv = self.accuracy(ICEvMFNM, seeds, K=2)
+        error_large, _cv = self.accuracy(ICEvMFNM, seeds, K=8)
+
+        assert error_large > error_small, (
+            f"K=8 gave relative error {error_large:.3f}, K=2 gave {error_small:.3f}"
+        )


### PR DESCRIPTION
First of the agreed expansion. `ICEvMFNM` is the baseline of reference [26] that the Safe-ICE paper's tables measure against.

**Built as exactly Safe-ICE minus its two additions**, rather than reimplemented: `lambda` held at 1 so the proposal is the vMFNM mixture alone, and the penalty coefficient held at 0 so the M-step is the plain weighted EM update of equation (19). Everything else — smoothed indicator, sigma schedule, weights, final estimator — is shared, and a test asserts that `_cosine_annealing_schedule` is the *only* override.

That sharing is the point. A comparison means nothing if the two methods differ in ways other than the ones being compared, and this codebase has already shown twice what happens to a second copy of the algorithm: `safe_ice_optimized.py` returned `nan` on every problem, and `nakagami_stable.py` was the correct one while the version in use was wrong.

**It reproduces the paper's claim** — which is not that Safe-ICE is slightly better, but that the baseline's accuracy depends on a choice the user has to make blind. Ten runs each on the four-mode problem:

| Method | rel. err. of mean | CV |
| --- | --- | --- |
| Safe-ICE | **0.010** | **0.109** |
| ICE-vMFNM (K=2) | 0.084 | 0.180 |
| ICE-vMFNM (K=4) | 0.276 | 0.366 |
| ICE-vMFNM (K=8) | 0.290 | 0.214 |

Adding components makes it *worse*, which is the paper's own observation ("simply increasing the number of mixtures could lead to worse performance"). That is what the penalised EM removes: there is no K to choose.

**One claim of mine needed correcting against measurement.** I wrote that K is fixed. It is not quite: nothing drives components out deliberately, but plain EM can still lose one that ends up with no responsibility at all, so asking for 8 on a four-mode problem ends with 6. K=2 and K=4 hold exactly. The tests now separate that starvation from Safe-ICE's deliberate pruning rather than asserting something untrue.

Also adds `PenalizedEMOptimizer(penalized=False)`, which is the mechanism.

Coverage of the new module is 100%; package stays at 85%.

Still to come, per the roadmap: subset simulation, CE with a Gaussian mixture, an isoprobabilistic transform, and the USGS flood example.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `ICEvMFNM` baseline that the Safe-ICE paper compares against, implemented as Safe-ICE without the heavy-tailed proposal and without the penalized EM step. This enables an apples-to-apples comparison and reproduces the paper’s finding that the baseline’s accuracy depends on K.

- New class `ICEvMFNM` in `safe_ice/core/ice_vmfnm.py`, exported via `safe_ice.core` and top-level `safe_ice`.
- Subclasses `SafeICE`; only override is `_cosine_annealing_schedule` (returns 1). Sets `lambda_max=1` and uses `PenalizedEMOptimizer(..., penalized=False)` for plain weighted EM.
- Behavior: proposal is vMFNM only; no penalty-driven pruning. K stays as requested unless EM starves components (zero responsibility), which can drop them; contrasts with Safe-ICE’s deliberate pruning.
- Tests (`tests/test_ice_vmfnm.py`) assert shared implementation boundaries and reproduce the paper’s trend (Safe-ICE more accurate/stable; ICE-vMFNM accuracy worsens with larger K). New module has 100% coverage.
- `PenalizedEMOptimizer` adds an optional `penalized` flag (default True); existing callers are unaffected. To run the baseline: instantiate `ICEvMFNM(..., K=<components>)`.

<sup>Written for commit b3df6fc7be887af1dec03a65d3b37caf4bf21e62. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/adaptive-importance-sampling/pull/100?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

