### PR TITLE
Add the isoprobabilistic transform, and rescale the limit state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `MarginalTransform`, which maps a problem stated in physical units into the
+  standard normal space the estimators work in. Until now there was no way to
+  apply any of them to measured data at all: the prior is standard normal and
+  real inputs are lognormal discharges, Gumbel wind speeds, skewed strengths.
+  The paper notes the same gap in its introduction.
+
+  Independent marginals map exactly, `u_i = Phi^-1(F_i(x_i))`. Correlated ones
+  use the Nataf transformation: a prescribed physical correlation is not the
+  correlation of the underlying normals, because the marginal transforms are
+  non-linear and distort it. Two lognormals with a 30% coefficient of variation
+  asked for `+0.8` need a Gaussian correlation of `0.806`, and asked for `-0.5`
+  need `-0.535`. The Gaussian correlation is solved per pair by quadrature and a
+  bracketed root find, and the sample correlations come back within 0.002 of
+  their targets.
+
+  `wrap` converts a physical limit state into one the estimators accept, and
+  `sample` draws physical values with the requested marginals and correlation.
+
+  Validated against a closed form: two lognormal resistances with
+  `P(R < S) = 1.817e-05` exactly. Safe-ICE gives 1.05x of it and subset
+  simulation 0.96x.
+
+- **`wrap` rescales the limit state by default, and that turns out to matter a
+  great deal.** Safe-ICE smooths the failure indicator as `Phi(-g/sigma)`
+  starting from `sigma0 = 1`, which assumes `g` is of order one. A limit state
+  in physical units is not: on the lognormal problem above the spread of `g` is
+  33, so `Phi(-g/1)` is already a hard indicator and the smoothing the method
+  depends on does nothing at all. The run stops after two iterations with sigma
+  still at 0.999.
+
+  That turned the true `1.817e-05` into `5.13e-06`, with individual runs between
+  0.03x and 0.61x of the answer. Wrong, and not obviously so -- which is how
+  the discrepancy was noticed at all: subset simulation gave 0.97x on the same
+  problem while Safe-ICE gave 0.35x.
+
+  Dividing `g` by a positive constant cannot change the answer, since
+  `{g <= 0}` and `{g/c <= 0}` are the same set, so `wrap` divides by the spread
+  of `g` under the prior. With that the estimate is 1.05x with runs spanning
+  0.91x to 1.06x. Setting `sigma0` to the spread instead is exactly equivalent,
+  and there is a test asserting the two agree to 1e-12, because the method only
+  ever sees `g/sigma`.
+
 - `SubsetSimulation`, the method of Au and Beck (2001), reference [13]. It is
   not importance sampling: it factorises the rare event into nested ones,
   choosing each threshold so a fixed fraction `p0` of the current samples pass,

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -87,17 +87,26 @@ finite-difference discretisation and not the estimator. One method remains:
 * **Cross-entropy with a Gaussian mixture** (Kurtz and Song 2013, reference
   [25]), the older variant ICE improved on. A third point of comparison.
 
-### Real data, which needs an isoprobabilistic transform first
+### Make sigma0 aware of the limit state's scale
 
-The estimator works in standard normal space, and real inputs are not standard
-normal, so there is no way to apply it to measured data at present. The paper
-notes the same thing in its introduction: a Nataf or Rosenblatt transformation
-maps the original distributions to Gaussian ones. That layer has to exist
-before any real-data example can.
+`sigma0` defaults to 1, which assumes `g` is of order one. Every benchmark in
+the paper satisfies that, so the assumption is invisible there. A limit state in
+physical units does not: a resistance minus a load with a spread of 33 makes
+`Phi(-g/1)` a hard indicator, the annealing does nothing, and the answer comes
+back three to thirty times too small without any sign of trouble.
 
-Agreed example: river flood exceedance from USGS daily discharge records --
-fit marginals to a real gauge record, transform, and estimate the probability
-of exceeding a flood stage.
+`MarginalTransform.wrap` divides by the spread of `g` for exactly this reason,
+which covers anyone coming through the transform. Anyone writing a limit state
+directly is still exposed. The fix is for `SafeICE` to estimate the spread from
+a pilot sample and set `sigma0` from it, defaulting to the current behaviour
+only when told to. That changes a default for every problem, so it needs
+re-validating across the whole benchmark set rather than being slipped in.
+
+### Real data: river flood exceedance
+
+The transform layer now exists, so this is unblocked. Fit marginals to a real
+USGS gauge record, transform, and estimate the probability of exceeding a flood
+stage.
 
 
 These are the next items from a repository review on 2026-08-18. The estimator

--- a/safe_ice/__init__.py
+++ b/safe_ice/__init__.py
@@ -26,6 +26,7 @@ from .problems import (
     SystemReliabilityProblem,
     TimeVariantProblem,
 )
+from .transforms import MarginalTransform
 
 try:
     __version__ = version("safe-ice")
@@ -40,6 +41,7 @@ __all__ = [
     "HeatTransferProblem",
     "ICEvMFNM",
     "InverseNakagamiDistribution",
+    "MarginalTransform",
     "NakagamiDistribution",
     "NetworkReliabilityProblem",
     "OptimizedSafeICE",

--- a/safe_ice/transforms.py
+++ b/safe_ice/transforms.py
@@ -1,0 +1,383 @@
+"""Map a problem stated in physical units into the space the estimator works in.
+
+The estimator draws from a standard normal prior, so a limit state written in
+terms of real quantities -- a discharge in cubic metres per second, a yield
+strength in megapascals -- cannot be handed to it directly. The Safe-ICE paper
+says as much in its introduction: "The prior is typically Gaussian; otherwise a
+Nataf or Rosenblatt transformation can be applied to map the original
+distributions to Gaussian ones."
+
+:class:`MarginalTransform` is that map. Given the marginal distribution of each
+input, and optionally the correlation between them, it converts back and forth
+and wraps a physical limit state into one the estimator accepts.
+
+Independent inputs
+------------------
+With independent marginals the map is one-dimensional and exact:
+
+.. math::
+
+    u_i = \\Phi^{-1}(F_i(x_i)), \\qquad x_i = F_i^{-1}(\\Phi(u_i))
+
+Correlated inputs
+-----------------
+Correlation needs the Nataf transformation. Prescribing a correlation
+``rho_x`` between two physical variables does not mean the underlying normals
+are correlated by the same amount: the marginal transforms are non-linear, so
+they distort it. The Gaussian correlation ``rho_z`` that produces a given
+``rho_x`` solves
+
+.. math::
+
+    \\rho_x = \\int\\!\\!\\int
+        \\frac{F_i^{-1}(\\Phi(z_i)) - \\mu_i}{\\sigma_i}
+        \\frac{F_j^{-1}(\\Phi(z_j)) - \\mu_j}{\\sigma_j}
+        \\varphi_2(z_i, z_j; \\rho_z)\\, dz_i\\, dz_j
+
+which is solved here per pair by quadrature and a bracketed root find. The
+distortion is real: two lognormals with a 30% coefficient of variation asked
+for a physical correlation of 0.8 need a Gaussian correlation of 0.806, and
+asked for -0.5 need -0.535. It grows with the skew of the marginals.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any, Protocol
+
+import numpy as np
+from scipy import stats
+from scipy.optimize import brentq
+
+from .typing import LimitStateFunction, NDArrayF
+
+__all__ = ["Marginal", "MarginalTransform"]
+
+#: How far from the boundary the uniform intermediate is kept. Phi(u) reaches
+#: exactly 0 or 1 in floating point for |u| beyond about 8.3, and a ppf given
+#: exactly 0 or 1 returns an infinity, which then propagates into the limit
+#: state. The estimator's heavy-tailed proposal does reach that far out.
+_PROBABILITY_MARGIN = 1e-15
+
+
+class Marginal(Protocol):
+    """What this module needs of a marginal distribution.
+
+    Any frozen ``scipy.stats`` distribution satisfies it, as does anything else
+    providing the same four methods.
+    """
+
+    def cdf(self, x: Any) -> Any:
+        """Cumulative distribution function."""
+        ...
+
+    def ppf(self, q: Any) -> Any:
+        """Inverse cumulative distribution function."""
+        ...
+
+    def mean(self) -> Any:
+        """Distribution mean."""
+        ...
+
+    def std(self) -> Any:
+        """Distribution standard deviation."""
+        ...
+
+
+class MarginalTransform:
+    """Convert between physical space and independent standard normal space.
+
+    Parameters
+    ----------
+    marginals:
+        One distribution per input, in order. Frozen ``scipy.stats``
+        distributions are the usual choice, e.g.
+        ``[lognorm(s=0.15, scale=200.0), gumbel_r(loc=30.0, scale=4.0)]``.
+    correlation:
+        Target correlation matrix between the *physical* variables. Omit it for
+        independent inputs. Must be symmetric with unit diagonal.
+    quadrature_points:
+        Nodes per axis in the Gauss-Hermite rule used to solve for the Gaussian
+        correlations. The default is ample; raising it costs setup time only.
+
+    Attributes
+    ----------
+    gaussian_correlation:
+        The correlation the underlying normals need in order to produce
+        ``correlation`` in physical space. Equal to ``correlation`` only when
+        the marginals are themselves normal.
+
+    Examples
+    --------
+    Wrap a limit state written in physical units and hand it to the estimator::
+
+        from scipy.stats import lognorm
+        from safe_ice import SafeICE
+        from safe_ice.transforms import MarginalTransform
+
+        transform = MarginalTransform(
+            [lognorm(s=0.15, scale=200.0), lognorm(s=0.25, scale=80.0)]
+        )
+
+
+        def capacity_exceeded(x):
+            return x[:, 0] - x[:, 1]  # resistance minus load
+
+
+        estimator = SafeICE(
+            limit_state_function=transform.wrap(capacity_exceeded),
+            dimension=2,
+        )
+    """
+
+    def __init__(
+        self,
+        marginals: Sequence[Marginal],
+        correlation: NDArrayF | None = None,
+        quadrature_points: int = 40,
+    ) -> None:
+        self.marginals = list(marginals)
+        self.d = len(self.marginals)
+        if self.d == 0:
+            raise ValueError("At least one marginal is required.")
+
+        if correlation is None:
+            self.correlation: NDArrayF = np.eye(self.d, dtype=np.float64)
+            self.gaussian_correlation: NDArrayF = np.eye(self.d, dtype=np.float64)
+        else:
+            self.correlation = self._validated_correlation(correlation)
+            self.gaussian_correlation = self._solve_gaussian_correlation(
+                int(quadrature_points)
+            )
+
+        # z = u @ L.T turns independent normals into ones with the required
+        # Gaussian correlation.
+        self._cholesky: NDArrayF = np.linalg.cholesky(self.gaussian_correlation)
+
+    # -------------------------------------------------------------------------
+    # Public API
+    # -------------------------------------------------------------------------
+    def to_physical(self, u: NDArrayF) -> NDArrayF:
+        """Map independent standard normals to physical values."""
+        points = self._as_2d(u)
+        if points.shape[1] != self.d:
+            raise ValueError(f"Expected {self.d} columns, got {points.shape[1]}.")
+
+        z = points @ self._cholesky.T
+        probabilities = np.clip(
+            stats.norm.cdf(z), _PROBABILITY_MARGIN, 1.0 - _PROBABILITY_MARGIN
+        )
+
+        physical: NDArrayF = np.empty_like(probabilities, dtype=np.float64)
+        for i, marginal in enumerate(self.marginals):
+            physical[:, i] = np.asarray(marginal.ppf(probabilities[:, i]))
+        return physical
+
+    def to_standard(self, x: NDArrayF) -> NDArrayF:
+        """Map physical values back to independent standard normals."""
+        points = self._as_2d(x)
+        if points.shape[1] != self.d:
+            raise ValueError(f"Expected {self.d} columns, got {points.shape[1]}.")
+
+        z = np.empty_like(points)
+        for i, marginal in enumerate(self.marginals):
+            probabilities = np.clip(
+                np.asarray(marginal.cdf(points[:, i])),
+                _PROBABILITY_MARGIN,
+                1.0 - _PROBABILITY_MARGIN,
+            )
+            z[:, i] = stats.norm.ppf(probabilities)
+
+        # Undo z = u @ L.T without forming the inverse.
+        return np.linalg.solve(self._cholesky, z.T).T
+
+    def wrap(
+        self,
+        limit_state: LimitStateFunction,
+        scale: bool | float = True,
+        pilot: int = 512,
+        random_state: int | np.random.Generator | None = 0,
+    ) -> LimitStateFunction:
+        """Turn a limit state written in physical units into one in u-space.
+
+        The returned function is what the estimators take. Failure is still
+        ``g <= 0``; only the coordinates change.
+
+        Parameters
+        ----------
+        limit_state:
+            The limit state in physical units. Receives an ``(n, d)`` array of
+            physical values.
+        scale:
+            Divide the result by a constant, so that its spread is of order one.
+            ``True`` estimates that constant from a pilot sample, a float uses
+            the value given, and ``False`` leaves the limit state alone.
+
+            This matters more than it looks. Safe-ICE smooths the failure
+            indicator as ``Phi(-g/sigma)`` and starts from ``sigma0 = 1``, which
+            assumes ``g`` is of order one. A limit state in physical units is
+            not: a resistance minus a load in newtons has a spread in the
+            hundreds, and ``Phi(-g/1)`` is then already a hard indicator, so the
+            smoothing the method depends on does nothing. On the lognormal
+            resistance problem below that turned a true 1.82e-05 into 5.1e-06,
+            with individual runs between 0.03x and 0.61x of the answer -- wrong,
+            but not obviously so.
+
+            Dividing by a positive constant cannot change the answer, since
+            ``{g <= 0}`` and ``{g/c <= 0}`` are the same set, so this is a pure
+            reparameterisation. With it, the same problem gives 1.05x with runs
+            spanning 0.94x to 1.06x. Setting ``sigma0`` to the spread instead is
+            exactly equivalent -- the method only ever sees ``g/sigma`` -- but
+            doing it here means the scale is handled where the physical units
+            enter.
+        pilot:
+            Samples used to estimate the spread when ``scale`` is ``True``. Each
+            costs one limit-state evaluation, which is worth knowing if that is
+            a finite-element solve.
+        random_state:
+            Seed for the pilot sample, so the scaling is reproducible.
+        """
+
+        def in_u_space(u: NDArrayF) -> NDArrayF:
+            physical = self.to_physical(np.asarray(u, dtype=np.float64))
+            return np.asarray(limit_state(physical), dtype=np.float64).reshape(-1)
+
+        divisor = 1.0
+        if scale is True:
+            sample = self.sample(int(pilot), random_state=random_state)
+            spread = float(
+                np.std(np.asarray(limit_state(sample), dtype=np.float64).reshape(-1))
+            )
+            if np.isfinite(spread) and spread > 0.0:
+                divisor = spread
+        elif scale is not False:
+            divisor = float(scale)
+            if divisor <= 0.0:
+                raise ValueError(f"scale must be positive, got {divisor}.")
+
+        def transformed(u: NDArrayF) -> float | NDArrayF:
+            values = in_u_space(u) / divisor
+            if np.ndim(u) == 1:
+                return float(values[0])
+            return values
+
+        transformed.limit_state_scale = divisor  # type: ignore[attr-defined]
+        return transformed
+
+    def sample(
+        self, n: int, random_state: int | np.random.Generator | None = None
+    ) -> NDArrayF:
+        """Draw physical samples with the requested marginals and correlation.
+
+        Useful for checking a transform against the data it was fitted to, and
+        for crude Monte Carlo in physical space.
+        """
+        if isinstance(random_state, np.random.Generator):
+            rng = random_state
+        else:
+            rng = np.random.default_rng(random_state)
+        return self.to_physical(
+            np.asarray(rng.standard_normal((int(n), self.d)), dtype=np.float64)
+        )
+
+    # -------------------------------------------------------------------------
+    # Internals
+    # -------------------------------------------------------------------------
+    @staticmethod
+    def _as_2d(values: NDArrayF) -> NDArrayF:
+        array = np.asarray(values, dtype=np.float64)
+        if array.ndim == 1:
+            return array.reshape(1, -1)
+        if array.ndim != 2:
+            raise ValueError("Input must be a 1-D or 2-D array.")
+        return array
+
+    def _validated_correlation(self, correlation: NDArrayF) -> NDArrayF:
+        matrix = np.asarray(correlation, dtype=np.float64)
+        if matrix.shape != (self.d, self.d):
+            raise ValueError(
+                f"Correlation must be {self.d}x{self.d}, got {matrix.shape}."
+            )
+        if not np.allclose(matrix, matrix.T):
+            raise ValueError("Correlation must be symmetric.")
+        if not np.allclose(np.diag(matrix), 1.0):
+            raise ValueError("Correlation must have a unit diagonal.")
+        if float(np.min(np.linalg.eigvalsh(matrix))) <= 0.0:
+            raise ValueError("Correlation must be positive definite.")
+        return matrix
+
+    def _solve_gaussian_correlation(self, quadrature_points: int) -> NDArrayF:
+        """Find the Gaussian correlations that yield the physical ones.
+
+        One bracketed root find per off-diagonal pair. The integrand is
+        evaluated on a tensor Gauss-Hermite grid, which is cheap because the
+        standardised marginal values at the nodes do not depend on ``rho_z`` and
+        so are computed once per variable.
+        """
+        nodes, weights = np.polynomial.hermite_e.hermegauss(quadrature_points)
+        weights = weights / np.sqrt(2.0 * np.pi)
+
+        # Standardised physical value at each node, per variable.
+        standardised = np.empty((self.d, quadrature_points), dtype=np.float64)
+        for i, marginal in enumerate(self.marginals):
+            probabilities = np.clip(
+                stats.norm.cdf(nodes), _PROBABILITY_MARGIN, 1.0 - _PROBABILITY_MARGIN
+            )
+            values = np.asarray(marginal.ppf(probabilities), dtype=np.float64)
+            mean = float(np.asarray(marginal.mean()))
+            std = float(np.asarray(marginal.std()))
+            if not np.isfinite(mean) or not np.isfinite(std) or std <= 0.0:
+                raise ValueError(
+                    f"Marginal {i} needs a finite mean and a positive finite "
+                    "standard deviation for the Nataf correlation solve."
+                )
+            standardised[i] = (values - mean) / std
+
+        gaussian = np.eye(self.d, dtype=np.float64)
+
+        for i in range(self.d):
+            for j in range(i + 1, self.d):
+                target = float(self.correlation[i, j])
+                if target == 0.0:
+                    continue
+
+                def mismatch(
+                    rho: float, i: int = i, j: int = j, t: float = target
+                ) -> float:
+                    return self._pair_correlation(rho, standardised, weights, i, j) - t
+
+                # The map from rho_z to rho_x is increasing and passes through
+                # the target, so a bracket at the extremes suffices.
+                low, high = -0.999, 0.999
+                if mismatch(low) > 0.0 or mismatch(high) < 0.0:
+                    raise ValueError(
+                        f"A physical correlation of {target} is not attainable "
+                        f"for marginals {i} and {j}. Non-normal marginals bound "
+                        "the correlation they can express."
+                    )
+                rho_z = float(brentq(mismatch, low, high, xtol=1e-10))
+                gaussian[i, j] = gaussian[j, i] = rho_z
+
+        return gaussian
+
+    @staticmethod
+    def _pair_correlation(
+        rho: float,
+        standardised: NDArrayF,
+        weights: NDArrayF,
+        i: int,
+        j: int,
+    ) -> float:
+        """Physical correlation produced by a Gaussian correlation of ``rho``.
+
+        The two standard normals are written as ``z_i`` and
+        ``rho z_i + sqrt(1 - rho^2) z_j`` with ``z_i, z_j`` independent, so the
+        double integral becomes a weighted sum over the same node grid. The
+        second variable's standardised values have to be interpolated, since the
+        combination lands between nodes.
+        """
+        nodes, _ = np.polynomial.hermite_e.hermegauss(standardised.shape[1])
+        combined = rho * nodes[:, None] + np.sqrt(1.0 - rho**2) * nodes[None, :]
+        second = np.interp(combined, nodes, standardised[j])
+        outer_weights = weights[:, None] * weights[None, :]
+        return float(np.sum(outer_weights * standardised[i][:, None] * second))

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -1,0 +1,311 @@
+"""The map from physical units into the space the estimator works in.
+
+Without this there is no way to apply the estimator to measured data at all: it
+draws from a standard normal prior, and real inputs are lognormal discharges,
+Gumbel wind speeds, skewed strengths. The paper says the same in its
+introduction -- a Nataf or Rosenblatt transformation maps the original
+distributions to Gaussian ones.
+
+Two properties are checked here that a transform can get wrong while looking
+right. The marginals and the correlation of the samples it produces must be the
+ones asked for, and a problem stated in physical units must give the same answer
+as its analytical solution.
+
+The second of those turned up a trap that has nothing to do with the transform
+and everything to do with using it. Safe-ICE smooths the failure indicator as
+``Phi(-g/sigma)`` from ``sigma0 = 1``, which assumes ``g`` is of order one. A
+resistance minus a load in physical units is not: on the lognormal problem below
+the spread of ``g`` is 33, so ``Phi(-g/1)`` is already a hard indicator and the
+smoothing does nothing. That turned a true 1.82e-05 into 5.13e-06, with runs
+between 0.03x and 0.61x -- wrong, and not obviously so. ``wrap`` therefore
+divides by the spread of ``g`` by default, which cannot change the answer
+because ``{g <= 0}`` and ``{g/c <= 0}`` are the same set.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from scipy import stats
+
+from safe_ice import SafeICE, SubsetSimulation
+from safe_ice.transforms import MarginalTransform
+
+# Two lognormal resistances. ln R - ln S is normal, so P(R < S) is exact.
+RESISTANCE = stats.lognorm(s=0.15, scale=200.0)
+LOAD = stats.lognorm(s=0.25, scale=60.0)
+EXACT_PF = float(
+    stats.norm.cdf(-(np.log(200.0) - np.log(60.0)) / np.sqrt(0.15**2 + 0.25**2))
+)
+
+
+def resistance_minus_load(x: np.ndarray) -> np.ndarray:
+    """Failure when the load exceeds the resistance, in physical units."""
+    return x[:, 0] - x[:, 1]
+
+
+class TestRoundTrip:
+    """to_physical and to_standard must invert each other exactly."""
+
+    @pytest.mark.parametrize(
+        "marginals",
+        [
+            [stats.lognorm(s=0.3, scale=10.0)],
+            [stats.norm(loc=5.0, scale=2.0), stats.gumbel_r(loc=30.0, scale=4.0)],
+            [stats.expon(scale=3.0), stats.weibull_min(c=2.0, scale=7.0)],
+        ],
+    )
+    def test_u_to_x_to_u(self, marginals, rng) -> None:
+        transform = MarginalTransform(marginals)
+        u = rng.standard_normal((2000, len(marginals)))
+
+        assert transform.to_standard(transform.to_physical(u)) == pytest.approx(
+            u, abs=1e-9
+        )
+
+    def test_round_trip_with_correlation(self, rng) -> None:
+        correlation = np.array([[1.0, 0.6], [0.6, 1.0]])
+        transform = MarginalTransform(
+            [stats.lognorm(s=0.3, scale=10.0), stats.gumbel_r(loc=2.0, scale=1.0)],
+            correlation=correlation,
+        )
+        u = rng.standard_normal((2000, 2))
+
+        assert transform.to_standard(transform.to_physical(u)) == pytest.approx(
+            u, abs=1e-9
+        )
+
+    def test_a_single_point_is_accepted(self) -> None:
+        transform = MarginalTransform([RESISTANCE, LOAD])
+        physical = transform.to_physical(np.zeros(2))
+
+        assert physical.shape == (1, 2)
+        # u = 0 is the median of each marginal.
+        assert physical[0, 0] == pytest.approx(200.0)
+        assert physical[0, 1] == pytest.approx(60.0)
+
+
+class TestMarginalsAreWhatWasAskedFor:
+    @pytest.mark.parametrize(
+        "marginal",
+        [
+            stats.lognorm(s=0.4, scale=50.0),
+            stats.gumbel_r(loc=30.0, scale=4.0),
+            stats.weibull_min(c=1.8, scale=12.0),
+        ],
+    )
+    def test_samples_follow_the_marginal(self, marginal) -> None:
+        """A Kolmogorov-Smirnov test against the distribution asked for."""
+        samples = MarginalTransform([marginal]).sample(20_000, random_state=0)
+
+        _statistic, p_value = stats.kstest(samples[:, 0], marginal.cdf)
+        assert p_value > 0.01, f"KS p-value {p_value:.4f}"
+
+
+class TestNatafCorrelation:
+    """A physical correlation is not the correlation of the underlying normals."""
+
+    @pytest.mark.parametrize("target", [0.3, 0.6, 0.8, -0.5])
+    def test_sample_correlation_hits_the_target(self, target: float) -> None:
+        correlation = np.array([[1.0, target], [target, 1.0]])
+        transform = MarginalTransform(
+            [stats.lognorm(s=0.3, scale=200.0), stats.lognorm(s=0.3, scale=80.0)],
+            correlation=correlation,
+        )
+        samples = transform.sample(200_000, random_state=0)
+
+        achieved = float(np.corrcoef(samples.T)[0, 1])
+        assert achieved == pytest.approx(target, abs=0.02)
+
+    def test_gaussian_correlation_differs_for_skewed_marginals(self) -> None:
+        """The distortion is the reason the Nataf solve is needed at all."""
+        target = 0.8
+        transform = MarginalTransform(
+            [stats.lognorm(s=0.3, scale=200.0), stats.lognorm(s=0.3, scale=80.0)],
+            correlation=np.array([[1.0, target], [target, 1.0]]),
+        )
+        rho_z = float(transform.gaussian_correlation[0, 1])
+
+        assert rho_z != pytest.approx(target, abs=1e-3)
+        assert rho_z == pytest.approx(0.806, abs=0.01)
+
+    def test_normal_marginals_need_no_correction(self) -> None:
+        """With normal marginals the transform is linear, so rho_z == rho_x."""
+        target = 0.7
+        transform = MarginalTransform(
+            [stats.norm(loc=3.0, scale=2.0), stats.norm(loc=-1.0, scale=5.0)],
+            correlation=np.array([[1.0, target], [target, 1.0]]),
+        )
+
+        assert float(transform.gaussian_correlation[0, 1]) == pytest.approx(
+            target, abs=1e-4
+        )
+
+    def test_independent_marginals_skip_the_solve(self) -> None:
+        transform = MarginalTransform([RESISTANCE, LOAD])
+        assert transform.gaussian_correlation == pytest.approx(np.eye(2))
+
+
+class TestAgainstAnAnalyticalAnswer:
+    """A physical problem whose answer is known in closed form."""
+
+    def test_crude_monte_carlo_in_physical_space(self, rng) -> None:
+        """First check the problem itself, before involving an estimator."""
+        transform = MarginalTransform([RESISTANCE, LOAD])
+        samples = transform.sample(2_000_000, random_state=1)
+        observed = float((resistance_minus_load(samples) <= 0).mean())
+
+        assert observed == pytest.approx(EXACT_PF, rel=0.25)
+
+    @pytest.mark.slow
+    @pytest.mark.parametrize("estimator", [SafeICE, SubsetSimulation])
+    def test_estimators_reproduce_the_closed_form(self, estimator) -> None:
+        transform = MarginalTransform([RESISTANCE, LOAD])
+        wrapped = transform.wrap(resistance_minus_load)
+
+        estimates = [
+            estimator(limit_state_function=wrapped, dimension=2, random_state=seed).run(
+                verbose=False
+            )[0]
+            for seed in range(6)
+        ]
+        median = float(np.median(estimates))
+
+        assert EXACT_PF / 2 < median < EXACT_PF * 2, (
+            f"{estimator.__name__}: {median:.3e} against {EXACT_PF:.3e}; {estimates}"
+        )
+
+
+class TestLimitStateScaling:
+    """The trap, and the default that avoids it."""
+
+    def test_the_spread_is_estimated_and_reported(self) -> None:
+        transform = MarginalTransform([RESISTANCE, LOAD])
+        wrapped = transform.wrap(resistance_minus_load)
+
+        # The spread of R - S under the prior is about 33 physical units.
+        assert wrapped.limit_state_scale == pytest.approx(33.0, rel=0.2)
+
+    def test_scaling_does_not_move_the_failure_boundary(self, rng) -> None:
+        """Dividing by a positive constant leaves {g <= 0} alone, exactly."""
+        transform = MarginalTransform([RESISTANCE, LOAD])
+        scaled = transform.wrap(resistance_minus_load)
+        unscaled = transform.wrap(resistance_minus_load, scale=False)
+
+        u = rng.standard_normal((5000, 2))
+        assert np.array_equal(np.asarray(scaled(u)) <= 0, np.asarray(unscaled(u)) <= 0)
+
+    @pytest.mark.slow
+    def test_scaling_is_what_makes_the_estimate_right(self) -> None:
+        """Recorded because the failure is quiet: a plausible, wrong answer.
+
+        Without it the smoothed indicator is already hard at sigma0 = 1, so the
+        annealing does nothing and the run stops after two iterations with sigma
+        still at 0.999.
+        """
+        transform = MarginalTransform([RESISTANCE, LOAD])
+
+        def median_over_seeds(wrapped):
+            return float(
+                np.median(
+                    [
+                        SafeICE(
+                            limit_state_function=wrapped,
+                            dimension=2,
+                            N=1000,
+                            max_iterations=15,
+                            random_state=seed,
+                        ).run(verbose=False)[0]
+                        for seed in range(6)
+                    ]
+                )
+            )
+
+        scaled = median_over_seeds(transform.wrap(resistance_minus_load))
+        unscaled = median_over_seeds(transform.wrap(resistance_minus_load, scale=False))
+
+        assert EXACT_PF / 1.5 < scaled < EXACT_PF * 1.5, f"{scaled:.3e}"
+        assert unscaled < EXACT_PF / 2, (
+            f"unscaled gave {unscaled:.3e}, which is close to the answer "
+            f"{EXACT_PF:.3e}; if the trap has gone, drop this test"
+        )
+
+    def test_setting_sigma0_to_the_spread_is_equivalent(self) -> None:
+        """The method only ever sees g/sigma, so the two are the same thing."""
+        transform = MarginalTransform([RESISTANCE, LOAD])
+        unscaled = transform.wrap(resistance_minus_load, scale=False)
+        spread = transform.wrap(resistance_minus_load).limit_state_scale
+
+        by_scaling = SafeICE(
+            limit_state_function=transform.wrap(
+                resistance_minus_load, scale=float(spread)
+            ),
+            dimension=2,
+            N=1000,
+            max_iterations=15,
+            random_state=0,
+        ).run(verbose=False)[0]
+        by_sigma0 = SafeICE(
+            limit_state_function=unscaled,
+            dimension=2,
+            N=1000,
+            max_iterations=15,
+            sigma0=float(spread),
+            random_state=0,
+        ).run(verbose=False)[0]
+
+        assert by_scaling == pytest.approx(by_sigma0, rel=1e-12)
+
+    def test_an_explicit_scale_is_used_verbatim(self) -> None:
+        transform = MarginalTransform([RESISTANCE, LOAD])
+        wrapped = transform.wrap(resistance_minus_load, scale=10.0)
+
+        assert wrapped.limit_state_scale == 10.0
+        physical = transform.to_physical(np.zeros(2))
+        expected = float(resistance_minus_load(physical)[0]) / 10.0
+        assert float(np.asarray(wrapped(np.zeros(2)))) == pytest.approx(expected)
+
+    def test_a_non_positive_scale_is_rejected(self) -> None:
+        transform = MarginalTransform([RESISTANCE, LOAD])
+        with pytest.raises(ValueError, match="scale must be positive"):
+            transform.wrap(resistance_minus_load, scale=-1.0)
+
+
+class TestArgumentChecking:
+    def test_at_least_one_marginal(self) -> None:
+        with pytest.raises(ValueError, match="At least one marginal"):
+            MarginalTransform([])
+
+    def test_correlation_shape(self) -> None:
+        with pytest.raises(ValueError, match="Correlation must be 2x2"):
+            MarginalTransform([RESISTANCE, LOAD], correlation=np.eye(3))
+
+    def test_correlation_must_be_symmetric(self) -> None:
+        with pytest.raises(ValueError, match="symmetric"):
+            MarginalTransform(
+                [RESISTANCE, LOAD], correlation=np.array([[1.0, 0.5], [0.2, 1.0]])
+            )
+
+    def test_correlation_needs_a_unit_diagonal(self) -> None:
+        with pytest.raises(ValueError, match="unit diagonal"):
+            MarginalTransform(
+                [RESISTANCE, LOAD], correlation=np.array([[2.0, 0.5], [0.5, 2.0]])
+            )
+
+    def test_correlation_must_be_positive_definite(self) -> None:
+        with pytest.raises(ValueError, match="positive definite"):
+            MarginalTransform(
+                [RESISTANCE, LOAD], correlation=np.array([[1.0, 1.0], [1.0, 1.0]])
+            )
+
+    def test_wrong_number_of_columns(self) -> None:
+        transform = MarginalTransform([RESISTANCE, LOAD])
+        with pytest.raises(ValueError, match="Expected 2 columns"):
+            transform.to_physical(np.zeros((4, 3)))
+        with pytest.raises(ValueError, match="Expected 2 columns"):
+            transform.to_standard(np.zeros((4, 3)))
+
+    def test_three_dimensional_input_is_rejected(self) -> None:
+        transform = MarginalTransform([RESISTANCE, LOAD])
+        with pytest.raises(ValueError, match="1-D or 2-D"):
+            transform.to_physical(np.zeros((2, 2, 2)))


### PR DESCRIPTION
Until now there was no way to apply any estimator to measured data. The prior is standard normal; real inputs are lognormal discharges, Gumbel wind speeds, skewed strengths. The paper notes the same gap in its introduction.

`MarginalTransform` maps between the two. Independent marginals go exactly, `u_i = Phi^-1(F_i(x_i))`. Correlated ones need the Nataf transformation, because a prescribed *physical* correlation is not the correlation of the underlying normals — the marginal transforms are non-linear and distort it:

| target ρ_x | required ρ_z | achieved in samples |
| --- | --- | --- |
| +0.30 | +0.3090 | +0.2984 |
| +0.60 | +0.6096 | +0.5990 |
| +0.80 | +0.8056 | +0.7989 |
| −0.50 | −0.5349 | −0.5003 |

Validated against a closed form — two lognormal resistances with `P(R < S) = 1.817e-05` exactly. Safe-ICE gives 1.05×, subset simulation 0.96×.

## The trap this exposed, which is worth more than the transform

Safe-ICE smooths the indicator as `Phi(-g/sigma)` from `sigma0 = 1`, which **assumes `g` is of order one**. Every benchmark in the paper satisfies that, so the assumption is invisible there. A limit state in physical units does not: the spread of `R − S` here is 33, so `Phi(-g/1)` is already a *hard* indicator, the annealing does nothing, and the run stops after two iterations with sigma still at 0.999.

| | median | spread over seeds |
| --- | --- | --- |
| `g` as-is, σ₀=1 | `5.13e-06` (**0.28×**) | 0.03–0.61× |
| `g/spread`, σ₀=1 | `1.91e-05` (1.05×) | 0.94–1.06× |
| `g` as-is, σ₀=spread | `1.91e-05` (1.05×) | 0.94–1.06× |

Wrong, and not obviously so. **It was noticed only because subset simulation gave 0.97× on the same problem while Safe-ICE gave 0.35×** — which is the entire reason for having a method that cannot be wrong in the same way. That PR paid for itself twice now.

`wrap` therefore divides `g` by its spread under the prior. This cannot change the answer, since `{g <= 0}` and `{g/c <= 0}` are the same set, so it is a pure reparameterisation. The last two rows above are identical because the method only ever sees `g/sigma`; a test asserts they agree to 1e-12.

Anyone writing a limit state directly rather than through the transform is still exposed. Fixing that in `SafeICE` means changing a default for every problem, so it needs re-validating across the whole benchmark set — recorded on the roadmap rather than slipped in here.

31 tests: exact round trips, KS tests against each marginal, Nataf correlation targets, the closed form through both estimators, and the scaling behaviour including a test that fails if the trap ever disappears.

Next: the USGS flood example, which this unblocks, and CE with a Gaussian mixture.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `MarginalTransform` to map problems in physical units to standard normal space and enables estimators to run on measured data. Also changes the default behavior when wrapping a limit state: previously `SafeICE` started at `sigma0=1` and assumed `g` was O(1); now `wrap` divides `g` by its prior spread so the smoothing is effective without changing the failure set.

- Implements Nataf correlation: per-pair Gaussian correlation is solved via Gauss–Hermite quadrature and a bracketed root find; normal marginals pass through unchanged, skewed marginals get the necessary adjusted `rho_z`.
- Public API in `safe_ice.transforms.MarginalTransform`: `to_physical`, `to_standard`, `sample`, and `wrap(limit_state, scale=True|False|float)`. `wrap` attaches `limit_state_scale` and defaults to scaling; pass `scale=False` to opt out or a float to fix the divisor. Equivalent to setting `sigma0` to that spread.
- Validated against a closed form (`P(R < S) = 1.817e-05`) using both `SafeICE` and `SubsetSimulation`; round-trips, KS tests, correlation targets, and scaling behavior covered in `tests/test_transforms.py`.
- Review focus: `safe_ice/transforms.py` (core transform and Nataf solve), new export in `safe_ice/__init__.py`, notes in `CHANGELOG.md` and `ROADMAP.md`. No breaking changes to existing estimator APIs; only the wrapped limit state’s scale changes unless `scale=False` is used.

<sup>Written for commit f021aeaffc181d96368e465a632ea1f5bd393948. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/adaptive-importance-sampling/pull/102?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

