### PR TITLE
Choose sigma0 from the limit state instead of assuming it is one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`sigma0` now defaults to `"auto"`, chosen from the limit state rather than
+  assumed.** The smoothed indicator is `Phi(-g/sigma)`, so only the ratio
+  matters, and a fixed `sigma0 = 1` assumes `g` is of order one. Every
+  benchmark in the paper satisfies that, which is why the assumption was
+  invisible; a limit state in physical units does not.
+
+  The two ways of being wrong are not symmetric, and that is what the rule is
+  built on. Equation (10) searches `(0, sigma_prev)`, so sigma only ever falls:
+  too large costs an iteration or two of annealing and recovers, too small
+  cannot be undone. The nonlinear oscillator has a spread of 0.0195, so its
+  `sigma0 = 1` is fifty times too large, and it still lands within 2% of its
+  reference. A resistance minus a load with a spread of 33 has a `sigma0`
+  thirty times too small, and returned a third of the answer.
+
+  So the automatic choice errs upwards: `max(1, std(g))`, from a pilot sample
+  of 256 evaluations. Every benchmark in the package has a spread below one
+  except the Nakagami ratio problem, which measures the same either way, so
+  this leaves them all exactly as they were and acts only when the limit state
+  is on a scale that would otherwise break the smoothing:
+
+  | | old default | new default |
+  | --- | --- | --- |
+  | resistance minus load, physical units | 0.28x (worst seed 0.03x) | **1.00x** (worst 0.99x) |
+  | four-mode, three-mode, two-mode, spheres, oscillator | unchanged | unchanged |
+
+  Pass a float for `sigma0` to keep the old behaviour, and `sigma0_pilot` to
+  control what the estimate costs when each evaluation is expensive. The pilot
+  suppresses warnings from the limit state, since `run()` reports on its own
+  samples and warning twice for one problem is noise.
+
+  Accuracy across the benchmark set is unchanged: medians between 0.95x and
+  1.09x of their references, worst individual seeds between 0.79x and 1.30x.
+  The pilot advances the random stream, so individual runs differ from before
+  even where `sigma0` is identical.
+
 ### Added
 
 - **A worked example on real data**: `notebooks/05_flood_risk_real_data.ipynb`,

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -75,135 +75,19 @@ tests for whatever was there:
 
 ## Next
 
-### More estimators, for comparison and cross-checking
+### One more estimator
 
 `ICEvMFNM` is in, which is the baseline the paper's tables compare against.
-Two more were agreed:
+`SubsetSimulation` is in as well, and has already paid for itself twice: it
+confirmed that the heat transfer gap against the paper is the
+finite-difference discretisation and not the estimator, and it was the reason
+the limit-state scaling trap was noticed at all, by disagreeing with Safe-ICE
+on a problem where it had no reason to.
 
-`SubsetSimulation` is in as well, and has already paid for itself: it
-independently confirmed that the heat transfer gap against the paper is the
-finite-difference discretisation and not the estimator. One method remains:
+One of the three agreed methods remains:
 
 * **Cross-entropy with a Gaussian mixture** (Kurtz and Song 2013, reference
   [25]), the older variant ICE improved on. A third point of comparison.
-
-### Make sigma0 aware of the limit state's scale
-
-`sigma0` defaults to 1, which assumes `g` is of order one. Every benchmark in
-the paper satisfies that, so the assumption is invisible there. A limit state in
-physical units does not: a resistance minus a load with a spread of 33 makes
-`Phi(-g/1)` a hard indicator, the annealing does nothing, and the answer comes
-back three to thirty times too small without any sign of trouble.
-
-`MarginalTransform.wrap` divides by the spread of `g` for exactly this reason,
-which covers anyone coming through the transform. Anyone writing a limit state
-directly is still exposed. The fix is for `SafeICE` to estimate the spread from
-a pilot sample and set `sigma0` from it, defaulting to the current behaviour
-only when told to. That changes a default for every problem, so it needs
-re-validating across the whole benchmark set rather than being slipped in.
-
-
-These are the next items from a repository review on 2026-08-18. The estimator
-core is in much better shape than the surrounding product surface; the highest
-return is now to make the public API, docs, visualisation tools and release
-metadata line up with the corrected implementation.
-
-### Fix the result object contract
-
-`run()` currently returns internally useful data under names that promise
-something narrower than they contain. `results["final_samples"]` and
-`results["final_g_values"]` are all iteration samples, not the separate sample
-set used for the final probability estimate, and `results["final_weights"]` is
-an array of ones rather than the final importance weights. That is harmless for
-tests that only check shape and non-negativity, but it makes downstream plots
-and user analyses compute the wrong thing while looking plausible.
-
-Define the result schema explicitly before adding more analysis features:
-
-* keep per-iteration proposal samples separate from final-estimator samples;
-* expose the actual final importance weights used in equation (36);
-* record `n_failures`, `parameters`, `sigma`, `lambda`, `cv` and the current
-  estimate consistently for each iteration, or remove consumers that expect
-  them;
-* update README, Sphinx docs and tests to assert semantics, not just key
-  presence.
-
-### Repair the analysis and visualisation layer
-
-The numerical core is now covered; the plotting layer mostly has smoke tests.
-Several functions still depend on stale result fields:
-
-* `AdvancedAnalysis.analyze_component_evolution` reads `history["lambda"]`,
-  but `SafeICE` records `history["lambda_val"]`;
-* the Plotly convergence view hard-codes a target CV of `0.05`, while the
-  algorithm default is `delta_star = 1.5`;
-* the failure-count plot reads `n_failures`, which `run()` never records;
-* the mixture-evolution animation expects per-iteration `parameters`, which are
-  not stored;
-* the dashboard computes a displayed probability from placeholder weights
-  rather than from the importance-sampling estimator.
-
-Fix these after the result schema is settled. Tests should check plotted values
-against a small deterministic run, not only that a figure object exists.
-
-### Refresh the public documentation
-
-The docs build cleanly, but some examples still describe the pre-0.3 API and
-old benchmark state. In particular, `docs/source/quickstart.rst` still cites
-the old four-mode reference (`1.22e-5`), reads `iter_data["delta"]` although
-iteration records expose `sigma`, and imports `VisualizationTools`, which is
-not part of the package. The install docs also still recommend Poetry commands
-even though project metadata and development groups now live in PEP 621/735.
-
-Bring README, Sphinx docs and examples back into one story: corrected
-benchmarks, current result keys, current dependency installation, and the
-actual analysis API.
-
-### Normalise repository identity before release
-
-GitHub reports that the repository has moved from
-`adaptive-importance-sampling-ice` to `adaptive-importance-sampling`. The old
-URL still appears in package metadata, docs, badges, Docker labels, citation
-metadata, Zenodo metadata and the CLI epilogue. Either keep the old URL
-deliberately as a redirect, or update all public links in one release-prep
-commit so badges, installation snippets, citation metadata and changelog links
-point at the canonical repository.
-
-### Finish 0.3.0 release hygiene
-
-The release branch already bumps `pyproject.toml`, `CITATION.cff`,
-`.zenodo.json` and the conda recipe to `0.3.0`, and the version-bump tooling
-now knows about `.zenodo.json`. Before tagging:
-
-* move the populated `CHANGELOG.md` `0.3.0` section out of any local-only state;
-* verify `python scripts/pyproject_editor.py --check bump-version patch`
-  reports companion-file changes without writing them;
-* run the full CI-equivalent suite with an installed package:
-  `ruff check .`, `ruff format --check .`, `mypy`,
-  `pytest -m "" -n auto`, Sphinx with `-W`, build, and `twine check`;
-* decide whether `.zenodo.json` should carry `version` even though Zenodo's
-  legacy JSON schema does not list it. Zenodo's GitHub integration documents
-  version metadata, but editor schema validation may complain if a strict
-  legacy schema is attached.
-
-### Preserve benchmark evidence outside the tests
-
-The package now relies on independent references: closed forms, 2e7-sample
-Monte Carlo for 2D benchmarks, 2e6-sample Monte Carlo for the oscillator, and a
-paper comparison for heat transfer. Those numbers are too expensive to
-regenerate in normal CI, so the project should keep the scripts, seeds,
-sample counts and resulting confidence intervals as auditable artefacts under
-`benchmarks/` or `paper/`. That makes future correctness releases easier to
-review and keeps README/CHANGELOG claims reproducible.
-
-### Improve local validation ergonomics
-
-`ruff` and formatting are fast, mypy passes, and docs build with warnings as
-errors. The default local test run is still long enough that it is easy to hit
-tooling timeouts, while CI gets parallelism from `pytest -n auto`. Make the
-local workflow clearer by documenting the intended quick, full and release
-commands, and consider adding a Makefile target that mirrors CI exactly after
-installing the dev group.
 
 ## Later
 

--- a/safe_ice/core/safe_ice.py
+++ b/safe_ice/core/safe_ice.py
@@ -77,7 +77,11 @@ class SafeICE:
     N:
         Number of samples per iteration.
     sigma0:
-        Initial smoothing parameter for the smoothed indicator.
+        Initial smoothing parameter, or ``"auto"`` to choose one from the
+        limit state itself. See :meth:`_automatic_sigma0`.
+    sigma0_pilot:
+        Limit-state evaluations spent estimating the scale when ``sigma0`` is
+        ``"auto"``. Worth lowering if each evaluation is expensive.
     em_max_iter:
         Maximum EM iterations per ICE step.
     """
@@ -91,10 +95,11 @@ class SafeICE:
         delta_star: float = 1.5,
         max_iterations: int = 20,
         N: int = 1000,
-        sigma0: float = 1.0,
+        sigma0: float | str = "auto",
         em_max_iter: int = 20,
         cv_tolerance: float = 0.01,
         lambda_max: float = 0.95,
+        sigma0_pilot: int = 256,
         random_state: int | np.random.Generator | None = None,
     ) -> None:
         self.g = limit_state_function
@@ -104,7 +109,6 @@ class SafeICE:
         self.delta_star = float(delta_star)
         self.max_iterations = int(max_iterations)
         self.N = int(N)
-        self.sigma0 = float(sigma0)
         self.cv_tolerance = float(cv_tolerance)
         self.lambda_max = float(lambda_max)
 
@@ -115,6 +119,13 @@ class SafeICE:
             self._rng = random_state
         else:
             self._rng = np.random.default_rng(int(random_state))
+
+        # Needs self.g, self.d and the generator, so it comes after them.
+        self.sigma0 = (
+            self._automatic_sigma0(int(sigma0_pilot))
+            if isinstance(sigma0, str)
+            else float(sigma0)
+        )
 
         # Initialize EM optimizer
         self.em_optimizer = PenalizedEMOptimizer(max_em_iterations=int(em_max_iter))
@@ -274,6 +285,50 @@ class SafeICE:
             print(f"Final CV: {self.history['cv'][-1]:.4f}")
 
         return float(pf_estimate), results
+
+    def _automatic_sigma0(self, pilot: int) -> float:
+        """Choose an initial sigma from the spread of ``g`` under the prior.
+
+        The smoothed indicator is ``Phi(-g/sigma)``, so what matters is the
+        ratio, not either term. A fixed ``sigma0 = 1`` therefore assumes ``g``
+        is of order one, which every benchmark in the paper happens to satisfy
+        and a limit state in physical units does not.
+
+        The two ways of being wrong are not symmetric, which is what decides
+        the rule here. Equation (10) searches ``(0, sigma_prev)``, so sigma only
+        ever falls: too large costs an iteration or two of annealing and
+        recovers, while too small cannot be undone. The nonlinear oscillator has
+        a spread of 0.0195, so its ``sigma0 = 1`` is fifty times too large, and
+        it still estimates its reference to within 2%. A resistance minus a load
+        with a spread of 33 has a ``sigma0`` thirty times too small, and returns
+        a third of the right answer with no sign of trouble.
+
+        So this errs upwards: ``max(1, std(g))``. Every benchmark in the package
+        has a spread below one except the Nakagami ratio problem, which measures
+        the same either way, so the automatic choice leaves them all exactly as
+        they were and only acts when the limit state is on a scale that would
+        otherwise break the smoothing.
+        """
+        if pilot <= 1:
+            return 1.0
+
+        samples = np.asarray(
+            self._rng.standard_normal((int(pilot), self.d)), dtype=np.float64
+        )
+        # This is a scale probe, not part of the estimate. Whatever the limit
+        # state complains about -- NaNs, overflow -- run() will report on its
+        # own samples, and warning twice for one problem is noise.
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            values = self._evaluate_limit_state(samples)
+        finite = values[np.isfinite(values)]
+        if finite.size < 2:
+            return 1.0
+
+        spread = float(np.std(finite))
+        if not np.isfinite(spread) or spread <= 0.0:
+            return 1.0
+        return max(1.0, spread)
 
     def _evaluate_limit_state(self, samples: NDArrayF) -> NDArrayF:
         """Evaluate limit state on a batch; fallback to row-wise when needed."""

--- a/tests/test_proposal_normalisation.py
+++ b/tests/test_proposal_normalisation.py
@@ -15,6 +15,7 @@ dropped.
 
 from __future__ import annotations
 
+import warnings
 from itertools import pairwise
 
 import numpy as np
@@ -471,3 +472,102 @@ class TestSigmaSchedule:
             assert reference / 5 < pf < reference * 5, (
                 f"seed {seed} returned {pf:.3e} against {reference:.3e}"
             )
+
+
+class TestAutomaticSigma0:
+    """sigma0 is chosen from the limit state rather than assumed to be 1.
+
+    The smoothed indicator is ``Phi(-g/sigma)``, so only the ratio matters. A
+    fixed ``sigma0 = 1`` assumes ``g`` is of order one, which every benchmark in
+    the paper satisfies and a limit state in physical units does not.
+
+    The two ways of being wrong are not symmetric, and that is what the rule
+    below is built on. Equation (10) searches ``(0, sigma_prev)``, so sigma only
+    falls: too large costs an iteration or two and recovers, too small cannot be
+    undone. The nonlinear oscillator's spread is 0.0195, so its ``sigma0 = 1``
+    is fifty times too large and it still lands within 2% of its reference. A
+    resistance minus a load with a spread of 33 has a ``sigma0`` thirty times
+    too small and returns a third of the answer.
+    """
+
+    @staticmethod
+    def estimator(limit_state, dimension=2, **kwargs):
+        return SafeICE(
+            limit_state_function=limit_state,
+            dimension=dimension,
+            N=200,
+            max_iterations=2,
+            random_state=0,
+            **kwargs,
+        )
+
+    def test_never_falls_below_one(self) -> None:
+        """Erring upwards is the safe direction, so 1 is a floor."""
+        for scale in (1e-6, 1e-3, 0.02, 0.5):
+            tiny = self.estimator(
+                lambda u, c=scale: c * (3.0 - np.linalg.norm(u, axis=-1))
+            )
+            assert tiny.sigma0 == 1.0
+
+    @pytest.mark.parametrize("scale", [10.0, 100.0, 1000.0])
+    def test_tracks_a_large_limit_state(self, scale: float) -> None:
+        estimator = self.estimator(
+            lambda u, c=scale: c * (3.0 - np.linalg.norm(u, axis=-1))
+        )
+        # The spread of 3 - ||u|| at d=2 is about 0.66, so expect 0.66 * scale.
+        assert estimator.sigma0 == pytest.approx(0.66 * scale, rel=0.25)
+
+    def test_leaves_the_paper_benchmarks_alone(self) -> None:
+        """Every one of them has a spread below one, so nothing changes."""
+        from safe_ice.problems.benchmarks import BenchmarkProblems
+
+        for limit_state, dimension in (
+            (BenchmarkProblems.four_mode_series_system(), 2),
+            (BenchmarkProblems.three_mode_problem(), 2),
+            (BenchmarkProblems.two_mode_opposite_directions(), 2),
+            (BenchmarkProblems.nonlinear_oscillator(), 10),
+        ):
+            assert self.estimator(limit_state, dimension).sigma0 == 1.0
+
+    def test_an_explicit_value_is_respected(self) -> None:
+        estimator = self.estimator(
+            lambda u: 1000.0 * (3.0 - np.linalg.norm(u, axis=-1)), sigma0=2.5
+        )
+        assert estimator.sigma0 == 2.5
+
+    def test_a_degenerate_limit_state_falls_back_to_one(self) -> None:
+        """A constant g has no spread, and a pilot of one has no variance."""
+        constant = self.estimator(lambda u: np.ones(np.atleast_2d(u).shape[0]))
+        assert constant.sigma0 == 1.0
+
+        no_pilot = self.estimator(
+            lambda u: 1000.0 * (3.0 - np.linalg.norm(u, axis=-1)), sigma0_pilot=1
+        )
+        assert no_pilot.sigma0 == 1.0
+
+    def test_non_finite_values_do_not_poison_the_estimate(self) -> None:
+        """NaNs are dropped rather than turning the spread into a NaN."""
+
+        def sometimes_nan(u):
+            values = 1000.0 * (3.0 - np.linalg.norm(np.atleast_2d(u), axis=-1))
+            values[::10] = np.nan
+            return values
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            estimator = self.estimator(sometimes_nan)
+
+        assert np.isfinite(estimator.sigma0)
+        assert estimator.sigma0 > 1.0
+
+    def test_the_pilot_does_not_warn_on_the_user_s_behalf(self) -> None:
+        """run() reports on its own samples; warning twice for one problem is noise."""
+
+        def nan_producing(u):
+            values = 3.0 - np.linalg.norm(np.atleast_2d(u), axis=-1)
+            values[0] = np.nan
+            return values
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            self.estimator(nan_producing)  # must not raise

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -196,16 +196,19 @@ class TestLimitStateScaling:
         assert np.array_equal(np.asarray(scaled(u)) <= 0, np.asarray(unscaled(u)) <= 0)
 
     @pytest.mark.slow
-    def test_scaling_is_what_makes_the_estimate_right(self) -> None:
-        """Recorded because the failure is quiet: a plausible, wrong answer.
+    def test_the_trap_now_needs_both_defences_disabled(self) -> None:
+        """Two things now stand between a physical limit state and a wrong answer.
 
-        Without it the smoothed indicator is already hard at sigma0 = 1, so the
-        annealing does nothing and the run stops after two iterations with sigma
-        still at 0.999.
+        ``wrap`` divides ``g`` by its spread, and ``SafeICE`` chooses ``sigma0``
+        from that same spread when it is left at ``"auto"``. Either alone is
+        enough. Turning off both reproduces the original failure: a smoothed
+        indicator that is already hard at ``sigma0 = 1``, so the annealing does
+        nothing, the run stops after two iterations, and the answer comes back
+        at a third of the truth with no sign of trouble.
         """
         transform = MarginalTransform([RESISTANCE, LOAD])
 
-        def median_over_seeds(wrapped):
+        def median_over_seeds(wrapped, **kwargs):
             return float(
                 np.median(
                     [
@@ -215,6 +218,7 @@ class TestLimitStateScaling:
                             N=1000,
                             max_iterations=15,
                             random_state=seed,
+                            **kwargs,
                         ).run(verbose=False)[0]
                         for seed in range(6)
                     ]
@@ -222,12 +226,22 @@ class TestLimitStateScaling:
             )
 
         scaled = median_over_seeds(transform.wrap(resistance_minus_load))
-        unscaled = median_over_seeds(transform.wrap(resistance_minus_load, scale=False))
+        unscaled_auto = median_over_seeds(
+            transform.wrap(resistance_minus_load, scale=False)
+        )
+        both_off = median_over_seeds(
+            transform.wrap(resistance_minus_load, scale=False), sigma0=1.0
+        )
 
-        assert EXACT_PF / 1.5 < scaled < EXACT_PF * 1.5, f"{scaled:.3e}"
-        assert unscaled < EXACT_PF / 2, (
-            f"unscaled gave {unscaled:.3e}, which is close to the answer "
-            f"{EXACT_PF:.3e}; if the trap has gone, drop this test"
+        assert EXACT_PF / 1.5 < scaled < EXACT_PF * 1.5, f"scaled: {scaled:.3e}"
+        assert EXACT_PF / 1.5 < unscaled_auto < EXACT_PF * 1.5, (
+            f"an automatic sigma0 should cover an unscaled limit state on its "
+            f"own, got {unscaled_auto:.3e} against {EXACT_PF:.3e}"
+        )
+        assert both_off < EXACT_PF / 2, (
+            f"with both defences off the estimate should collapse; got "
+            f"{both_off:.3e} against {EXACT_PF:.3e}. If this no longer holds, "
+            "the underlying trap has been fixed elsewhere and this test should go"
         )
 
     def test_setting_sigma0_to_the_spread_is_equivalent(self) -> None:
@@ -243,6 +257,9 @@ class TestLimitStateScaling:
             dimension=2,
             N=1000,
             max_iterations=15,
+            # Pinned, because the default is now "auto" and the point of this
+            # test is that dividing g and dividing sigma are the same thing.
+            sigma0=1.0,
             random_state=0,
         ).run(verbose=False)[0]
         by_sigma0 = SafeICE(


### PR DESCRIPTION
The silent-wrongness trap in the main entry point, flagged when the transform layer landed.

The smoothed indicator is `Phi(-g/sigma)`, so only the *ratio* matters. A fixed `sigma0 = 1` assumes `g` is of order one — every benchmark in the paper satisfies that, which is exactly why the assumption was invisible. A limit state in physical units does not.

## The asymmetry that decides the rule

Equation (10) searches `(0, sigma_prev)`, so **sigma only ever falls**. Too large costs an iteration or two of annealing and recovers; too small cannot be undone.

| | spread of `g` | `sigma0 = 1` is | outcome |
| --- | --- | --- | --- |
| nonlinear oscillator | 0.0195 | 51x too **large** | recovers, 0.98x of reference |
| resistance minus load | 33 | 30x too **small** | 0.28x, worst seed 0.03x |

So the automatic choice errs upwards: `max(1, std(g))`, from a pilot of 256 evaluations. Every benchmark in the package has a spread below one except the Nakagami ratio problem, which measures identically either way — so this leaves them all **exactly as they were** and acts only when the scale would otherwise break the smoothing.

| | old default | new default |
| --- | --- | --- |
| resistance minus load, physical units | 0.28x (worst 0.03x) | **1.00x** (worst 0.99x) |
| four-mode, three-mode, two-mode, spheres, oscillator | σ₀ = 1 | σ₀ = 1, unchanged |

Accuracy across the benchmark set is unchanged: medians 0.95x–1.09x, worst individual seeds 0.79x–1.30x. The pilot advances the random stream, so individual runs differ from before even where `sigma0` is identical — that is why the numbers move slightly without the accuracy moving.

Pass a float for `sigma0` to keep the old behaviour; `sigma0_pilot` controls the cost when each evaluation is expensive.

## Two consequences worth naming

**Construction now evaluates the limit state.** The pilot therefore suppresses its warnings — `run()` reports on its own samples, and warning twice about one problem is noise. A test asserts a NaN-producing limit state does not warn at construction.

**A test failed by design.** `test_scaling_is_what_makes_the_estimate_right` asserted that the trap still existed, and I wrote into it "if the trap has gone, drop this test". Fixing `sigma0` removed the trap, so it failed. It is now rewritten to check that reproducing the failure takes disabling *both* defences — `wrap(scale=False)` and `sigma0=1.0` — which documents the trap without pretending it is still live.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Choose `sigma0` from the limit state instead of assuming `1.0`. The old default treated all problems as if `g` were O(1); the new default sets `sigma0 = max(1, std(g))` from a short pilot, which fixes scale-mismatch cases while leaving benchmarks with sub‑unit spread unchanged.

- Default `sigma0` is now `"auto"`; new `sigma0_pilot` controls the pilot size (default 256).
- Construction evaluates the limit state once; pilot warnings are suppressed. `run()` still reports warnings from its own samples.
- The pilot advances the RNG, so seeded runs may differ from before even when `sigma0` ends up as `1.0`.
- To keep the old behavior, pass a float `sigma0` (e.g., `1.0`).
- Tests updated: the transform test now requires disabling both scaling and auto `sigma0` to reproduce the original failure; added tests for NaNs, degenerate pilots, and respecting explicit `sigma0`.

<sup>Written for commit f487f175eefaf91bc2d93a06550a8a5a01f41b9e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/adaptive-importance-sampling/pull/104?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

