### PR TITLE
Add a notebook comparing all four estimators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `notebooks/06_comparing_estimators.ipynb`, running all four estimators on the
+  same problems. The useful half is where each one stops rather than where they
+  agree, and on a two-dimensional, gently-shaped problem they all land on the
+  answer, so the differences below are not about implementation quality.
+
+  Multiple modes separate them, and for different reasons. On the four-mode
+  problem, lobes reached out of four across six seeds:
+
+  | | lobes | worst seed |
+  | --- | --- | --- |
+  | Safe-ICE | `[4,4,4,4,4,4]` | 0.79x |
+  | ICE-vMFNM | `[4,4,1,4,4,4]` | 0.13x |
+  | CE-GM | `[3,3,4,3,4,2]` | 0.17x |
+  | subset simulation | `[4,4,4,4,4,4]` | 0.58x |
+
+  CE-GM is consistently short because it fits to the best tenth of each
+  iteration. ICE-vMFNM usually finds all four but collapsed onto one on a single
+  seed, having no penalty holding its components apart -- which is the mechanism
+  Safe-ICE adds. Subset simulation reaches all four because its chains walk
+  rather than fit, so there is no fitted object to collapse.
+
+  Dimension separates them too: on the sphere problem CE-GM is fine at `d=10`
+  and returns 0.00x by `d=50`, while the other three hold from `d=2` to `d=100`.
+
+  The closing section is deliberately even-handed about Safe-ICE's own limits:
+  its sensitivity to the scale of `g`, and its need for a limit state with a
+  usable gradient, which a connectivity problem returning +/-1 does not have.
+
 - `CrossEntropyGaussianMixture`, the method of Kurtz and Song (2013),
   reference [25], and the last of the three comparison estimators. It is the
   older approach ICE was introduced to improve on, and it differs from ICE in

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ vectorised function.
 
 ## Notebooks
 
-Five notebooks in [notebooks/](notebooks/), executed with their outputs saved
+Six notebooks in [notebooks/](notebooks/), executed with their outputs saved
 so the plots and numbers render on GitHub without running anything:
 
 | Notebook | What it shows |
@@ -142,6 +142,7 @@ so the plots and numbers render on GitHub without running anything:
 | [High dimensions](notebooks/03_high_dimensions.ipynb) | `d=2` to `d=200` against the exact chi-square tail |
 | [How it works](notebooks/04_how_it_works.ipynb) | The smoothed indicator, sigma schedule, penalised EM and heavy-tailed component |
 | [Flood risk, real data](notebooks/05_flood_risk_real_data.ipynb) | 95 years of USGS gauge data, a levee, and three estimators that agree |
+| [Comparing estimators](notebooks/06_comparing_estimators.ipynb) | All four estimators on the same problems, and where each one stops |
 
 ## How it works
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -73,6 +73,11 @@ tests for whatever was there:
   so a defect there misleads rather than corrupts, and the tests are shallow
   by design.
 
+### Done: a notebook comparing all four
+
+`notebooks/06_comparing_estimators.ipynb` runs them on the same problems and
+records where each one stops, including Safe-ICE.
+
 ### Done: all three comparison estimators are in
 
 `ICEvMFNM` is the baseline the paper's tables compare against.
@@ -89,13 +94,18 @@ side by side on the same problems would be a reasonable next step.
 
 ## Next
 
-### A comparison notebook
+### Keep the notebooks from going quietly stale
 
-Four estimators now solve the same problems by different means: Safe-ICE,
-ICE-vMFNM, subset simulation and cross-entropy with a Gaussian mixture. Putting
-them side by side on one set of problems, with their costs, would make the
-paper's argument visible rather than tabulated -- and would show where each one
-stops, which is the more useful half.
+All six carry saved outputs so they render on GitHub, and nothing re-executes
+them. Every number in them is pinned to the behaviour of the version that ran
+them, so a change to an estimator leaves them wrong in a way no test catches --
+`tests/test_flood_data.py` guards one notebook's claims, and the rest are
+unguarded.
+
+A workflow that re-runs them and fails on error would close it, at a few
+minutes per build. Re-running on every push would also churn the committed
+outputs, so it probably wants to run on a schedule, or on changes to
+`safe_ice/` only, and report rather than commit.
 
 ## Later
 

--- a/notebooks/06_comparing_estimators.ipynb
+++ b/notebooks/06_comparing_estimators.ipynb
@@ -1,0 +1,597 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "373669e1",
+   "metadata": {},
+   "source": [
+    "# Four estimators, side by side\n",
+    "\n",
+    "The package implements four methods for the same question. This notebook runs\n",
+    "them on the same problems and, more usefully, shows where each one stops.\n",
+    "\n",
+    "| Method | Proposal | How the intermediate level is set |\n",
+    "| --- | --- | --- |\n",
+    "| **Safe-ICE** | vMF-Nakagami mixture plus a heavy-tailed component | smoothed indicator $\\Phi(-g/\\sigma)$ |\n",
+    "| **ICE-vMFNM** | vMF-Nakagami mixture | smoothed indicator $\\Phi(-g/\\sigma)$ |\n",
+    "| **CE-GM** | Gaussian mixture | hard threshold at the $\\rho$-quantile |\n",
+    "| **Subset simulation** | none — MCMC in nested levels | hard threshold at the $p_0$-quantile |\n",
+    "\n",
+    "The first three are importance sampling: fit a proposal, reweight by $p/q$.\n",
+    "The fourth is not, which is what makes it useful as a check rather than a\n",
+    "second opinion from the same machinery."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "50b09a4d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-19T15:00:51.547834Z",
+     "iopub.status.busy": "2026-08-19T15:00:51.547370Z",
+     "iopub.status.idle": "2026-08-19T15:00:53.705248Z",
+     "shell.execute_reply": "2026-08-19T15:00:53.703759Z"
+    },
+    "lines_to_next_cell": 2
+   },
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "from scipy import stats\n",
+    "\n",
+    "from safe_ice import (\n",
+    "    CrossEntropyGaussianMixture,\n",
+    "    ICEvMFNM,\n",
+    "    SafeICE,\n",
+    "    SubsetSimulation,\n",
+    ")\n",
+    "from safe_ice.problems.benchmarks import BenchmarkProblems\n",
+    "\n",
+    "plt.rcParams.update({\"figure.dpi\": 110, \"font.size\": 10, \"figure.facecolor\": \"white\"})\n",
+    "\n",
+    "METHODS = {\n",
+    "    \"Safe-ICE\": (SafeICE, {\"N\": 1000, \"max_iterations\": 15}),\n",
+    "    \"ICE-vMFNM\": (ICEvMFNM, {\"K\": 4, \"N\": 1000, \"max_iterations\": 15}),\n",
+    "    \"CE-GM\": (CrossEntropyGaussianMixture, {\"K\": 4, \"N\": 2000}),\n",
+    "    \"subset sim\": (SubsetSimulation, {\"N\": 2000}),\n",
+    "}\n",
+    "COLOURS = {\n",
+    "    \"Safe-ICE\": \"#1d3557\",\n",
+    "    \"ICE-vMFNM\": \"#457b9d\",\n",
+    "    \"CE-GM\": \"#c1121f\",\n",
+    "    \"subset sim\": \"#2a9d8f\",\n",
+    "}\n",
+    "SEEDS = range(5)\n",
+    "\n",
+    "\n",
+    "def run_all(limit_state, dimension, seeds=SEEDS):\n",
+    "    \"\"\"Every method on one problem, returning estimates and evaluation counts.\"\"\"\n",
+    "    out = {}\n",
+    "    for name, (cls, kwargs) in METHODS.items():\n",
+    "        estimates, costs = [], []\n",
+    "        for seed in seeds:\n",
+    "            instance = cls(\n",
+    "                limit_state_function=limit_state,\n",
+    "                dimension=dimension,\n",
+    "                random_state=seed,\n",
+    "                **kwargs,\n",
+    "            )\n",
+    "            pf, diagnostics = instance.run(verbose=False)\n",
+    "            estimates.append(pf)\n",
+    "            costs.append(\n",
+    "                diagnostics.get(\"n_evaluations\")\n",
+    "                or instance.N * (len(diagnostics[\"iterations\"]) + 1)\n",
+    "            )\n",
+    "        out[name] = (np.array(estimates), int(np.median(costs)))\n",
+    "    return out"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4b7d17f9",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
+   "source": [
+    "## Where they agree\n",
+    "\n",
+    "Two problems with answers known in closed form, so there is nothing to argue\n",
+    "about."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "bd867bba",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-19T15:00:53.709286Z",
+     "iopub.status.busy": "2026-08-19T15:00:53.708605Z",
+     "iopub.status.idle": "2026-08-19T15:00:58.270063Z",
+     "shell.execute_reply": "2026-08-19T15:00:58.269406Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "two-mode, z=3  (closed form, P_F = 2.6998e-03)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    Safe-ICE     2.7606e-03   1.02x    3,000 evaluations\n",
+      "    ICE-vMFNM    2.6172e-03   0.97x    4,000 evaluations\n",
+      "    CE-GM        2.5137e-03   0.93x    8,000 evaluations\n",
+      "    subset sim   2.8600e-03   1.06x    6,000 evaluations\n",
+      "\n",
+      "sphere, d=2  (closed form, P_F = 2.1875e-03)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    Safe-ICE     2.2277e-03   1.02x    3,000 evaluations\n",
+      "    ICE-vMFNM    2.1803e-03   1.00x    4,000 evaluations\n",
+      "    CE-GM        1.7241e-03   0.79x    6,000 evaluations\n",
+      "    subset sim   2.5950e-03   1.19x    6,000 evaluations\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "def sphere(beta):\n",
+    "    return lambda u: beta - np.linalg.norm(u, axis=-1)\n",
+    "\n",
+    "\n",
+    "problems = [\n",
+    "    (\n",
+    "        \"two-mode, z=3\",\n",
+    "        BenchmarkProblems.two_mode_opposite_directions(z=3.0),\n",
+    "        2,\n",
+    "        float(2 * stats.norm.cdf(-3.0)),\n",
+    "        \"closed form\",\n",
+    "    ),\n",
+    "    (\n",
+    "        \"sphere, d=2\",\n",
+    "        sphere(3.5),\n",
+    "        2,\n",
+    "        float(stats.chi2.sf(3.5**2, df=2)),\n",
+    "        \"closed form\",\n",
+    "    ),\n",
+    "]\n",
+    "\n",
+    "for label, limit_state, dimension, reference, source in problems:\n",
+    "    print(f\"{label}  ({source}, P_F = {reference:.4e})\")\n",
+    "    for name, (estimates, cost) in run_all(limit_state, dimension).items():\n",
+    "        median = float(np.median(estimates))\n",
+    "        print(\n",
+    "            f\"    {name:12s} {median:.4e}  {median / reference:5.2f}x  \"\n",
+    "            f\"{cost:7,d} evaluations\"\n",
+    "        )\n",
+    "    print()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c1190089",
+   "metadata": {},
+   "source": [
+    "All four land on the answer. On a two-dimensional, gently-shaped problem the\n",
+    "choice of method barely matters — which is worth knowing, because it means the\n",
+    "differences below are not about one implementation being better written than\n",
+    "another."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c0170329",
+   "metadata": {},
+   "source": [
+    "## Where multiple modes separate them\n",
+    "\n",
+    "The four-mode series system puts its failure region in four disconnected\n",
+    "lobes. A proposal that finds three of them returns three quarters of the\n",
+    "answer, and looks perfectly converged while doing so."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "159131b2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-19T15:00:58.272451Z",
+     "iopub.status.busy": "2026-08-19T15:00:58.272127Z",
+     "iopub.status.idle": "2026-08-19T15:01:02.417768Z",
+     "shell.execute_reply": "2026-08-19T15:01:02.416454Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "four-mode series system, reference 6.4650e-05\n",
+      "    method            median   ratio  worst seed\n",
+      "    ---------------------------------------------\n",
+      "    Safe-ICE      5.9278e-05   0.92x       0.79x\n",
+      "    ICE-vMFNM     3.9135e-05   0.61x       0.13x\n",
+      "    CE-GM         3.1847e-05   0.49x       0.17x\n",
+      "    subset sim    6.2050e-05   0.96x       0.58x\n"
+     ]
+    }
+   ],
+   "source": [
+    "FOUR_MODE = BenchmarkProblems.four_mode_series_system(z=1.0)\n",
+    "FOUR_MODE_PF = 6.465e-05  # crude MC over 2e7 samples\n",
+    "\n",
+    "four_mode_results = run_all(FOUR_MODE, 2, seeds=range(6))\n",
+    "\n",
+    "print(f\"four-mode series system, reference {FOUR_MODE_PF:.4e}\")\n",
+    "print(f\"    {'method':12s} {'median':>11s} {'ratio':>7s} {'worst seed':>11s}\")\n",
+    "print(\"    \" + \"-\" * 45)\n",
+    "for name, (estimates, _cost) in four_mode_results.items():\n",
+    "    ratios = estimates / FOUR_MODE_PF\n",
+    "    worst = ratios[np.argmax(np.abs(np.log(np.maximum(ratios, 1e-300))))]\n",
+    "    print(\n",
+    "        f\"    {name:12s} {np.median(estimates):11.4e} \"\n",
+    "        f\"{np.median(ratios):6.2f}x {worst:10.2f}x\"\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "242ec9b5",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-19T15:01:02.422505Z",
+     "iopub.status.busy": "2026-08-19T15:01:02.421696Z",
+     "iopub.status.idle": "2026-08-19T15:01:06.880603Z",
+     "shell.execute_reply": "2026-08-19T15:01:06.879795Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "lobes of the failure region the final samples reach (4 exist):\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    Safe-ICE     [4, 4, 4, 4, 4, 4]   median 4/4\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    ICE-vMFNM    [4, 4, 1, 4, 4, 4]   median 4/4\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    CE-GM        [3, 3, 4, 3, 4, 2]   median 3/4\n",
+      "    subset sim   [4, 4, 4, 4, 4, 4]   median 4/4\n"
+     ]
+    }
+   ],
+   "source": [
+    "def lobes_covered(samples, g_values):\n",
+    "    \"\"\"How many of the four lobes the failing samples fall in.\"\"\"\n",
+    "    failing = np.asarray(samples)[np.asarray(g_values) <= 0]\n",
+    "    if failing.size == 0:\n",
+    "        return 0\n",
+    "    keys = list(\n",
+    "        zip(\n",
+    "            np.sign(failing[:, 0] + failing[:, 1]).astype(int),\n",
+    "            np.sign(failing[:, 0] - failing[:, 1]).astype(int),\n",
+    "            strict=False,\n",
+    "        )\n",
+    "    )\n",
+    "    counts = {}\n",
+    "    for key in keys:\n",
+    "        counts[key] = counts.get(key, 0) + 1\n",
+    "    return sum(1 for count in counts.values() if count >= 3)\n",
+    "\n",
+    "\n",
+    "print(\"lobes of the failure region the final samples reach (4 exist):\")\n",
+    "for name, (cls, kwargs) in METHODS.items():\n",
+    "    found = []\n",
+    "    for seed in range(6):\n",
+    "        _pf, diagnostics = cls(\n",
+    "            limit_state_function=FOUR_MODE, dimension=2, random_state=seed, **kwargs\n",
+    "        ).run(verbose=False)\n",
+    "        found.append(\n",
+    "            lobes_covered(diagnostics[\"final_samples\"], diagnostics[\"final_g_values\"])\n",
+    "        )\n",
+    "    print(f\"    {name:12s} {found}   median {int(np.median(found))}/4\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1d05fab2",
+   "metadata": {},
+   "source": [
+    "The lobe count explains the estimates above, and the three methods miss modes\n",
+    "for different reasons.\n",
+    "\n",
+    "CE-GM is consistently short, at three of four, because it fits a mixture to\n",
+    "the best tenth of each iteration and that concentrates wherever the first\n",
+    "elites happened to land. ICE-vMFNM usually finds all four, but one seed in six\n",
+    "collapsed to a single lobe — it has no penalty holding its components apart,\n",
+    "so nothing stops EM from merging them, and that one run is where its worst-case\n",
+    "0.13x comes from. Safe-ICE's penalised EM is precisely the mechanism that\n",
+    "prevents it.\n",
+    "\n",
+    "Subset simulation reaches all four for a different reason again: its chains do\n",
+    "not fit anything, they walk, so there is no fitted object to collapse."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0eef78b0",
+   "metadata": {},
+   "source": [
+    "## Where dimension separates them\n",
+    "\n",
+    "The prior's mass concentrates on a shell of radius $\\sqrt{d}$. Representing\n",
+    "that with a Gaussian mixture is fine at $d = 10$ and hopeless by $d = 50$; a\n",
+    "vMF-Nakagami mixture is written in polar form, separating radius from\n",
+    "direction, and so does not have to represent a shell with an ellipsoid."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "c4133611",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-19T15:01:06.884311Z",
+     "iopub.status.busy": "2026-08-19T15:01:06.883986Z",
+     "iopub.status.idle": "2026-08-19T15:01:15.465186Z",
+     "shell.execute_reply": "2026-08-19T15:01:15.464564Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "method             d=2      d=10      d=50     d=100\n",
+      "----------------------------------------------------\n",
+      "Safe-ICE         1.01x     0.98x     0.97x     0.96x\n",
+      "ICE-vMFNM        1.00x     0.92x     1.04x     0.90x\n",
+      "CE-GM            0.90x     1.03x     0.00x     0.00x\n",
+      "subset sim       1.11x     0.95x     0.94x     1.03x\n"
+     ]
+    }
+   ],
+   "source": [
+    "dimension_cases = [(2, 3.5), (10, 5.0), (50, 9.0), (100, 12.0)]\n",
+    "by_dimension = {name: [] for name in METHODS}\n",
+    "\n",
+    "for d, beta in dimension_cases:\n",
+    "    exact = float(stats.chi2.sf(beta**2, df=d))\n",
+    "    for name, (estimates, _cost) in run_all(sphere(beta), d, seeds=range(3)).items():\n",
+    "        by_dimension[name].append(float(np.median(estimates)) / exact)\n",
+    "\n",
+    "print(f\"{'method':12s}\" + \"\".join(f\"{f'd={d}':>10s}\" for d, _ in dimension_cases))\n",
+    "print(\"-\" * 52)\n",
+    "for name, ratios in by_dimension.items():\n",
+    "    print(f\"{name:12s}\" + \"\".join(f\"{r:9.2f}x\" for r in ratios))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "90a6153b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-19T15:01:15.467323Z",
+     "iopub.status.busy": "2026-08-19T15:01:15.467044Z",
+     "iopub.status.idle": "2026-08-19T15:01:15.925704Z",
+     "shell.execute_reply": "2026-08-19T15:01:15.924841Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAsoAAAGtCAYAAAAPj1I/AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAQ6wAAEOsBUJTofAAAj2tJREFUeJzt3Qd4U1UbB/B/94K2UAqUPcvee++9t4AMERkqiMiWKVNQED+2sgRlD9lLUGTJRvaebRmltIWWzuR73lNSO9JJ2yTt/+cTQ25u7j25N2nenLznPWZarVYLIiIiIiKKxjz6TSIiIiIiYqBMRERERBQH9igTEREREenBQJmIiIiISA8GykREREREejBQJiIiIiLSg4EyEREREZEeDJSJiIiIiPRgoExEREREpAcDZSIiIiIiPRgoExkJMzMz9O3b19DNoPe0atUqdS7//PPPRK0v51zWp9ju37+P9u3bw9XV1STfHw8ePFDtnjx5crzL0pP69eujQIEChm4GUYqxTLlNEZFOUgKflStXmlwAQJQU8qVBLsOGDYOzs3OiHyfvi3///Rdff/01cubMicKFC/PAE1GaYqBMlArWrFkT7fb169cxY8YM1KlTBwMGDIh2X82aNXkOKF2TIHnKlCkq8E1soBwcHIy///4bn3/+OUaMGIH0In/+/Hj79i0sLdPnx++BAweg1WoN3QyiFJM+36lEBvbhhx/GChQkUC5UqFCs+8h4+fv7w9HR0dDNyJCePXumAq6sWbMatB3ShoCAAGTKlCnFfm2ytbVFemVtbW3oJhClKOYoExmZ06dPo2HDhuqDWXrfPvjgAzx//jzWeiEhIZg9ezbKli0LOzs7FdA1btwYR48eTXQA8L///Q8VKlSAk5OT2p/8tN2jRw94eXlFa0+/fv1QrFgxODg4qEuVKlVUykhMkncpgYD0oEsvYO7cuWFvb696zWU74vjx4yqPUfYnuafDhw9HWFiY3kBpyJAhKt9RPnxz5MihvmRIjmdi6Npy7do1tQ9piwQo5cqVw/r162OtL/uRdslP/a1atUKWLFnUcdG5ceOGOhfSDhsbG/WlR56jBNP6yHOaNm0aChYsqNaX4yfHO7ES+/x1OdF//PFH5Jcx3fPcu3evWkeOQevWrdXzkdeU9Oy+efMG79tz2L17d/Wa0b3+6tati507d0ZbT46p9CYLORbS1oRydOUx0vMq5LG6x+jyvjUaDX788Uf1HHX7lvfMwYMHY20rrtxm2ZbcJ8cv5rE8dOgQZs6cCXd3d3XuvvvuuwSPx7p161R75NjLa01ec4GBgUnOW966dSsqVqyonle+fPki9+3n54eBAweqFBS5T57vrVu39L6vf/rpJ1StWjXy/Srvv+3bt8d5bBLzN0d6+KdOnYqSJUuqbcoxl9e0/G2QHvKEcpT/+ecf9RqULz5yjIoXL662J3/H9L1v5blNnDhRvQ7kHJQoUQK//vprrO2eOnUKbdq0Qa5cudR6bm5uaNCggd7nS5Qc7FEmMiKXLl1CixYt0Lt3b3Tr1g3nzp3Dzz//DF9fX+zbty9aENayZUv89ddfKlgZNGiQ+lBeu3at+sCTDwn5UIqPBFXjx49X2+nfv78Kxh49eqT24+npqT5wxLZt23DlyhV07txZfWjJB/bGjRvVB+SLFy8watSoWNvu06eP+jCU+6Q3Tj7smzRpolJS5INZ9icfxhLIzZs3TwXMY8eOjXz848eP1Ye7BHMff/yxClg8PDywePFiFaCdPXtWBRGJIcdSggcJXOTDXoIhOWaybWlHVLLfevXqoUOHDipQevr0qVp+8eJFFQTKcf/0009VMHrs2DF8//33KkCV4F++EEQ1ZswYdaw++eQT9QEugdTQoUNVACwBdHyS8/zl+MnzGzx4MCwsLDB//ny0a9cOmzdvVtvo2rWrCihOnjyJ1atXqzYtXboUySXHUZ6LBO958uRRrwXZbtu2bdUXEXn9CskvluBIXkdyrrNly6aWyxe8uMhjZBDfl19+qc5Fx44d1XIJloS8huS1VKtWLfU6luMk75NmzZrhl19+ee9fbUaOHKneT/I6ltdm3rx5411/yZIl6rgXLVpUBXfyXpKgLrFfWnV2796NhQsXqm3Ja1OOo7RF3kvyxVQC8AkTJqgvsvLak2Mk701z8//6vD766CN1DOTc9+zZUy2T4FuOo7x+5G9Fcv7mSAqMLJdtyutYN9hy165d6j0uwXtcZDvyupDgWt4/Euzv2bNHHasTJ06o5x31OQg59hIwy77kvkWLFqnzKl/MqlevrtaRYLpRo0bInj272q4Ey97e3uo5yOtcjg/Re9MSUao7cuSIJO1p+/TpE+c6cr+ZmZn2+PHj0ZYPHDhQ3Xfz5s3IZT/88INatnXr1mjrhoSEaCtUqKAtWLBggm2S9UqUKJHgem/evIm1LDw8XFunTh2tk5OT2qfOpEmTVLtatGih1tHZtm2bWm5hYaE9depUtG2VL19e6+bmFm1Z+/bttVmyZNHevXs32vL79+9rM2XKpO3bt2+C7da1pVKlStqgoKDI5b6+vtp8+fJpM2fOrPXz84tcnj9/frX+4sWLY21Lnqucm2PHjkVbPmXKFPWYqVOnRi5buXKlWpYnTx7tq1evIpdLG6pWrao1NzfX3rlzJ3K5vCZi/ilOyvPX7a9cuXLRnueFCxciX1MbNmyItp127dppraystK9fv9Yml77XRUBAgLZo0aLakiVL6j0X0v7EknXlMfLYqP7444/I11hYWFjk8ufPn2uzZ8+udXZ2jva84nrf6d6TcvxiHsvChQsn+tjI60nOibym5N86gYGB6rUd8znoe166ZXZ2dtHOuZzPHDlyqHM4ePDgaPudN2+eesz+/fsjl23fvl0tmzt3bqx2tmnTRuvo6Kj19/dP1t8ceT02b948weNRr1499V7SkXNUoEAB9dxu374dbd2PPvpI7WfNmjUJ/g159OiRes127949ctn8+fPVujH/phClJKZeEBmRGjVqxBrcJz2xIurPrNKbJj9vyuBA6UHRXaQHU3pupKdH38+yUclPrNJLKb3S8ZGfWXXkJ9aXL1/Cx8cHzZs3V/u7efNmrMdIT2DUHiLppRXVqlVTl6ikp1Z6yHSpALLNHTt2qJ5u6YGK+vzkp2HpTdq/fz8S66uvvlK9pzqSfvDZZ5/h9evXsX6ql55P6QGOSnpKZVCZnAfpwYxKUi/k+GzZsiXWfqWHK+rANWmDtEXSBuL7WTi5z1+eU9TnWb58efV4+WVAepOjkvMRGhqa6DSWhF4X0qMorwvphZVfNCTVQ45vatAda+lZlZ5zHen5lWMgPaHSy/8+pPc0sTnJ0sMvr115TNRUHelhTeogROn1lV8rdOR8yvtFYlp5T0Wle0/F/Lsg+5We4aivG7lI76qkCUlPa3L+5shr+erVq6oHOinOnz+vXme9evVCkSJFot2nSz/R9/6J+TdEevUl1SNmm4S8n6KmfxClJKZeEBmRqB+SOi4uLupaAhEdyQGWoESCg7jIz+Lyk31cJLVAPpglp1DyXyXolp8xJS0h6ge+fMjKT6TyYRQ1d1lHguaEnofk+8b1/HT3yfOT4EQ+CCWYlJ+u9eUkipg/08ZHcirjWnbnzp1oy+Vn3ajBl7h37566LlOmTKztSLqFPObu3bvvtd+okvv84zq2+tIGoh7z5JLgR4JV+Qld32vg1atXyJw5M1JafOdDt0zf+UiK+N43Men2pe98lypVKkn7je/9Edd7KubfBQkYJUUjvr8LyfmbI6k8EuzKFzBJ+5G/F5Lq0qVLl3gHJ8Z3vmQ78mVO3/mKq10PHz6MvC3pW5LSNGvWLJXWI3nZ8sVblpcuXTrONhElBQNlIiMSM0iLKmrJJQmkpHdlwYIFca6f0AeF9FRJwCYDl44cOaJ6liWfVYJiya2UwTayT/kwvHz5shpYJoP45ANa2ikBknw4SVsS+zwS8/x025Ne0Ji9u6ktZp6xIST3+b/PMU8q6UGVgER6v7/44guVbywBjwTwK1asUMGLvteFMdE3gNTQr4P4zlVc98X8uyBfcuV9HJeYwXtiXx+S3y5fjuTXDF1dbPkiJ4MtpZc6vi/tyak5n5jnK7ngMs5Beq2lXTJuQP4mSd76nDlz1C84RO+LgTKRCZIeLxnwJb3B71OPVQICSdWQi27QjQzskR4aGawlAbJ8CEnP4TfffBPtsfoqDKQE+XlWAi7pGZMqHu9L0gCkGkHMZbp9JUTXsyU/O8ckbZQeM33bkX3IgKqk7jeln39qOHz4sHr9LV++XA3qjEoqLsSUkjMP6iYdkfMRM41HBrZFXUeXTqOvx1vX05lS7ZFzK9VSotL3mkntvwtSnUUq2eh6hVOSpDpIWoduoKZuEKMMQIyriknU8xWTvIbky9b7TiQjVULkovslQ1JJxo0bp77cs1wdvS/mKBOZIBmhLh8I06dPT9TPq/pI7m1MlSpVivaTq65XJ2bPo1TFkBHwqUE+4CU/V0bCS093cp+fjlQHkGoQOvLBLB/skuahy8WMj/SUyc/M0mOlK3EXddvSu9qpU6dYj5NR+pIvqyNtkPUlCI4ZQKfm808Ncb0upLSevvxrXb6vvoA1qXQVMKTXMGqvtaQIyXmVYE5SiHTklxfp8Yxaqi0oKChJpfri07RpU5WvLb/uyGsr6j4SU1Yupf8uCKk2o+/XguS+bsLDw9Xfm4T+XugjQbuMp5D86ahpE0L35Vvf+ycx5JzHJL94yZdbKTuXWnnylLGwR5nIBMnP3TJgSXpxJE1CPqyl50x6aKTckvSWJdRjJqW2pEdO8vqkvJcEMVLeS1eaSUj6haRwSL1mCQjlZ1sZKChlxaQXKCUCH32kp6p27doqkJW6zpLyIQGmfNBKykflypWj1b9NiPQwyXbkw1PKbEkZPNlHYicTkZq9kmogA9WkB01XHu63335TvdVSei4myfuWdkuPq/RqSTqClK2SsnEJ9WSn9PNPLOn5lRKACQ3yk0GNMkhQftqW15kEQpIfK73JkosqzzMqXTmv0aNHq/JiktMqr6vk5JHKOZBcWQm8pF6u5NnrysNJ7V8pjRZ1IJ6UF5O8e/n1RQJJWVfWiZqH/z5kO99++60azCfnScqzyfmWUo3xpTWkBgk4JV1HzoMMupMBfFKKTb7YyjmR144M4kwqCTjlfEv6heQoy79lm7If+UVLV4ZOHzkGUpZOfrWS4yPl6aScm6RMSHsktUte48khZRblVzAphSk1uqUtkkIm25VlqdGrThkPA2UiEyQfCDKxw7Jly1RwKx8YknMpH4ryE6SkTiRERuTLh4z0fEpvkXyoyIeg5PjpelrlQ056NiXAkaBQRs1LD50EzhK4SVCQGmQwkqR8yH6kh1LqNkvwIculd1fqAieWBEUSRElvrvR8SfsltzIpH85yXGTCBPliIgGq9BxKzVYJkCWnW19Oq5wD6cmUcyTVRSSY/OGHH9SXnLR8/oml632LbyCYjvTaSrUHeV1IECS95ZKnLMdV2h0zUJbAWoJJ+QIggZy8VidNmpTsAVdyDqQ3U1I/5IuHlZWVCsLkWMuXxqhkYJfUw5YvO3K+ZACZBGvyPona8/w+pNqGHBN5jvIakfeS7FdqISd1QN/7kmMgXyDkWnq0JYVHvrTJsU5uL7q8vuXYScqN5CbL3wEJduULkNR5li/b8ZEKOfKFXiYYkTZI7768H6RHWV5DSRmcG5V8EZBzK1UzpLdcXgeyXTkPknZBlBLMpEZcimyJiMiISMAiA42kB1zfTGEUnQTk0jsrwZAEWkRExBxlIiJ6N5BTfq5mkExE9B+mXhARkUqLICKi6Fj1goiIiIhID+YoExERERHpwR5lIiIiIiI9GCgTEREREenBQJmIiIiISA9WvXgPMkXp5cuX1RS3MgEEERERERk3mfToxYsXaiZRmSk0Pozu3oMEyQnNSERERERExuf06dNqVs/4MFB+D9KTrDvQbm5u77MpIiIiIkoDXl5eqqNTF8fFh4FyMsyZM0ddwsPD1W0JkvPkyZOcTRERERGRASQmbZaD+ZJh5MiReP78OS5dupSchxMRERGRCWCgTERERESkBwNlIiIiIiI9GCgTEREREenBQJmIiIiISA8GyskgFS+yZ8+OcuXKJefhRERERGQCGCgnA6teEBEREaV/DJSJiIiIiPRgoExEREREpAcDZSIiIiIiPRgoExERERHpkfAk15Qgr5evARt/HikiIiIiU4jbEomBcjLLw8klPDxc3Q4KCVcXIiIiIjJuSYnZmHqRDCwPR0RERJT+MVAmIiIiItKDgTIRERERkR4MlImIiIiI9GCgTERERESkR4YNlG/cuIGqVavC3d0d9evXh6enp6GbRERERERGJMMGygMHDsTo0aNx69YtdOjQQVWyMFZBYaHY//gWxv6zF58e26au5bYsJyIiIqLUYabVarUwEXfu3MF3332HU6dO4cqVKyhevLi61tdbPGTIEJw4cQKZM2dG7969MW3aNFhbW6v7nz17hjJlyqhrMzMzvHnzBjlz5sTr16/V7cR68uQJ8ubNi6OnL8MtV+4Ufa6R+wjww8Qz+/Ey+C0gp0ra9+7axcYO31RphjwOTjBGmsC3eLtnD97u2g2NzyuYZ80Cu9atYNeyJczt7QzdPKIMLTg0DGduP8bpW4/x+m0wMtvZoKp7XlQpmhc2ViyxT0SpTzr8/vK6jz8978IvNAhOVraon6sw6rkVhK2lVart18vTA3WrlsHjx4+RJ0+eeNc1qb+GV69exe7du1GtWjVoNBp1ienVq1do2LAhihYtiq1bt8LDwwPDhw9HYGAgFixYEC3A1QXFmTJlgr29PZ4/f44cOXLAmF5AX5/aC9/QoIgAWRfEv7t+GRSo7l9ar1OqvqCSI+z+A7z4ZCC0z59D8+6nC82DBwg5fwH+S5bB9aelsCxYwNDNJMqQnr16jR92HINfYFDkF29ZdsfrJXafuYFhbWsjR5bMhm4mEaVjT/R0BHpo/XDN9zk23L1oNB2BJhUot2nTBu3atVP/7tu3L86ePRtrnSVLlsDf3x/btm1D1qxZ1bKwsDB8+umnGDduHHLlygVTcfDRLfiGBf8XIMdkZqbuX3PzHBrndUcmK2s4WFnDzsIqST3jqdGT/OzjTxDk54uz1UrjdMXieJ3JHpnfBKLq+RuofP6Gut9t1w72LBMZoCd57vaj8A0KQlDmMARmCoXGQgvzcDPYv7FC+GuNuv+bD5uxZ5mIkNE7Ak0qUDY3Tzileu/evWjcuHFkkCy6du2KQYMG4cCBAyrAlm526W6XrBNd6oX0OLu6usKY7Lx1GcC7dIt47HpyU110zGGmAmYHy4jAWQLoTLp/W9pE3Pfu/kyxrm1gmYjjHB//33fgmVk4fhzVB6+cM8NMo4HW3BzPsznjTqE82Nu4GoYu2wqHHTvg/EG399oXkTGRvymadxfpIFHXGi3kP41Gz32625roy6PeF3m/bD9yvajbir2/2Nv4r223njyHT/hbeOcLhMZS7pAPp4g/NSF24TDPYgaNlxar/zgL99yuMDczU38nI64R47YZzM3N1MPNzM3U355o66j7zN7dF2UduVafjfFvO/YyPfuPsZyI9P9t0ka9lv/U2//d34mItaIse3eN/x4jfz8ilurZnm4d+b/8LdLtRc/2ZDt/e9xLVEfgoce30bpgSYOeUpMKlBND8pP79esXbZmzszPc3NzUfULSKyS/WVIzOnXqhOXLl6Nt27YJBuLSUy0XHS8vL3X92Se9YG1tk+LP5frLZ9DKp0kaUx96WsBcvki8u1YXTcS1hVxrNLAI10ReW4SHwzw8XF1rNRo8zp0d4YtXQKu2Ft0DaNE/TAO3iaMR/tOCZLcx5ZgluPFU3d9/X6JTXLQBCO/+UOldJ0qwFOtx75ZELnsXW8W5vyjDHmKtF+Ox0daMY99R96v/GUTbZfQ19LQ1+jGJuBWrTVF2Gu2+GBtT95rMKI8I0txQm3Bo43nN3dMCF4ItUvh1n7b0Bc3/LYoI7nVP8L81I4LuaI+J8Y+IKzM9j9Wzjt7lMZfpu1P/vqPfE/GmNYurMyX27hOz4Ti3k6jXQpSVtDEW6X3fxlyq9+0Ux3tez0bj/PsW1xrR9hf7b0Hc+4u9p//uins7Me+J/rctEe2PbG/cf2P1/U0ysT9R0UyGOdZmyYaUFhISnHEDZclRlsA4pixZssDHxydaikafPn0wZswYlY7x66+/JrjtuXPnYsqUKUgrEoCGm5vrDTZ15I+kRZj8bGopIzNhFtHv9O7eiG906l8yBlBFwGbQqH+bQWNupq5jUo8yAzSR9yX+4zKiDVEfG5usEWZpgecumRH0xi/qk4n9AZP4Pev9ZzxrJelxCW0lCZ83URYkNwzR/0luykFNqknooKSng6b3i4aej0jzd38L4tuUGRBqHQ6zqMNA9EV5KXg8owUAaXVezAwYUMT7DY6IRKgmHIaW7gLlxCpZsiTOnDmTpMfIoMD+/ftH61GWWswLf1qTKlUvFn81FPuaVkpwvR6bDqHO6Stx9Q3H80gtwizMEGhrg7d2Ngi0s1XXAXbRbwfa2eCNvS0CHOzUMrkdZGuNIBsrlVJBREQmJo5A3SzO9SL7vmM91kxvoC89MnF8AsVcHmUf0dqQ0vtRy6L+fpDY/UR5TKKPW8L7ib696N3xcT2f6NuLvtb77kcVQYvIo4h22+xd2pfqr1bXEduL/AXxXZqXWqbbRszt6daTOzRaBBa3RphtXE/0v/ZZBQDrO/VBalW9yJCBsvQc+/lF6aWM0tMcNW85ORwdHdVlzpw56hIenrrfdKpfuoV/qrrD19FBb0Aqub/O/gGoeiEipUQvOzvAwQFae3t10djZQWNrj3B7e4Tb2iLM1hahNnYIt7GFuY0NLK1tYGdtAzMrG1hYWcNKcpYtrCDF3JzCwhEWrkFIWDhCA8MR4h+OYE2Y+sYXhDBozLTQmGsR4PwawbYJv7RsgkJQ/M4jaMzM4ZfZCa8csyLUKvlJ+7o/sTHGBEQui+wff3dHxE+v//3xj1hsFu3fukX/XUe9/93tKD3h/y2Pf9ux14+6nSiPjbrPqG2J8hh9+9O3nm6d/1oS/efpqNuP+XNwXM8nMR1/+jvK4u4+S3rBSj0/V6Zg75y+n4cT2YrErJScVRL9QH0/5V559Qxai4TPnFm4FhWyukXkGEd5nepeQeYxlqmcYsReJidDd5+ZvveA7rHvMgh060guc2Rb3i2P+rqN9jqNnBTg3Xs9yraivsJ1+436noq8rR733/qS86xbJ/o+3wUoUbYV87e3iGMmv51FPybRjo3uialf4XTH4d1W3sUPumMfdfuR7/uoj3vXPlU4INpxVitGO9YqYV39FqnLG4WqIBWZZ/ouRUvluMdcpomSb6oumshtRM1j1b3/InJao27/v8frcuhjLo+2TP07+vKIeC36OrL1qO2Iuu+YzyFmG9Q60e6LI/821n0RzzH2unE8l3cpEbHX/a/NJvGjglmM62QyfxMCX7ugBPfl8MbwYarhW5DCJPdYl4usI4Gz9P7KfSlBJieRi67MXGrJnCULhizbiv8N6BhtUJzuWoJkGRQH1xzIOmEczDM5wMwh07trB5jZ28PMwgJpQd7o4RotQsPD8fHe9QjRhMXb2yzPIatvIAauPwiz4He5QvLc6teHRY8esChRItogHfOYA4Ni3MdBPESJM2DfejzTyiCa+N7QQHZzO0yq3oyHlSiNRAbQavBu9EG8ugHBsQYC675AqPviGCwc53I920rEOpoog4O1epdFvz/m4+Ty97W78A8LVhV39P4tkvFR4WbIrTV8mcp0Fyi3aNECM2bMgK+vb2Su8qZNm9RAvaZNm8KUuHbuAPvpMzFp9mqcqVBclVnzz2wPx9cRZdaqXLgBm9AwOHw9GLa1ahq0rRKoWlrIxRzVshfAYf978a4vQXRJ90rIeaA3AtdvRMD69dC88oX28GGEHT4M8yqVYde3N2xq12YQTJSC2riXwc+3Y5fWjMYMaOueuJ8liShlRP4qY2EG1cWVNv1cBpE1kx3WnbkEb7fY1XfkWoLkbF72aFKlhKGbaloz80kJtz179qh/L1y4EHfv3lUD7ES9evVUeTdJsShVqhTc3d1V3WTdhCM9e/aMnHDkfUVNvZABgqk1M5/UI37apj003i9UtYlY90tvajZX5Ny53ajqEfsFBaHf4U0IM9fE+U3RUmOOFQ27wMnWVi3SvH2Ltzt24s0vaxH++HHkqpaFCyNT396wa9kCZu+RlkFE/9UvHfjXlv/ql8Z6f2rhbGVrFPVLiSj91nOfuHZ/nPXcbV9bwtnWNtXquSdlZj6TCpQfPHiAggUL6r3vyJEjqF+/vvr39evXY01hPX369MgprFNKWkxhLTPceQ8YBM2zZ6pChVSV0F2b58iBbMuWGOUMd5c8PfHNxT8QZqGJ9U3RMtwcE8s3Qjk9k79ow8MRdPgI3qz6BaGXpY50BPPsrnDo0QMOXTrBPLPhf4ohSm8zYumuXWzsjGZGLCLKWDOE4t21k71tqs4Qmm4DZWORVj3KUXuW3+7Zi7e7d0Pz0gfmLllh16qV6mU1pp5kfT3La/89j3+8HyEI4bCFBaply4cPy1aM7EmOi7wsQy5cRMCq1Qj686/I5ZJ7bd+pIzJ92AMWOXOmwbMgSr89y0e97uNPr3vwDXkLZ2s71HcrhLpuBdmTTERp1rN85vZjnL71GK/fBiOznQ2quudFlaJ5U3VmUAbKaSQtepQJCL1/HwGr1yBw5y4gNDTikFhawq55M5WWYeXuzsNEREREKR4oswguGT2rggXhPHkicuzfg0z9P4aZpF6EheHtrt140bkbXg76DMGnTkWW2CEiIiJKCQyUk0HSLrJnz45y5cqlyEmgxLHIlg2OQz9HjoP74DhqJCxyuanlwSdO4OWAwfDu1gOBu/dCGxbGQ0pERETvjTnK74GpF4YlAfHbAwcRIAP/otTOtnDLCYcPP4R9pw4wt7c3aBuJiIjIuDD1gjIEM0tL2LdsgWwbfoPLsiWwqRlRSzrc6yn853yHZ02aw3/+/xDu7W3ophIREZEJYuoFpYsi7TbVq8FlyUK4bt4Auzat1WA/7evXeLN8BZ41awnfSVPUoEAiIiKixGLqRQqUhzt98RqrXhiZsKdP4ffLr/DfsBnagIDI5fYN6sHp476wrVSRM/4RERFl0NSLquVLso5yWuUoJ6a8CBlGmL8/vFavg8eSFQh5+ixyeeZK5ZHn84HI1qopzCzS8TyhRERElOz4jakXlK5ZOjoi75CBqHrhb7gv+A72JYqp5a/PXcT1jwbjTPVG8FyxBuGBbw3dVCIiIjIyDJQpQzC3tkbO7p1R6e99KL1hJZxq11DLg+49wJ2RE3C6fC08+HYeQrxfGrqpREREZCQYKCcD6yib9sC/rI0boNzv61Dh0A64dmgNmJsj9KUPHs2erwLm2yPG4+29B4ZuKhERERkYB/O9B+Yopw9vHz6Gx+LlePrrBmh0KRhmZsjWujnyfD4AjpUrGLqJRERElEKYo0yUBHb586LIrMmodukE8o/9Clau2QCtFt479+Jisw642LorXu47BK1Gw+NKRESUgTD1gugdq6xZkH/EEFS7eAxF582EXeFCarn/ydO42rM/ztVqCq+1G6AJDuYxIyIiygAYKBPFfFPY2sKtd3dUPnUIJdcsg2O1ymp54K07uP3FaJyuUBuP5i1EqK8fjx0REVE6xkA5GTiYL2MwMzdHtpZNUX7PZpTftwUurZqp3OWQZy/wYNoc/FO2Bu5+/Q2CHj8xdFOJiIgoFXAw33vgYL6MJ/DOPXgs/hlP122GNjgkYqGFBVzbt0LezwcgU9nShm4iERERxYOD+YhSiX2RQij6/Qw18C/fiKGwzOIMhIfjxZYdON+gNf7t+CF8jhyFVqvlOSAiIjJxTL0gSgZr12woMHa4CpgLz5oC2/x51XLfv47hSufeOF+vBZ5t2ApNaCiPLxERkYlioEz0Hiwc7JH7kz6ocvoISixfgEzly6rlAVdv4Oanw3G6Yl08WfgTwvxf8zgTERGZGAbKRCnAzNISru1bo8Kh31H293XI2qSBWh7i6YV7E6fjn3I1cW/yTAR7PePxJiIiMhEMlIlSeIps59o1UHr9SlQ6fgA5uneGmZUVwv1f48n/lqrScjc/H4GAG7d43ImIiIwcA2WiVOJQ3B3FFnyHquf/Rt6hg2DhmBna0FA8W7dZTV5y5YOP4HvsJAf+ERERGSkGysnAOsqUFDa5cqLgpDFq4F+hqeNhnctNLfc5eAT/tuuOC43b4cX2XdCGhfHAEhERGRHWUX4PrKNMySGVMF5s24UnC5aqQX86Ujkj9+D+yNmjixokSERERCmPdZSJjJi5lRVydO2Ain/tRenNv8C5Xm21POjhY9wdM0kN/Hsw43uEvPA2dFOJiIgyNKZeEBlw4F/WBnVRdutaVDyyC66d26lZ/sJe+eLR9/9TAfOt4WPVbIBERESU9hgoExkBmfq6xNL5qHruL+Qe1A/mDvZqiuynq9fhbPVGuNprAPxOnzN0M4mIiDIUBspERsQ2bx4Unj4R1f49iQLjR8I6hyug1eLlngO41KITLrboBO/d+6HVaAzdVCIionQvQwfK48aNQ8GCBdVP4Hfu3DF0c4giWTk7Id+Xn6HqhWNw/3E27N2LqOX+p8/hWu+BOFu9MbxW/wZNUBCPGhERUSrJ0IFy69atcfToUeTPn9/QTSHSy9zGBjl7dlWTl5T6bTmcalZVy9/evYfbw8fhn/K18fC7/yHU5xWPIBERUXoOlKVXd9CgQShfvjwsLS1RunRpvevduHEDTZo0gYODA3LmzIlRo0YhJCQkyfurWbMm8ubNmwItJ0pdZubmcGnWCOV2bkT5/duQrW1LwNwcoS+88XDm92rg350xk/H24WOeCiIiovQYKF+9ehW7d+9GkSJFULJkSb3rvHr1Cg0bNlSB8datWzFjxgwsW7YMw4cPT/P2EhmCY+UKKLlyEaqcPgK3fr1gbmcLTeBbeP60Cmcq18P1/p/j9YV/eXKIiIjSU6Dcpk0bPH78GJs3b0bFihX1rrNkyRL4+/tj27ZtaNasGfr164fZs2er5Z6enpHrVa1aFdmyZYt1iWu7RKbGrmB+FJ0zVc34l3/0MFi5ZAU0GjWZyYXGbXGp3Qdq9j+tVmvophIREZkkowqUzc0Tbs7evXvRuHFjZM2aNXJZ165dodFocODAgchlp0+fhre3d6zL+fPnU639RIYgAXL+UcNQ9eJxFJkzFbYFI3Lu/Y6dwpUPPsK52s3w9LdN0CQjPYmIiCgjM6pAOTEkP7l48eLRljk7O8PNzU3dl5qkJ1umPdRdvLy8UnV/RElhYW+HXP16oco/h1Fi5WJkrlReLQ+8cQu3hozE6Qp18PjHJQjz9+eBJSIiSo+BsuQoS2AcU5YsWeDj45OkbckgwDx58qigt06dOqhRo0a868+dO1cN/tNdJL2DyNiYWVjAtW0LNeiv3K6NcGneWC0PefoM96fMwj9lauLexOkI9uAXPSIionQVKKckyW2WIDksLEz1Dp88eTLe9WXAoORQ6y6S3kFkrKQ+uFONqij168+ofPIQcvb6AGbW1gh/8wZPFv6E0xXr4Mbg4Xhz9bqhm0pERGSUTC5Qlp5jPz8/vT3NUfOWU4Ojo6PqgV63bp0aFNi8efNU3R9RSpEJS9x/mIVqF48h75efwdLJEdqwMDzfuBXn67bA5S698eqv4xz4R0REZMqBsuQnx8xFlsBZeoRj5i6nlpEjR+L58+e4dOlSmuyPKKVY58iOguNHqimyC8+YCJu8udXyV4eP4nLHnrjQsDWeb/ldBdFEREQZnckFyi1atMChQ4fg6+sbuWzTpk2qYkbTpk3TpA1z5sxB9uzZUa5cuTTZH1FKs8jkgNwD+6Hq2b9QfNl8ZCpbSi1/8+9V3BjwBU5XrgePpSsQ/iaAB5+IiDIsM60RFVkNDAzEnj171L8XLlyIu3fvqgF0ol69enB1dVUpFqVKlYK7uzvGjRsHDw8PlTvcs2dPLFiwIE3bK/nNMqhP8pUlJYPIVMmfAd+jJ/BkwVLVu6wjKRpuH32I3AP6qt5oIiIiU5eU+M2oAuUHDx6gYMGCeu87cuQI6tevr/59/fp1DBkyBCdOnEDmzJnRu3dvTJ8+HdbW1mnaXgbKlB7J4L4nC37Ci607IlMwZBBgjq4dkOezT1S+MxERkaky2UDZVEjqhVzCw8NVSTr2KFN6FOThCc+lK+G1ep2qlKGTtXlj5P18AByrV1GVNYiIiEwJA2UjPNBEpkomKJFg2WPJClWLWUcmNMnz+UBka9VU1W4mIiJKb/GbyQ3mMwYczEcZiaWjI/IOGYiqF/6G+//mwL64u1r++txFXP9oMM5UbwTPFWsQ/jbI0E0lIiJKUUy9eA/sUaaMSLK1Xv3xJx7/bxn8jv03SY+VS1bk6t8buT7urf5NRERkjNijTESpRvKSszZugHK/r0OFQzvg2qE1YG6O0Jc+ePjtD/inXE3cHjkBb+8/5FkgIiKTxtQLIkq2zBXKosTPC1Dl7F/I9UlfmNvbQfM2CF4r1uBMlfq49tGn8D93kUeYiIhMEgPlZGCOMlF0dvnzosisyah26QTyj/0KVq7ZJEcD3jv24GLT9rjUpite7jsErUbDQ0dERCaDOcrvgTnKRPppgoLwbMNWPFn4M97evRe5XGow5/7sE+To0h7mNjY8fERElOaYo0xEBmVuawu3Pj1Q+dQhlPxlKRyrVlLLA2/dwe0vRuN0hdp4NG8hQn39eKaIiMhoMfWCiFKNmbk5srVqhvJ7t6Dc3i1wadlURgMi5NkLPJg2B6fL1sTdr79B0OMnPAtERGR0GCgnA3OUiZLOqWollFqzDJVP/QG3vj1gZmON8IAANZHJ6Ur1cH3gF3hz+SoPLRERGQ3mKL8H5igTJV/IC294/vwLPJf/grBXvpHLnevVRp4hA5Clfh1OkU1ERCmOOcpEZPSsXbOhwNjhqlJG4VlTYJs/r1ru+9cxXOncG+frt8SzjdugCQ01dFOJiCiDYuoFERmUhYM9cn/SB1VOH0GJ5QuQqXxZtTzgynXcHPwlzlSqhyeLfkbY6zc8U0RElKYYKBORUTCztIRr+9aocOh3lP19HbI2aaCWB3t44t6EafinbA3cnzILwV7PDN1UIiLKIBgoJwMH8xGl7hTZzrVroPT6lah0/ABydO8MMysrhPu/xuMfl6jScjc/H4GAG7d4GoiIKFVxMN974GA+orQR7PkUHstWwmvVbwh//TpyufQ65/l8AJxqVefAPyIiShQO5iOidMUmV04UmjwW1f49gUJTx8M6l5ta7nPwCP5t1x0XGrfDi+27oA0LM3RTiYgoHWHqBRGZDEvHzMjzaX9UPX8UxRbPg0Op4mr5m4v/4vrHn+NM1Qbw+Gk1wgMCDd1UIiJKBxgoE5HJMbeyQo6uHVDxr70ovfkXVXtZBD18jLtjJuGfcjXxYOZcVauZiIgouRgoE5FJD/zL2qAuym5di4pHdsG1czvAwkJNYPLoux9xunwt3P5qHN7evW/ophIRkQlioExE6UKmsqVRYul8VD33F3IP6gdzB3togoLVAMAz1Rriau+B8D9zztDNJCIiE8JAmYjSFdu8eVB4+kRU+/ckCowfCescroBWi5e79+Ni80642KITvHfvh1ajMXRTiYjIyDFQTgbWUSYyflbOTsj35WeoeuEYis7/FnZFC6vl/qfP4VrvgThbvTG8Vv8GTVCQoZtKRERGinWU3wPrKBOZDulB9jlwGE8WLoPfidORy61csyFX/z7I9XEvWGVxNmgbiYgo9bGOMhFRDGbm5nBp3hjldm5E+f3bkK1tS8DcHKEvvPFw5vdqiuw7Yybj7cPHPHZERKQw9YKIMhzHyhVQcuUiVDl9BG79esHc1gaawLfw/GkVzlSuh+v9P8fri5cN3UwiIjLFQPnRo0cIDQ3Ve19YWJi6n4jI2NkVzI+ic6ai6qUTyD96GKxcsgIaDV5s24ULjdrgUrvu8Dl0BFqt1tBNJSIiUwmUCxYsiAsXLui979KlS+p+IiJTYZ3NBflHDUPVi8dRZM5U2BbMr5b7HTuJK90+wrk6zfF03WZoQkIM3VQiIjL2QDm+3pXg4GDY2NjA2D1+/BiNGzdGsWLFUKZMGXz88ceq7USUcVnY2yFXv16o8s9hlFi5GJkrlVfLA6/fxK3PR+B0hTp4/OMShPn7G7qpRERkTFUvbty4gWvXrql/d+7cGbNmzUKRIkWirRMUFIR169bh/v37uHLlCoyZl5eXShGpVq0aNBoNevbsiQoVKmDUqFGJ3garXhClb/Ln0f/UGTxesAw++w5FLrfIlAlufXsg94CPYJPbzaBtJCKipElK/GaZ2I1u2LABU6ZMiZw2dsyYMXrXc3Z2xqpVq5Acd+7cwXfffYdTp06pQLt48eJ6A24J2ocMGYITJ04gc+bM6N27N6ZNmwZra+tE78vNzU1dhLm5OSpXrqwCfCIiHflb51SjqroE3ryDJ4t+wrON2xD+5g2eLFgGjyUr4NqxLfJ8/gkylSrBA0dElFFTL4YNG6YCyXv37qlelq1bt6rbUS8eHh54+fIl2rZtm6zGXL16Fbt371Y91SVLltS7zqtXr9CwYUOEhISoNsyYMQPLli3D8OHDkVxv377FihUr0Lp162Rvg4jSN/tiReA+/1tUu3gMeb/8DJZOjtCGheH5xq04X7cFLnfpjVd/HefAPyKijD7hyMOHD5ErVy5YWVmlaGMkBUJ6d0Xfvn1x9uzZWD3KM2fOxPTp01XaRNasWdUyCZQ//fRTtUzaJapWraqC+pjy5cuH8+fPR94ODw9XqSSyfP78+UlqL1MviDKusNdv8PTXDfBYvALBTzwil2cqVxp5PvsEru1awcwy0T/aERFReplwRFIk1q5dq/c+Sbs4cuRIcjYbGSTHZ+/evWoQni5IFl27dlVB9oEDByKXnT59Gt7e3rEuUYNk+Y7w0UcfqfSNH374IVltJqKMyTJzJuQZ9DGqnP0TxZfNR6aypdTyN5eu4MaAL3C6cj14LF2B8DcBhm4qERElU7IC5fHjx+PZs2d673vx4oW6P7VIfrLkLsfMi5Z8Y7kvKaQXOiAgACtXrlS5iAnx9/dX30J0FxkQSEQZm7mVFbJ3aocKh3ehzNZfkaVhXbU8+LEH7o77Bv+Uq4n70+Yg5NlzQzeViIjSIlCWXGIZ/KZPxYoV1f2pRXKUJTCOKUuWLPDx8Un0do4fP44lS5ao4LpSpUooX748vvzyy3gfM3fuXNVVr7tIegcRkZAv21nq1UKZTb+g4tG9yN61o0q9CPP1w+N5C/FP+dq4NWwMAm/d4QEjIjIRlsn9QPDz84szkJW8X2NXq1atJA+6kQGD/fv3j7wtPcoMlokoJqmAUXzxXBQYPwKeS1fCa/U6VSnj6Zr16uLSvDHyDBkIx2qVE/VrFhERmVCPstQeXrhwYaxAU24vWrRI3Z9apOdYX5AuAXrUvOXU4OjoqJK+pVa09Jw3b948VfdHRKbNNncuFPrma1S7fAIFJ42Bdc4cavnLfYdwqVUXXGzeES927IXWBDoXiIgyomQFylJPWWoYly1bFt9//z1+++03Vf+4XLlyarnUNE4tkp8cMxdZAmfp3Y2Zu5xaRo4ciefPn6vpuomIEmLp6Ii8Qweh6oW/4f6/ObAv7q6Wvz57Adc/Gowz1RvBc8UahL8N4sEkIjL1QLlGjRr4448/VA/r6NGj8eGHH6oJSJycnNTy6tWrI7W0aNEChw4dgq+vb+SyTZs2qYoZTZs2RVqYM2cOsmfPrr4YEBEllrm1NXL26IJKx/aj9PqVcKod8bcy6N4D3Bk5AafL1cTD2T8g9GXix1sQEZGR1VGOOVmHboCdvb39ezUmMDAQe/bsUf+W1I67d++qAXSiXr16cHV1VfsqVaoU3N3dMW7cODXJieQOyxTUCxYsQFpiHWUiel+vL/yLJwuX4cXve6SYvFpmbmeLHN27IM+n/WFXMD8PMhGRgeK39w6UU9KDBw9QsGBBvfdJbeb69eurf1+/fj3WFNYyCUlSprBOCQyUiSilvH34GB6Ll6tJTDSBbyMWmpsjW+vmyPP5ADhWKs+DTURkKoGypD5s3rwZt27dQlBQ9Lw6GcWd1FnuTImkXshFqntISbrEHGgiosQI9XkFzxVr4fnzaoS+8I5c7lSzKvJ8PhBZmzSAWSImZyIiIgMFyrdv30bNmjURHBysJuyQlAgJGMPCwlRVCslV1jd9dHrDHmUiSi2aoCA827AVTxb+jLd3//t7au9eRPUwZ+/cDuY2NjwBRETGNoW15ARLCTiZnU/ibMkrllxlmdZaUiFkcB0RESWfua0t3Pr0QOVTh1Dyl6VwrFpJLZcJS24NHYXTFerg0Q+LEOqrv6Y9ERG9v2QFyqdPn8agQYNg8643IyQkBBYWFujRo4cKoocOHYr0jFUviCitSJpFtlbNUH7vFpTbuwUuLZtKfpuaEvvB1Nk4XbYm7n79DYKeePCkEBEZQ6AsKRdSGk5KsskkH56enpH3lS5dGhcvXkR6xjrKRGQITlUrodSaZah86g/k7NMdZjbWCA8IgMeSFThdsS6uD/wCby5f5ckhIjJkoCyl2R4+fKj+XaFCBTUb3+vXr1X6xdKlS5ErV66Uah8REcVgX6QQ3OfORLWLx5FvxFBYZnEGwsPxYvPvOF+/Ff7t+CF8jhyNNXsqERGlQaD8wQcfRPYaT506FWfOnFGD+KSXecuWLZg8eTLSM6ZeEJExsM7uigJjh6PapRMoPGsKbPPnVct9/zqGK51743z9lni2cRs0oaGGbioRkUlKkTrKMmpw3759qke5YcOGKv0iI2DVCyIyJtqwMHjv2ofH/1uGNxf/jVxukzsXcg/qh5y9PoBl5kxqWXhAIJ5v3o5nm7Yh1PslrLK5IEeXDsjeuT0sHN5v8igiImNm8AlHNBqNyl9O7xgoE5Exkj/rfsdP4cmCZfA5eCRyuYVjZuTq2xNZmjTEjYFfIMTTSw0MhHwMmJsBGi2sc7mh7Na1sC9a2KDPgYjIZMvDyXTR/v7+eu+TCUhq1KiRnM0SEVEKkEmfnGvXQOn1K1Hp+AHk6N4ZZlZWCPd/jcc/LsG/bbpGBMlC11eiibgOefpM5ThLjzMRUUaXrED5zz//RKlSpXDo0KFoy3/88UeUL5/+p1lljjIRmQqH4u4otuA7VD3/N/IMGQizhCYp0WhUEP18y+9p1UQiovQVKF+5cgW1atVCs2bNMGTIENy4cUPlJo8YMQKjR4/GiRMnkJ6xPBwRmRqbXDlRaPJYZCpbKiLdIj7mZni+aXtaNY2IyGhZJudBUuFi/fr1aN++PT766CNVHq5o0aI4efIkKlWKmD2KiIiMT5iv73/pFnHRaBHy4kVaNYmIyGgle8Sdj4+PmqpaZuXLly8fvLy80v1EI0REpk6qW6iBewmwdHJKk/YQEaW7QHnPnj0qR/ns2bMqT1kG8A0ePBgDBw5EmzZt8Pz585RvKRERvTcpAacbuBefgKvX8fTXjZy0hIgytGQFyq1bt0bz5s1x+fJlNGjQAFZWVpg1axaOHj2K69evZ5g6ykREpkbqJEsJOMRVwlPyl83MoHkbhFtDR+Fyp154++BRWjeTiMh0A+Vt27Zh5cqVaia+qGrWrIlLly6hU6dOSM9Y9YKITJVMJiJ1kq1z5ohYoEvDeHdt7ZYTZbb/iqxNGkTO8neuTjM8WfwztOHhBms3EZEhpMqEIxkFJxwhIlOlZubb8ruqbiED96xdXZG9S3tk79ROBdPy0fBiyw7cHTcFoS991GMyVywH9x9nw6FEMUM3n4jIeCccEVevXsUHH3yAwoULw8bGBufPn1fLv/76a+zduze5myUiojQgwbBb7+4ot3MDqpw6rK7ltm76apm0JHvndqh04iBcO7dTy16fv4TzDVrjway50AQH8zwRUbqXrED54MGDqFChAh4+fKhm6QsNDY28T/KVpVwcERGZPutsLiixdD5KrVuhcpu1oaF4NOdHFTD7nzln6OYRERlfoDx27FjVmyx1kydOnBjtPgmgL1y4kFLtIyIiI+DStCEqHz8At3691O3Am7dxsUVn3Bk7GeFvAgzdPCIi45qZr1evXpE/z0Xl7OwMb2/vlGkdEREZDUvHzCg6ZyrK7doIu8KF1MQlnstW4WztpvA5ctTQzSMiMo5AOWvWrPD09NR7n9RUdnNze992ERGRkXKqURWVju5B3i8/AywsEPzYA1c698bNz75C6CtfQzePiMiwgbJMXT1p0iTcvHkzcpn0LD99+hTfffcdy8MREaVz5ra2KDh+JCr+sQOZykXUzn+2fgvO1miMF7/v5kQlRJRxy8P5+fmhcePG+Pfff1GmTBlV8aJcuXK4d+8eihUrhsOHDyNTpkxI71gejogI0IaF4cni5Xgo1TCCIqphuLRogiKzp8ImV04eIiLKWOXhnJyccOLECSxZsgTu7u4qaJYA+fvvv8exY8cyRJBMREQRzCwtkXfIQFQ6ug9OtaqpZS/3HsTZmk3gtfo3aDUaHioiMkmccOQ9sEeZiCg6CYqfrlmPe5NmIvz1a7XMqXZ1uM+bBbtCBXi4iChjTDhCREQUk5m5Odz69EDlEwfh0ryxWuZ37JSaBvvx/5aqNA0iIlPBQJmIiFKc5CaXXPsTSixfACvXbCp3+f7kmbjQtAPeXLnGI05EJiHDBspNmzZVAxDl0qxZM9X9TkREKUeqIbm2b616l7N366iWvbl0GRcatcX9aXOgCQri4SYio5ZhA+VNmzbh0qVL6tKyZUuMHj3a0E0iIkqXrLJmQfFFc1F602rY5Mmt0i8ez1uIc/Vawu/UGUM3j4jo/QPlX3/9Fa9evUJquXPnDgYNGoTy5cvD0tISpUtH1OWM6caNG2jSpAkcHByQM2dOjBo1CiEhIcmq3KHj7+//Xm0nIqKEZW1YT02DnWtAX+luxts793CpVRfcHjkBYf4RA/+IiEwyUJYe1+zZs6NOnTqYPXs2rl1L2Ryzq1evYvfu3ShSpAhKliypdx0J1Bs2bKgC461bt2LGjBlYtmwZhg8fnqx9duvWTc0iuHHjRlXajoiIUpdFJgcUmTkZ5fduhr17EbXMa8UanKvdDD4Hj/DwE5Hploc7d+6cCmZ37dql/l2gQAG0bt0abdq0Qb169WBlZZXshmg0GpibR8Ttffv2xdmzZ3HlypVo68ycORPTp0/Ho0eP1DTaQgLlTz/9VC3LlSuXWla1alU1+UlM+fLlU5OjRCVPX4JkWX/RokVJajPLwxERJZ8mOBiP5i3E43mLIqthZO/cHoVnTISVS8TfeCKilJaU+C3ZdZRlumoJmCVwPnTokApyJSVCAudWrVrB1dU1ue2PM1CuW7euCpC3b98euczX11ctW7FihXpccsg25EC9efMmSY9joExE9P4Crt3AraGj8frCJXVbguTCMybBtVNbNSCQiMjk6ihLfnD//v2xbds2vHz5EuvXr1fLJk+erNIZatSogZQm+cnFixePtszZ2VntT+5LLMlJ9vDwiDawL66caCIiSl0OJYuj/P6tKDR1PMztbBH60gc3Bn6Bqz0+RpCHJw8/EZl21Qtra2u0aNECCxYswIMHD1R6Q9u2bZHSJEdZAuOYsmTJAh8fn0Rvx8/PDx06dECZMmVQtmxZ/P7771i7dm2iAmz5FqK7eHl5Jfk5EBFRbGYWFsjzaX9UOnYAznVqqmU+Bw7jXM2m8FyxhtNgE5FBWKbGRiX4lIuxku7206dPJ/lxc+fOxZQpU1KlTUREBNgVyIcy237Fs9824d6EaQjz88edkRPwfOtOuM+bCfuihXmYiCjNmFQdZek5lt5gfT3NusF9qUmqa0g+y9dffw0XFxe9vdtERPR+JC85Z8+uqHTiELK1aaGW+Z88jXP1WqjBf5rQUB5iIkoTJhUoS35yzFxkCZwlBSJm7nJqcHR0VEnf06ZNg7e3Ny5fvpzq+yQiyqhscmZHyVWLUXLVEljncIU2OAQPps3BhSbt8Poi//4SUeozqUBZ8qClwoZUqYg6EE8qbsiU1ERElP5ka9Nc9S7n6NlV3Q64fA0XmrbHvckzEf6W02ATUQYIlAMDA7F582Z1efjwoRo4p7v94sULtY7M3Jc5c2a0b98eBw4cwMqVKzFy5Ei1XFdDOS3MmTNHTb5Srly5NNsnEVFGZuXshGI/zkaZLWthmz8vEB6OJ/9binN1m8P32ElDN4+I0qlk11EW+/btw5kzZ1Te7vjx49WEHkePHlWz6yU1cJVqGQULFtR735EjR1C/fn317+vXr2PIkCE4ceKECpp79+6tJiGRyhtpjXWUiYjSXnhAIB7MmguPJStktiq1LGef7ig0eSwsHR15SojIsBOOSA+v9OqeOnUqckcSMFesWFFN+uHg4ICFCxcivZIeZbmEh4ersnSJOdBERJSy/M9dxK0vRiPw+k112zpnDhT9bhpcWjThoSYiw004MmzYMBUsy8x5d+7cUdNA6zRu3Bh//PEH0jNJ93j+/DkuXYqYRYqIiNKeY6XyqHh4J/KPHQ4zKyuEPH2Gqx9+gusff4aQ5xEpe0RE7yNZgbJMWy3pDiVKlIg1vahE6BKpExERpTZza2vkHzEUFf/cA8cqFdWyF9t342zNJni2fku0jhwiojQJlMPCwlR6hT5S09gQ+cJpiYP5iIiMi0Pxoii3exMKz5gEcwd7hL3yxc3PvsKVrn0Q9JidN0SUhoFytWrVsGLFCr33rV+/HrVq1UJ6xtQLIiLjnAY798CPUPnYfmRpWFcte3X4KM7WagqPZaugDQ83dBOJKCMEyjLhxq5du1C3bl01aE/SL7Zv344uXbpgx44dnOaZiIgMxjZfXpTeuBrFFs2FZRZnaAICcXfsZFxq1QUBN27zzBBR6gbKNWrUUCXbJED+6quvVA6Y5CzLDHkykE+qXxARERmKfD7l6NYRlU8chGuH1mqZ/5nzON+gFR5+9yM0ISE8OUSUunWUxdu3b1VesrOzM+zt7ZERsDwcEZFpebn3IG6PGK8qYwj7EsXgPv9bVTmDiDKWJ6ldHq5fv364f/+++rednZ2aXEQXJMusenJ/esYcZSIi0yK1lSufPKgmJhFSe/li8464O2GamsCEiCjFAuVVq1ZFTisdk7e3N1avXp2czRIREaUambXPfe5MlP19HWwLFVCz+nks+hnn6jTDq7+O88gTUcoEyiJm/WSd27dvw8XFJbmbJSIiSlXOtWug0tF9yDNkIGBhgaCHj3G5Y0/cHDoKob5+PPpEFMkSibR48WJ10QXJPXr0UGkXUQUFBeHBgweq+kVGyVEmIiLTY2Fni0KTx8K1fWvc+mIUAq5cx7NfN+LVoSMo8u1UZGvT3NBNJCJTGsz3+++/qxJwQlIrWrZsCVdX12jryEQjMlvfxx9/jMyZMyO9S0oyOBERGSdNaCieLFiGh3PmQxscUQ0jW+vmKPztN7DJmd3QzSMiA8Zvyap68dFHH2HixIkoWLAgMjIGykRE6Ufg7bu4NWwM/E+dUbctnRxRaOp45OjRJc50QyIyPale9WLlypUZPkgmIqL0xb5oYZTbuQFFZk+FhYMDwvz8cWvoKFzu1AtvHzwydPOIyJhzlGPy9fXF5s2bcevWLZWbHJV8854/f35KtI+IiCjNmJmbI9fHvZC1eSPcGTEePgcOw/evY6oyRoFxXyH3gI/UVNlElDEkK/VCKlvUrFkTwcHBCAgIULnKPj4+CAsLQ5YsWeDk5IR79+4hveKEI0RE6Z98PL7YsgN3x01B6EsftSxzxXJqohKHksUN3TwiMtbUi+HDh6NatWp49uyZ+kOyZ88eNUPf2rVr1SC+TZs2IT3jhCNEROmf/DqavXM7VJJpsDu3U8ten7+E8w1a48GsudAEBxu6iUSUypIVKJ8+fRqDBg2CjY2Nuh0SEgILCwtVMk6C6KFDh6Z0O4mIiAzCOpsLSiydj1LrVsA6lxu0YWF4NOdHnK/fCv5nzvGsEKVjyQqUJeXC0dER5ubmyJo1Kzw9PSPvK126NC5evJiSbSQiIjI4l6YNUfn4Abj166VuB966g4stOuPO2MkIfxNg6OYRkbEEyu7u7nj48KH6d4UKFbBo0SK8fv1apV8sXboUuXLlSul2EhERGZylY2YUnTMV5XZvgl2RQpLIDM9lq3C2dlP4HDlq6OYRkTEEyh988EFkr/HUqVNx5swZNYhPepm3bNmCyZMnp3Q7iYiIjIZT9Sqo9Nce5P3yMzUNdvBjD1zp3Bs3Ph2OUJ9Xhm4eERmy6kVMMmpw7969qkxcw4YNVfpFRsAJR4iI6M3lq7j1xWi8uXRFHQwr12woMmsysrVrxYlKiDLizHyU9ANNRETplwzwe7J4OR5KNYygiGoYLs0bo8icabDJldPQzSMiQwTKly9fVjuJOeGI6NixI9Ir1lEmIiJ93t69j1vDx8Lv2Cl12yJzZhSaMhY5e32gJjMhogwQKF+5cgVdu3bFzZs3VR3lWBs1M0N4eDjSO/YoExFRTFqNBk/XbsC9iTMQ/vq1WuZUuzrc582CXaECPGBE6X3CkY8//hiWlpbYsWOHCpbv378f7ZKeZ+UjIiKKj/Qcu/XujsonDqr0CyE9zDIN9uMfl6g0DSIyDcnqUc6UKRM2b96M5s2bIyNjjzIREcVHPmK9f9+NO2MmI/SFt1qWqVxpNQ12pjKlePCI0mOPcvny5fH8+fPkto+IiChDkFRE1/atVe9y9m4RY3ekOsb5Rm1xf9ocaPSM8SEi45GsQHnBggX4/vvvcfDgQYTxJyQiIqJ4WWXNguKL5qL0ptWwyZsbCA/H43kLca5eS/idOsOjR5SeAuWSJUuievXqKvXCzs5OTTQS9eLk5ARTIROmyDf+O3fuGLopRESUzmVtWA+Vjx1ArgF9pbsZb+/cw6VWXXB75ASE+UcM/CMi42GZnAcNHDgQ69atUyXgZDpra2trmKJ///0Xx48fR758+QzdFCIiyiAsMjmgyMzJyN6xDW4NHY3AW3fgtWINXu47hKLfT4dL04aGbiIRvU+gLNNUz507F59++ilSivTofvfddzh16pQqP1e8eHF1HdONGzcwZMgQnDhxApkzZ0bv3r0xbdq0JAfrkjIi7V+9ejUaNWqUYs+DiIgoMRyrVELFP3fj0byFeDxvEUI8vXC1ez+4dm6HwtMnwjqbCw8kkSmmXjg7O6NQoUIp2pCrV69i9+7dKFKkiErt0OfVq1dqiuyQkBBs3boVM2bMwLJlyzB8+PAk72/mzJno0KEDChcunAKtJyIiSjpzGxsUGDMcFY/sQuYK5dSyF5t/x7maTfB88+965yogIiMPlL/66iv873//S9GBfG3atFFlOqTsXMWKFfWus2TJEvj7+2Pbtm1o1qwZ+vXrh9mzZ6vlnp6eketVrVoV2bJli3XRbVdmFNy/fz+GDRuWYu0nIiJKLoeSxVF+/1YUmjYe5na2CH3pgxsDv8DVHh8jyOO/zzciMoHUC0mTkGBTemPr1aunepijksFx8+fPT9I2zRMxtefevXvRuHFjZM2aNXKZzBA4aNAgHDhwAH379lXLTp8+He92jh07hrt370b2Jks9vfr162PDhg2oVatWktpNRESUEswsLJBncH+4tGiK21+Ohe/R4/A5cBjnajZFwUmj4da3J6fBJjKFQHnXrl2wsLBQ//77779j3Z+cQDkxJD9ZepGjkiDdzc1N3ZdYgwcPVhedAgUK4NChQyrtIz7Smy0XHS8vryS1n4iIKCF2BfKhzNa1ePbbJtybMA1hfv64M3ICnm/dCfd5M2FflCmDREYdKMs01YYgOcoxe69FlixZ4OPjk+r7lwGMU6ZMSfX9EBFRxiYdTjl7dkWWRvVxd8wkeO/cC/+Tp3GuXgvkH/EF8gwZAHMrK0M3kyjdS1aOcnrz4MGDBHuThQwalDxq3SWhFA8iIqL3YZMzO0quWoySq5bAOocrtMEheDB9Di40bovXFy/z4BIZS4+yVJmQihPSoyv/TojUWE5p0nPs5+ent6c5at5yatFNqDJnzhx1CQ8PT/V9EhERZWvTHE51auDexOl49utGBFy5jgtN2yPPp/2Rf/SXsLCz5UEiSgVm2kTWnpHBdlLjWCpKJDTwTn4yep8gUgblnT17NlYd5bp168LFxUVVvdCRwFkC6BUrVkQO5ksrMggwb968qnc5T548abpvIiLKmF79dRy3h49F0INH6rZtoQIqd9m5dg1DN43IJCQlfrNMSl6yDJrT/dsQWrRooWon+/r6RuYqb9q0SQXuTZs2TbN2sEeZiIgMJUu9Wqh0dB8ezJoLjyUrEHTvAf5t1x05+3RHocljYenoyJNDlNY9ylE9evRIBc1WegYSSG1lqWmc1GmhAwMDsWfPHvXvhQsXqvJtMnhOSAk6V1dXlWJRqlQpNW32uHHj4OHhofKGe/bsiQULFiCtsUeZiIgMyf/cRdz6YjQCr99Ut61z5kDR76bBpUUTnhiiFIjfkhUoS2m4kydPqjSMmM6dO6eWJzX1QgbUFSxYUO99R44cUXWOxfXr12NNYT19+vQkT2GdEhgoExGRoWlCQvD4xyV49N3/oA0NVctc27dC4ZmTYZ3d1dDNI8oYqRdRxRdbBwcHw8bGJsnblFrGiYnZS5QooWoeGxJTL4iIyFiYW1sj/4ihyNa6BW4PGw3/M+fxYvtulctceNoEZO/WUY0dIqKkS3SPskzoce3aNfXvzp07Y9asWbFKqgUFBWHdunUqhznmQLz0iD3KRERkTLTh4fD8+Rfcnz4HmoBAtSxLw7ooOncGbPNy0DlRqqVeyEQbusk25JtpXA+TQXarVq1C27ZtkV5F7VGWiU5Y9YKIiIxJ0OMnuD18HF4dPqpumzvYo+DXI5Grf281VTZRRvYkNQJlKcMm1SZk9UKFCqlayhUqVIi2juQJ58yZM8P8xMMeZSIiMlbyef184zbc/fobhL3yVcsyV64A9/mz4VC8qKGbR5S+cpSdnJzURUhqRa5cufRWvSAiIiLDk06rHN06IkuDOrg7bgpebNuF12cv4HyDVsg3/DPk/WKwym8molSYwlpylqMO4JPKEx9++KFKuyAiIiLjIJUvSvy8AKXW/qTKx2lDQvBw1jycb9hGlZcjohQOlD/55BOsWbMm8vbo0aNV/rIEzwMGDMCiRYuQnkl+cvbs2VGuXDlDN4WIiChRpLZy5ZMH1cQkQmovX2zeEXcnTEP4u4F/RJQCgfLFixdRp06dyAlGVq9ejW+//VZNOz158mQsXrwY6dnIkSPx/PlzXLp0ydBNISIiSjSZtc997kyU3bFeTX0NjQYei37GuTrNVDk5IkqBQPn169eR+cr//PMP/P398cEHH6jbtWvXxr1795KzWSIiIkoDzrWqq2mw8wwZKLOIIejhY1zu2BM3h45CqK8fzwHR+wTKMkLw1KlT6t9S/aJkyZJqSmsh00zb29snZ7NERESURizsbFFo8lhUOLAdDqVLqGXPft2IczUbw3vnPp4HouQGyh9//DHGjx+PKlWqYP78+SovWUcCaJk9Lz1jjjIREaUXmcuXQYVDO1Bg/EiY2Vgj5NkLXOs7CNf6DELw0+eGbh6RQSW6jnJMv/zyC86cOYOKFSuib9++kbWTBw0ahJo1a6J3795I71hHmYiI0pPA23dxa9gY+J86o25bOjmi0NTxyNGjS4aZI4HSvyepMeEIvd+BJiIiMgVajQZeq37F/cmzEB4QoJY5162FovNmwq5APkM3jyhN47dk11EW+/btw9SpU1XqxaNHj9Syo0ePwtPT8302S0RERAZiZm6OXP16odLJg8jatKFa5nv0OM7Vbooni36GNjyc54YyjGQFyi9evECtWrXQqlUrLF++XF28vb3VfStWrFCTjxAREZHpss2dC6V+W47iS+fDyiUrNG+DcG/CNFV7OeDaf5OOEaVnyQqUhw0bpoLlK1eu4M6dO2o+eZ3GjRvjjz/+SMk2EhERkQFIXnL2zu1Q6cRBuHZup5a9Pn8J5xu0xoNZc6EJDuZ5oXQtWYHy7t27Va+xVLeImdwvOR+S+5GeseoFERFlJNbZXFBi6XyUWrcCNrlzQRsWhkdzfsT5+q3gf+acoZtHZFyBsszG5+DgoPc+qaNsbW2N9Iwz8xERUUbk0rQhKh0/gFwfR1S2Crx1BxdbdMadsZMR/iZi4B8RMnqgXK1aNZWLrM/69etV/jIRERGlP5aZM6HI7G9Qbvcm2BUpBGi18Fy2CmdrN4XP4b8M3TwiwwfK06ZNw65du1C3bl0sXLhQpV9s374dXbp0wY4dOzBlypSUbSUREREZFafqVVDprz3I++Vnahrs4MceuNKlD258OhyhPq8M3TwiwwXKNWrUwJEjR1SA/NVXX6nBfJKz7OXlpQbyySQkRERElL6Z29qi4PiRqPjHDmQqV1ote75hK87WbIIX23dFG+xPZIree8KRt2/fqrxkZ2dn2NvbIyOJr2C1v78//Pz8EM56k2QCLCws4OTkBEdHR0M3hYhMlAzwe7J4OR5KNYygiGoYLs0bo8icabDJldPQzSNK+wlHhJ2dHXLlypXhguT4SJDs4eGBoKAgQzeFKFHktSqvWXntEhElh5mlJfIOGYhKf++HU+3qatnLfYdU77LX6t/UjH9EpsbS0A0w1fJwcomrt1h6ki0tLVGoUCHVU0dk7OS1fO/ePfXaZa8yEb0Pu0IFUHbbb3i6dgPuTZyB8NevcXv4ODzf8jvc582CXeGCPMBkMt67RzkjSqg8nAQdVlZWDJLJZMgXOnnNMlWIiFJqGmy33t1R+cRBlX4h/I7/g3N1m+Pxj0tUmgaRKWCgTERERKlCcpNLrv0JJZYvgJVrNpW7fH/KLFxo2h5vLl/lUSejx0CZiIiIUo1UyHJt31r1Lmfv1lEte3PpCs43aov70+ZAw/E8ZMQYKBuZwLdB+HXbIXQeMBkNugxX13JblhvTwK/27durSidNmzY1dHOIiMgEWGXNguKL5qL0ptWwyZtb8hTxeN5CnKvXEn4nTxu6eUR6MVA2IncfeqJBl68wdubPOHPpprp99tJNdVuWy+2UdOLECdSpU0cFvHKpXLky9uzZk+DjtmzZgocPH6o87QMHDiR5v3/++Sdy5oxeKujw4cNo2LChGkjm4uKiZn9ctWqVuu/BgweqRyJTpkzRLnPnzk3yvomIyLCyNqyHyscOINeAvtLdjLd37uFS6664PXICwvxf8/SQUcnQgXKBAgVQsmRJlC9fXl0OHTpksLZIj3GPz6bjmbePuq0rb615dy3L5f6U6lmWMmCtWrVC//794e3tjWfPnmHevHmJqnhw//59FCtWDNbW1inSlm3btqFdu3bo2rWrCsClPf/73//U7I9RyfI3b95EXoYPH54i+yciorRlkckBRWZORvm9m2HvXkQt81qxBmdrNcXLA4d5OshoZPjycDLldpEiEW/S1BISGgYPrxfxrrPj4Al4PX8Z5/0ajVbd//Nve9CmSY0418vt5gprq4RP661btxAaGoo+ffqo21LOTnqXdUF0z5498c8//6h1ZCbGJUuWIF++fPj6669VaTwJ5KVX95tvvlEB69q1azFr1ixVxLtMmTJq/VKlSiXYDtnOsGHDMH78eAwaNChyedWqVbF58+YEH09ERKbLsUolVPxzNx7NW4jH8xYhxNMLV7v3g2vndig8fSKss7kYuomUwRlVoHznzh189913OHXqFK5cuYLixYur65hu3LiBIUOGqNSBzJkzo3fv3pg2bVqK9XCmNAmS63X+MkW29d3SjeoSl782z0PBfG4Jbsfd3R22trbo0aOHukiqg6urq7pPo9GoAHrDhg3q39Lr/Omnn6oeXpmqXMqIyTlYv369Wn/nzp0q0JVr6aH/+eef0aZNG7VOQufk5s2bePToEbp06ZLkY0FERKbP3MYGBcYMh2vblrj1xWi8Pn8JLzb/Dt8jf6PwjElw7dRWpd8RIaOnXly9ehW7d+9WPbwScOkj02VLLmtISAi2bt2KGTNmYNmyZcn+Gb5z584oW7YsvvjiC/VzfkYhKRbyRUNmVPzss89UznCDBg3UlxXJV5bjIvdJr/HYsWPx119/xbmtxYsXY/To0aonWerxDhw4UP1Rky88CXn5MqIXXWZ3TIi0UZdPLZf9+/cn8VkTEZGxcihZHOX3bUWhaeNhbm+H0Jc+uDHwC9XDHOSRsmN0iEyyR1l6ISVXVfTt2xdnz56NtY78pC+pAZLXmjVrVrUsLCxM9XiOGzcuMuCSn+5lprGYJH3g/Pnz6t9///23mutbqjgMHToUI0aMUNtPaZIOIT298Rky4X+4fON+ZG6yPhJ8li1RCD9+83m8+0os6VWW3l8hucEDBgxAr1698Mcff+DLL7/Evn371BcTIV8igoODYWNjE2s7MthOJmGRgFpHvsjIlMi//vqrCpxF/vz51ZehqGTgnvD09FQzGcbn6dOnqheciIjSJzMLC+QZ3B8uLZri9pdj4Xv0OHwOHsG5Gk1QcNIYuH3UU01mQpRWjOrVZp6IF//evXvRuHHjyCBZyCAwSRGIWoHh9OnTavBXzIsuSBYSJAsJvgYPHozjx48jNUjOsKRDxHfp3r5hvEGykPtlvfi2k5j8ZH0kiJV0Fkl1+f7773Ht2jXVIyxfSuQLhW7/+siXjwULFsDX1zfyEhgYiO7du6tcZ93gu5hBspBBgfJ45iMTEZGOXYF8KLN1Ldx/nA1LJ0eEBwTgzqgJuNSmGwJv3+WBoowZKCeG5L1K7nJU8jO8m5ubui+xAgIC4OfnFxkASj6uVL6IjwSNMlhNd/Hy8kJK6dC8Ntyyu8DcXH8eliyX+9s3q5Ui+5NjJYPyJD9Ynr+UepPeZRm49/r1a9jZ2anjKj3KU6dOjXdb8iVDBvLJlN6yLQmKJV9ZtpMQ6SWXahuSYy4pNBJkyzbkC023bt1S5LkSEZHpkc+HnD27otKJQ8jWpoVa5n/qDM7Va4FHcxdCExpq6CZSBmBygbIEbhLAxZQlSxb4+ESUVksMKYdWr149lZ8subUSMErAFh+p2yu90LqLpHekFHs7W/y28GvkyBbRU27+buCC7lqWy/2yXkqQQZCS2lKzZk2VhyxfEuR69erVqgqFpE7I4D4Z5NekSZN4tyXpMpMmTVIDAOXcFC1aFGvWrEl0Wzp27KhSaWRwoBzXbNmyqVSa1q1bR1tPlketo/zVV18l+/kTEZFpsMmZHSVXLUbJVUtgncMV2uAQPJg+Bxcat8Xri5cN3TxK58y0Cf3ebyC6HOWYVS+k4oL0cI4ZMyba8tKlS6ugT3olU4v0KMtFR3qUJVh+/Pgx8uTJEy1nV1enOamkTvL2/cexbe8xePv4IVtWJ3RoUVv1JKdUkEykz/u8bomI0kKorx/uT5qBp2s3RCwwN0eezz5B/lHDYGFvx5NAiSJZAdIxFzN+M/rBfIkhPce6lImYPc1R85ZTq1KEXCRlQS7h4eEpvg8Jhnu0b6QuRERE9B8rZye4z/8Wrh3b4vbwsQh68AhP/rcU3rv3w33eTDjXjnueAaIMkXoh+ckxc5ElcJbe3Zi5y6lFKjxITq/k5BIREVHaylKvFiod3Yfcn/ZXvcpB9x7g33bdcWv4WIRF+eWXKMMFyi1atFBTTcugL51NmzapihlNmzZNkzZIb3L27NlRrly5NNkfERERRWfhYI/CU8er2sv2JYqpZU9Xr8PZGk3wcu9BHi5Kf4GylBSTMmFykbq+kg+su/3iRcQU0DLNsQxEa9++vSoHt3LlStXDK8sTM2lFSmCPMhERkXFwrFQeFQ/vRP6xw2FmbY2Qp89w9cNPcP3jzxDyPCJ2IEoXg/lkMFHBggX13nfkyBHUr19f/fv69euxprCWqZXTegrruJLBOSiKTBFft0Rk6gJu3MbtYaPhfyZizgRLZycUnj4R2bt15DTYlKzBfEYVKJuKqIP5pCQdA2VKDxgoE1F6oA0Ph+fyNbg/bTY0AYFqWZYGdVB07gzY5ouYaIwytidJCJSNKvXCVDD1goiIyHinwc49oC8qHz+ALA3rqmWvjvyNs7WbwWPpShVIEyUWA2UiIiJKd2zz5kHpjatRbNFcWGZxVr3Ld8dNwcWWnVWKBlFiMFBOBla9ICIiMo1psHN064jKJw7CtUPEbK+vz17A+Qat8HDOfGhCQgzdRDJyDJSNLPXibUgodp+5geE/7Ua/H7aoa7kty1OSDIxcsmSJ+vebN2/Uc5KBlA4ODmpmto8//jgyZ1VmSZSBklGnj5bppJNj8uTJ6g+XDL6Mavv27Wr5Bx98ELlM2mFnZxdtvxcuXIi8T6bLjjpt+b59+6LNKiftlm3++uuv0fb1ww8/qOUxZ3ckIqL0yTq7K0r8vACl1v4E65w5oA0JwcNZ83C+YRv4n7to6OaREWOgbEQev/BD/x+2Yv7vJ3D10TM88fZT13Jblsv9KS0kJASNGzfGuXPnsGPHDlWST4JRqREt9ap1hg8frgJq3cXb2zvZ+3R3d8cvv/wSbdmqVatQrFhEHcyotm3bFm2/FSpUiLzPwsIC3377bYL7Wr16daL2RURE6ZtLiyaofPIg3Pr2ULcDr9/ExeYdcXf8VIS/G/hHFBUDZSNJvZAe4zEr98H7dcQbVVeLRHcty+X+lO5ZXrt2Le7du4fff/8dZcqUUcGnTBM+dOhQ9O/fP8nbmz17Nlq1ahVrWcuWLSNvS7BrY2OjyvsJqZEt/5ba2EkxatQoLFy4EJ6ennGuI22Rnn8Z4SouXryIoKAgVK9ePYnPjIiI0gNLR0cU/X4Gyu5YD9tCBQCNBh6Ll+NcnWZ49ddxQzePjAwD5TRIvQgNC4eHt1+8l63Hr+CFfwDiqtYny+X+bcevxrsd2VdSyKQtzZs3V/WoU0KPHj1UT7RughghqQ8ffvhhtPUkLULX0yv3d+jQAba2tknal3xRadeuHaZOnRrnOpIy0q1bN6xZsyayN7lPnz5JfFZERJTeONeqrqbBzjNkoPxEiaCHj3G5Y0/cHDoKob4p/wsumSZLQzcgI3ju+wYf/bAlRba16o/z6hKXlcM6IXc2p0Rv7+XLl6hUqVKC60lery6nWdcrLJPAxCT1CGvVqoWNGzfis88+w5UrV1SPdczeYgmcS5Uqhfnz56vgdfHixdi/f3+s7XXu3BmWlhEv05IlS0b2Qut88803KFu2LEaMGBFn2yUolwBe1tmwYQPOnj2Lr7/+OsHnTERE6ZuFnS0KTR4L1w5tcOuLUQi4fA3Pft2IV4eOoPCsb+DatoWhm0gGxh7lDM7FxSXe1AWdYcOGwdfXN/KiC5JnzJgROdCuRYsWkUGwbgCdrrfY3t4+2vYkdaVGjRpqcJ+kQsi/9ZHpy3X7jBkki8KFC6se4okTJ8bZ9ooVK6qe5QkTJqigOnfu3Ak+XyIiyjgylyuNCgd/R4HxI2FmY42QZy9w/aPBuNZnEIKfPjd088iA2KP8njPzJUZ250yqpzc+Mzf+idueLxHfNIlmMjgtdzaM6VIv3n0lRdOmTTF27Fg1UE6C3aQaN26cusTsBf78889x584d/Pbbb/jpp5/i7OmVdWNWwEgqCYBl0F58OeOyL+lRjlkBg4iISJhbWSHfl58hW+vmuDVsDPxPnYH3rn3w/fsECk0djxw9unAa7AyIPcppkKNsZWmh0iHiu7SoUizeIFnI/S0qF4t3O7KvpJDeXympJqkRV69eVcG/n5+fGiS3fPlyJIejoyNat26NTz/9FKGhoWjUqJHe9dq0aaNypAcPHoz34ebmpgJzGTQYFxmYKPvq2LHje+2LiIjSN/uihVFu5wYUmTMVFg4OCPPzx62ho3C544d4++CRoZtHaYyBspFoWK4wXB0d4vy2Kovl/gblCqXofiUlQQbflS9fXlWIkCBX0hOkOkSTJk0i15s7d260esZykfzm+ALwgwcPqrrIUklDHysrK1WaTuohvy+pgBFfD788L9mXVNsgIiKKj5m5OXL164VKJw8ia9OGapnv0eM4V7spniz6mdNgZyBm2rjKLFCCpORY3rx58fjxYzWITUc3UUfUyS8SQ+okSwk4qW4hgbGcGd21BMmzPmqOvK6JH6hHlBTJfd0SEaVnqurUlh1q+uvQlxGTXGWuUA7uP34Lh5LFDd08SsH4TR/2KBsRCYJ/HtYRw9rVQun8OZA3m5O6ltuynEEyERFR2pJferN3bofKJw8he+eICk6vL1zC+Qat8WDmXGiCg3lK0jEO5jMydtZWaFmlmLoQERGRcbByyYriS39QQfPtr75GsIcnHn33I7x37EHR+d/CqWrCpVbJ9LBH2Uhm5iMiIiLjl7VJA1Q6fgC5Pu6tbgfeuoNLLTvjzpjJCH8TYOjmUQpjoJwGVS+IiIgo/bDMnAlFZn+Dcrs3wa5IITWYyPOnVThbuyl8Dv9l6OZRCmKgTERERJQMTtWroNJfe5D3y89gZmmJ4MceuNKlD24MHo5Qn1c8pukAA2UiIiKi5AZStrYoOH4kKvyxA5nKlVHLnm/cirM1GuP5tp2qagaZLgbKRERERO8pU+mSqHBgGwpOHgtzWxuEer/Ejf5DcO3DTxDs+ZTH10QxUCYiIiJKAZJ+kXfIQFT6ez+caldXy17uO4SzNZvAa/Vv0Go0PM4mhoEyERERUQqyK1QAZbf9hqLzZsIic2aEv36N28PH4d/23fH27n0eaxPCQNnIysOFBwSqb50XW3fBmeoN1bXcluUpbdOmTahevbqajlqeT/369bFz5078+eefMDc3jzVl9ZYtW+Ld3oULF9C+fXu4uLioKaPd3d3x+eef4+HDh5Ezv0nhdlkeVWhoqNq/3BcUFJTiz5OIiMgQ02C79e6OyicOwqVFE7XM7/g/OFe3OR7/uATasDCeFBPAQNmIysMF3r6LM9UbqW+d/qfO4u3te/D/56y6Lcvl/pQyf/58DB48GMOHD4eXl5e6TJgwAdu3b1f3S+D65s2baJdOnTrFub1Tp06hTp06KF++PK5cuQJ/f38cPXoURYoUwV9/RS+VIwHxiRMnIm/v3r0bWbNmTbHnRkREZCxscuVEyTXLUGLFQli5ZoMmKBj3p8zChabt8ebyVUM3jxLAQNlISI/xvx0/RMjTZxELdKNkNRHXslzuT4meZQliv/76ayxcuBBdu3ZF5syZYWFhgUaNGmH58uXJ/vLQq1cvTJ48GW5ubmpZzpw5MWzYMPTuHVGUXadPnz5YtWpV5G35tywjIiJKj6SDyLVdK9W7nOODiE6nN5eu4Hyjtrg/dTY0/DXVaDFQTgOakBCVkxTf5cninxHi6QXEleiv0aj7PZYsj3c7sq+ESG+upDh07NgxRZ5fQECA2maXLl0Stf6HH36Ibdu2qTa8ePFCPbZDhw4p0hYiIiJjZZU1C4ot/B6lN62GTd7cQHg4Hv+wCOfqtoTfydOGbh7pYalvIaUsKUB+pmqDFNnWgxnfq0tcqpw+ArvCBePdxsuXL5EtWzZYWVnFuY6kljg7O0dbdvLkSZQoUSLWuq9evYJGo0GuXLkil3333XeYNm0awsLCVED+yy+/RN4naR01atRQaR5Pnz5VQbKtrW28bSYiIkovsjash8rHDuD+9Dnw/Gk13t69h0utu8KtXy8UnDAKlo6ZDd1Eeoc9yhmQDLbz9vZWg+jiIsGsr69vtIsEyY8ePYo2wE9uZ8mSRQ3+8/T0jHz8iBEj1GPkOkRPL3ffvn1VyoVc5N9EREQZiUUmBxSZORnl926GfbGiapnXijU4W6spXh44bOjmUUbvUX779i2GDh2qBppJz6pUa5g+fXqq7Et+XpGe3vhcH/AF3ly6/F9usj5mZshUvgxKLJ0f774SUrNmTdWDK+kPkqOcFPny5VMD+2KS6hlSFaNhw4aJ2k7r1q0xaNAgNYhPepelIgYREVFG41ilEioe2YVHPyzC43mLVJrl1e794NqpLQrPmATrbC6GbmKGlmEDZenplMFmt27dUrefPXs3iC4VmFtbJ5gO4db7A9we/m/8G9JqVamZhLaVECndJl8KpHSb9AQ3b94cdnZ2OHbsGNauXYuePXsmq2RekyZN1DH95JNP1LX0Wl+7dk3tIyZra2scOHAANjY27/VciIiITJ25jQ0KjP4Srm1b4tbQUXh9/hJebNmBV0f+VsFy9s7t1IBAysCpF3fu3FE9jFJezNLSEqVLl9a73o0bN1RA5uDgoIKxUaNG6f1pPz7SI7px40aMHz8+clmOHDlgSNk7t4d1LjdAT1CpmJur+7N3apci+/viiy+wYMEClUssz10qVUjFCulZ1+Uox6yj/OOPP8bbSy3l4M6cOYOSJUuqShq1atWCq6srvv32W72PkXOtL+eZiIgoI3IoUQzl921FoWnjYW5vhzCfV7g5aJjqYQ7y+C+9kTJgj/LVq1dVPd1q1aqpgWFy0TdoTH7aL1q0KLZu3QoPDw9VBzgwMFAFfYl19+5dFcCNHj0af//9t8rZlR7R1JhAJLEsHOxRduvaiBJxUv3C3CyiNNy7a+ucOdT9sl5KkbSLuFIv9B3/hFSqVAk7duyI8/4CBQpAG0dqSXz3ERERZRRmFhbIM7g/XFo0xe0vx8L36HH4HDyCczWaoOCkMXD7qKeazITShtEc6TZt2uDx48fYvHkzKlasqHedJUuWqBrAklvbrFkz9OvXD7Nnz1bLow4kq1q1qqrqEPOi265UYrh+/bqaIOPcuXMqDaNt27YGD9TsixZGlVN/qCkvnapXhV3RQupabstyuZ+IiIjSP7sC+VBm61q4/zgblk6OCA8IwJ1RE3CpTTcE3rpj6OZlGGZaQ0eHekgVhLNnz6oZ3qKqW7euGvylmz1OSGUFWbZixYpEV0+Q2r158+aNNl2yVHn4999/VTpHYj158kRtRwL8PHnyRC7XDUyTXlIiU8HXLRGRcQp59hx3Rk+C98696raZtTXyj/wCeYYMgHk8pV4pafGbUfcoJ4bkJxcvXjzaMqn1K/m1cl9iSdqF5M/qplaWoFzyoiVYJiIiIjIm1jmyo+SqxSi5agmsc7hCGxKCB9Pn4ELjtnh98bKhm5euGU2OcmJIjnLMSTCE1PH18fFJ0rYkXUNSN/z8/FSpNEn50FedISpJ+5CLjpeXV5L2SURERJRc2do0h1OdGrg/aQaert2AgCvXcaFJO+T57BPkHzUMFvZ2PLgZOVBOSTIgUAbyJcXcuXMxZcqUVGsTERERUXysnJ3gPv9buHZsi9vDxyLowSM8+d9SeO/eD/d5M+FcuwYPYAoyqdQL6TmWHmB9Pc2Sp5zapMKG5LPoLqdPc152IiIiSntZ6tVCpaP7kPvT/qqEbNC9B/i3XXfc+nIswvTESpQBAmXJT46ZiyyBs6RAxMxdTg0yUYckfa9bt05V0JCJOoiIiIgMQUrGFp46HhX2b4NDyYg46Okv63C2ZlN47znAk5LRAuUWLVrg0KFDqtKFzqZNm1RucdOmTdOsHSNHjlQTcly6dCnN9klERESkT+aK5VDhjx3IP3a4qogR8vQZrvUagOsff4aQ5y940NJDoCyThsiAOrk8fPhQDZrT3ZZybkJm7pMZ32T2OJn+eOXKlSpoleW5cuVKs7bK5CRSIcOQE5QYipTgGzNmDIyJnP9JkyYZuhlEREQGYy4l40YMRcUju+FYJWLeiBfbd+NsjcZ4tn6LweeKMFVGU0dZargWLFhQ731HjhxB/fr11b9lopAhQ4bgxIkTKmju3bs3pk+fDmtr6zRucerUUQ4MDcWuuzew6+51+AS9RVZbO7QuXAKtCxeHvRHUSpRAWWpNz5o1K0W3K8dKKpEwncVwWEeZiCh90IaHw3P5GtyfNhuagEC1LEuDOig6dwZs8+VFRvckCXWUjabqRWKnMC5RooRKvzAk6VGWS3h4eIpu976fD/rv24qnAW9gJi90CV78XuHcM08svfQPfm7eEQWdUn/QIhEREZn2NNi5B/SFS4vGuD18HF4dPopXR/7G2drNUPDrEcjVv49ah0wo9cKUpEaOsvQkS5D8PDBA3dZ9ZdBdy3K5X9ZLCd999536NiW98oUKFcL69evV8smTJ+ODDz6IXE9mLzQzM4vsbdRVGWnZsqV6rEwXHnUGxbi2K9auXYvSpUurWtgyffjVq1fV8u7du+PRo0fo0KEDMmXKhK+//jpWe6Ud0pvt4uICJycnlfZy7dq1WOkgf/75p+rxnj9/vpqIRtb/+eef1VTl5cuXV4/t1auXmsaciIgoPbPNmwelN65GsUVzYZnFWfUu3x33DS627IyAG7cN3TyTYDQ9yulZSHg4vN78N1GJPnvv3VI9yXHRaLXq/jVXz6N5Qfc413PL5AjrBL4l3rx5ExMnTsSFCxdQrFgxVTVEgt/EWrNmDXbs2IHff/8d3377rcoZl2okd+/ejXO7O3fuxPjx49V1yZIlVfDapk0b9TipInLy5Ml4Uy9Wr16Ny5cvq31IsCuPk3KB+nh7e+PZs2cq133//v3o0qWLGuy5d+9eNQNjlSpVsHHjRvTo0SPRz5mIiMgUSWdXjm4dkaVhXdwdOxkvtu3C67MXcL5+S+T76nPk/WKwym8m/Rgop0HqhQTJLbesRkr48fxJdYnLnk59kN9JfwCpI8GipLlIT3C+fPlUz6tcklJ9pHHjxurfY8eOVb23p06dUtuIa7uLFy/G6NGjUaZMGXV74MCBmD17tnpc3bp1E9yn5KC/fv1aBcjSiy0pOHGRKigyMYyVlZUKxuWxEhTr2iJB8/nz5xkoExFRhmHtmg0lfl6A7J3a4faI8aoyxsNZ8/Di9z1qAhPHSuUN3USjxNSLDFgernDhwqqH9scff0SOHDnQqlWrWPWp4yNBsI6F5EHlzg0PD494tyupG3LcJO1Cd5EeZ3lcYki6RJ8+fTBgwABVcUSuo04nHpVMPiNBso69vb1Kx4h6+82buHvviYiI0iuXFk1Q+eRBuPWN+FU18PpNXGzeEXfHT0X4u4F/9B/2KKcBSYeQnt74jPxzL669fB6Zk6yPDPArlS0HZtdrHu++EqNr167qImX5JL/3k08+UVN6S46wLNN5+vRprMdKPrGO9KpLsCvBcnzbleB61KhRKp9Y73Mzk2cXfy+45C7LRQJsSaeQXv2pU6cm6vkSERHRu89UR0cU/X6Gmgb71rAxalY/j8XL8XLPARSdOxNZ6tfmoXqHPcppQHKGJR0ivkvnYmXiDZKF3N+5WOl4t5NQfrIuR1kqh8gAORsbGxUcS8+wqFChggps7927h4CAAJXCENO+fftw+PBhhIaGqhxlGbhXrVq1eLc7ePBgVVJOeuElPUN6dCVfWdIphPRAS/5xXKREoDxWAnPZrmxft20iIiJKOuda1dU02HmHDpKfiBH08DEud/oQN4eMRKgvp8EWDJSNZMIRqZOc0yETzOPoWTWHmbq/VaH3n6o7ODhY9cy6urqqqhCSJywD6USjRo1UbepKlSqpChW6XOSoPvzwQ1XdQgbTbdu2TV0k1SG+7bZr105NCiLpE5J2UbRoUTUoUEdynSVnWe6bMGFCrH1Kz3a3bt3UQD5J8ZAebEnlICIiouSzsLNFwUljUOHg73AoU1Ite/bbJpyr2RgvduzN8IfWaCYcMUUpPeGIvjrKumsJkllHmVITJxwhIsrYNKGheLJgGR7OmQ9tcIhalq11cxT+9hvY5MyOjDjhCHuUjYhMJrKzYx9MrtUIlXLkRkGnLOpabstyTjZCREREqcXcygr5vvwMlf7aC8fqVdQy7137VO/y0183ZshpsDmYz8jINNVdipVRFyIiIqI0j0WKFka5nRvgtepX3J/yLcL8/HFr6Cg83/w7is6bCbsC/1W/Su/Yo2wkOcpERERExsLM3By5+vVCpRMHkLVpQ7XM9+hxnKvdFE8W/gRtIueSMHUMlDNgHWUiIiKixLDNnQulfluO4svmw8olKzRvg3Bv4nRcbNYRAdcSPweDqWKgTERERERxMjMzUzP6VT55CNk7t1fLXl+4hPMNWuPBzLnQBAen26PHQJmIiIiIEmTlkhXFl/6A0utXwiZ3LmjDwvDoux9xvn4r+J0+ly6PIANlIiIiIkq0rE0aoNLxA8j1cW91O/DWHVxq2Rl3xkxG+JuAdHUkGSgnAwfzERERUUZmmTkTisz+BuV2b4JdkUKAVgvPn1bhbK2m8PnjT6QXDJSTISMN5itVqpSaljouffv2xZgxY5L9+JQ0efJkZMuWTU1xLVNdm5Lbt2+r2RBlOvCpU6caujlERESJ4lS9Cir9tQd5h38OM0tLBD/xwJWufXFj8HCE+ryCqWMd5TTy3DcAIaGpG7xZW1kgu7NDim7z6tWr0QLRGzduYP369cl6fGqS2XVmzpyJ+/fvI1euXO+1LZlRUabebt68OdKKTN9dvXp1nDunP8erfv36+OCDDzBo0KA0axMREVFimNvaouDXI+DariVuDR2NN5cu4/nGrXh1+C8UnjUZru1bqwGBpog9ymlEguSgkNS9pHYgbswePnyILFmyvHeQnBLCwsKS/BgJ8MuU4SQzRERkujKVLokKB7ah4OSxMLe1Qaj3S9zoPwTXPvwEwZ5PYYoYKGdAa9euRePGjSNv165dW/Vm6khP6qpVqyJ7V/ft24ddu3ZhxowZ2LJli0ptkOU6/v7+6Nixo0obKFu2LC5evBh5n+7xuh7pTp064ZNPPoGTkxOKFCkSb1qG5ILLOrLdEiVKqH3rI9tv0qSJSoeRtnXo0EEt7969O9zc3NS+6tSpg8uXL0c+Jjg4GGPHjkXBggXV9itXrqx6peUxjx49UtuQbX399ddq/dOnT6NGjRpqWxLQyvHQkeclz79fv35wdnZW7Y4pJCREpezInPI5cuRQKSt+fn7qvrp16+LIkSMYNmyY2ueZM2eiPXb06NH4+++/I+/v1atXks7hrVu31PGRLxLu7u5Yvnx5nMeciIjofZhZWiLvkIGo9Pd+ONWO+Fx6ue8QztZsAs9Vv0Kr0ZjWAdZSsj1+/FgmPVfXUd2/f19doq373E97+4lPql5kH4ltt729vTY4OFgbEBCgzZYtmzZnzpza169fa0NDQ7UODg6R7c+fP79279696t+TJk3SduvWLdq2+vTpo3VyctL+/fff2rCwMO0XX3yhrVOnTuT9MR9vbW2t3bp1q1p37ty52rx588bZzk2bNmmfPHmiDQ8PV/+2s7OLdax1jhw5os2RI0e0ZStWrND6+flpg4KCtMOHD9eWKlUq8j5pZ82aNbUPHjxQ27948aLW29s7VpuFj4+PNkuWLNply5ap47N//351/K5duxb5vCwtLbXr1q1T2woMDIzVPlmnQoUKWg8PD62vr6+2TZs22h49ekTeX69ePe3ixYvjPBYx70/sOQwJCdEWLVpUO2HCBLXumTNntC4uLtqDBw/G2oe+1y0REVFyaTQarefq37TH8pfW/pU1v7pcbNNVG3jnnro/7E2A1nPVr9oLrTprT1droK7ltiw3RPymD3uUMyDp1ZSeVuklPX78uOqJrFmzJo4dO6Z6M2VAXNQe44S0b99e9WhaWFigd+/eOH/+fJzrSq+s9NbKun369FG9uN7e3nrX7dy5M3Lnzg1zc3P172LFiuGff/5JdLs++ugjODo6wsbGBhMnTlT50i9fvoRGo8GyZcswf/585M+fX21fpiN3cXHRu53du3er9aQn3NLSEk2bNkWbNm3w22+/Ra4jA/Ekh1i2ZWdnF2sb0gM8adIklRoivdKSk7xhwwbV05ya51CO16tXr9S+ra2tVc95//79sXr16mTtl4iIKLEkL9mtd3dUPnEQLi2aqGV+x//BubrNcXfidJyp3gi3h4+D/6mzeHv7Hvz/Oatuy/LA23dhDDiYL4OSwWHyc//bt2/RoEEDWFlZqdsSxMl9SZEzZ87If9vb2yMgICDR64o3b96owC6mX375BXPnzsWDBw8i14srqI5Jql5I2sSmTZvw4sULFcAKebzcJ89b0joSw8PDI9YXB7kty3UkkE7KNuTf0o6nT58iX758SK1zKPuVoFq+mETdtwTYREREacEmV06UXLMM3jv24M7oSQh94Q2PhT/9t4JWOngBaCKuQ54+w78dP0SVU3/AwiEiVjAU9ihn0DrKEkj9+eef6iJBVtTbcQXKaTliVQbnSc/njz/+qHqBfX19VW6wVvdmSoD09m7duhUHDx5UucCyPSGPl6Bcen3v3LmTqOcpvdq6YF1HbsvyuB4TU8xtyL8leI/6xSE++rafmHMo+33y5Em0cnkx205ERJTazMzM4Nqulepdzly5QvwrazQI8fTC8y2/G/zEMFDOoHWUJZA6efIk7t69qwL+0qVLq0Fs8jN+XIGyDEKTIEtSF1Kbrlfa1dU1snf5ypUriX7869evVcqFpFNIj+v48eMj75MAVYLwL7/8Uj1nCZ7lXEpArnueclx0WrZsqZ73ihUrVEULGYC4c+dO9OjRI9Ht6dmzp6qP7OXlpQY/Su3pbt26qXSIxIjZpsSew2rVqqkBhrJvSfOQtBgZzCcDAomIiNKaVdYsMLOylMg5/hXNzfB80/a0albczTB0A8gw5Od4yZeVnGEJHOWbXq1atVRgGld+cpcuXdTP+xJ8Fi5cOFXbV7JkSfWFRNokQaJU0pAc3MSSXOlChQqpnlOpmFGlSpVo90uOsASRklstqQoSOEtALaQahtwvAeaECROQNWtW7NmzB0uXLlXPXapPSI+1bDexxo0bh3r16qkcYUn5kNzpRYsWJfrxX3zxBXbs2KEqV0hud2LPoZwvCeqlaob8CiLB+fTp01WeNRERkSGEer/8L90iLhotQl68gKGZyYg+QzfCVMlP2nnz5lUD0iRo0dH9xB414DTVCUco49D3uiUiIkppF1t3UQP3dDnJepmbwal6VZTbuSHN4jd9OJgvjTCAJSIiIgJydOkA/5PR5wyIRaNF9i7tDX64mHpBRERERGkme+f2sM7lJoOG9K9gbq7uz96pncHPinlG/pm5fPnykRfJZa1QIYFRmERERET0XqTkW9mta2GdM0fEAnOzaNeyXO43dGm4DJ16IXmYUada7tq1q5o0goiIiIhSl33RwqpOspSAk+oWMnDP2tVVpVtIT7IxBMlG16MsdW0HDRqkenhlBjQpd6XPjRs30KRJEzg4OKg6tKNGjUr2DGdCZi6T2ddYMouIiIgobVg42KuZ+2TAXpVTh9W13DaWINnoepRlimEJWKVsl9Tq1VevV4Lahg0bomjRompCCZl5bPjw4QgMDMSCBQuStV+ZSrhu3bqq1FZKkFnQgoKC1CQPUWdEIzJW8loNDQ2Fra2toZtCRERkNIwqUG7Tpg3atYtI3O7bty/Onj0ba50lS5aoCRu2bdum6tsKmQTi008/VbVqdcFu1apVce/evViPl+mCZdKFqFavXq1q46YUqcsr0y3L/qWOLZGxkyBZ3kfy2iUiIiIjTL2QSRMSsnfvXjRu3DgySNblF0vv84EDByKXnT59Gt7e3rEuMYPkW7du4ebNm2jfPuVKkMhkEjI4kL1zZCrktSqvWXntEhERkRH2KCeG5Cf369cv2jKZQc3NzU3dl1TSmyyzlcl0xwmRnmy56Mh0xHGRgINBBxEREZHpMrlAWXKUJTCOSab29fHxSdK2pBd6zZo12LRpU6LWnzt3LqZMmZKkfRARERGRaTK5QDmlUz0ePXqU6PVl0GD//v2j9ShLLjQRERERpT9GlaOcGNJz7Ofnp7enOWrecmqQVAqZE3zdunWoWLEimjdvnqr7IyIiIiLDMbke5eLFi8fKRZbAWXp35b60MHLkSHWR2f0KFiwYb64yERERERkPXdwm1Z7SXaDcokULzJgxA76+vpG5ypJjLGkUTZs2TZM2zJkzR12kpJZg+gURERGRaXnx4oWaqTk+ZlqtVgsjIZOG7NmzR/174cKFuHv3rhpAJ+rVqwdXV1eVYlGqVCm4u7urusm6CUd69uyZ7AlHkksmFbl8+bJql8wkmFS6HGcpZSdVO8i08XymLzyf6QvPZ/rC85m+eKVxPCQ9yRIklylTJsFSvkbVo/z8+XN06dIl2jLd7SNHjqB+/foqR/mPP/7AkCFDVO3jzJkzqwF206dPT/P2ysGtUqXKe29HXhSS+0zpA89n+sLzmb7wfKYvPJ/pi1saxkMJ9SQbZaAsjU5MB3eJEiVw6NChNGkTEREREWVMJlf1goiIiIgoLTBQNiApNzdp0iTO4JdO8HymLzyf6QvPZ/rC85m+OBpxPGRUg/mIiIiIiIwFe5SJiIiIiPRgoExEREREpAcDZSIiIiIiPRgoExERERHpwUDZQG7cuIEmTZrAwcEBOXPmxKhRoxASEmKo5lAiyXTp7dq1UwXR5dyVL18eK1asiFX/e/ny5Wr2SJmUply5cti1axePsZF78+aNOq9mZmY4e/ZstPt4Pk3H6tWrUaFCBfXey5YtG1q0aIG3b99G3r9z5071npT75T26cuVKg7aX4rZjxw5Uq1ZNTSwmE1F07doV9+7di7Ue35/G586dOxg0aJD6jJSZi0uXLq13vcScOz8/P3z88cfImjWrei107txZzeSXVhgoG4BMw92wYUMVGG/duhUzZszAsmXL1FTcZNxkSnV7e3t8//336gNXPoQ/+eQTfPPNN5HrrF+/Xi3r1q0b9u7dixo1aqBDhw44deqUQdtO8Zs6daqa1jQmnk/TITO0yqyt8t7bv38/li5dioIFCyI8PFzdf+zYMfVelPekvDdlPfkA3rx5s6GbTjH8+eef6lyVLFkS27Ztww8//IBLly6hadOm0b748P1pnK5evYrdu3ejSJEi6hzqk9hzJ/cfOHAAS5Yswa+//oqbN2+qz159f69ThZSHo7Q1Y8YMrYODg/bly5eRy5YuXaq1sLDQenh48HQYsRcvXsRa9sknn2gdHR214eHh6ra7u7u2e/fu0dapUaOGtkWLFmnWTkqa69evq/fkkiVL5KcB7ZkzZyLv4/k0DTdu3NBaWlpq9+zZE+c6TZs21dasWTPaMnmvlihRIg1aSEkxcOBAbcGCBbUajSZy2eHDh9X78+jRo5HL+P40TuHvPg9Fnz59tKVKlYq1TmLO3YkTJ9Q5379/f7T3upmZmXbDhg3atMAeZQOQb06NGzdWPyPoyE9KGo1GfWsi4yU/5cYkP/P6+/sjICBA/Sx469YtdT6j+uCDD/DHH38gODg4DVtLiSW9kPIzYbFixaIt5/k0HZJCIb3H0tOkj7z3jhw5gi5dusR6b16/fh0PHjxIo5ZSYoSGhqqf2SUVSsfJyUld61Ld+P40Xubm8YeXiT13Ei85OzurVFUd+TstKR179uxBWmCgbKD85OLFi0dbJi8EycGS+8i0yM+5uXPnVn/Udecv5vktUaKESrW5f/++gVpJcZGf3S9fvoyJEyfGuo/n03TIz7VlypTBtGnTkD17dlhbW6NWrVr4559/1P13795VwZe+96bg317j0rdvX1y7dg2LFi1SOaoSWI0bN051TMh5FXx/mq4bifyslPUkMI76hUm3Xlq9ZxkoGyhHWQLjmLJkyQIfHx9DNIneI0iWPKsRI0ZEnlsR8/zKuRU8v8YlMDBQjQ2QcQL6pk7l+TQdT58+Vb/I/fLLLyq42r59u/pwlZzW58+f81yamDp16qjc5DFjxqi/p4ULF8azZ89UD6OFhYVah+9P0/UqkZ+VxhAvMVAmSqYnT56oQQYNGjTA0KFDeRxNkPQ+5siRAx999JGhm0LvSVLXpHKJ/EIgo+JbtmypqibIz/QLFizg8TUxJ06cQK9evdRgr8OHD6uKQ3KOW7VqFW0wH1FqY6BsAPJNSH5Kikm+OUXNWybj5evrq3IhXVxcsGXLlsh8LN234ZjnV/ftmefXeDx8+FBVL5kyZYo6X3JOJdASci0Xnk/TIedK3o9ly5aNXCbvN/mpXkbg81yaFul8kOpQ8h6Vzgj58iNVFM6fP481a9aodXhOTVeWRH5WGkO8xEDZACQnJ2ZujbwQpC5gzHwdMj7Sm9G6dWt1zuRnQN0AE6E7fzHPr9yWnMlChQqleXtJP8mBk1w46aGSP8ZyadOmjbpPPphlwC3Pp+koVapUnPcFBQWpn+6trKz0vjcF//YaF8lPlgFbUUmdcxlQLfnmgu9P01U8kZ+Vsp6Ug4s5V4G+sV6phYGyAUhP5KFDh1QPlo78rCS9kpJPR8ZL6jbKKF0ZJb9v3z41iC8qeXNL8XQ5n1Ft2LABjRo1Un8AyDjIh7BUQYh6mTdvnrpP6nVKnivPp+mQL68vX77ExYsXI5fJbemBrFSpEmxsbNQXoJg1k+W9KQODChQoYIBWU1zy58+vzl3MX4G8vb0jzxXfn6arUCI/KyVekt5jqYShI9UyLly4oNKr0kSaFKGjaHx8fLRubm7aevXqqdqAK1as0Do7O2s/++wzHikjJzWT5W3z/fffa0+ePBntEhQUpNb57bffVI3HiRMnao8cOaIdNGiQqu8q9SDJuMn5illHmefTdOq2VqlSRVu4cGHt+vXrtb///ru2evXqWhcXF62Xl5da5++//1b16gcPHqzOtbxH5b26ceNGQzefYvjhhx/Ue3Ho0KHagwcPqnNaunRpbY4cObTe3t6R6/H9aZwCAgK0mzZtUpf69etr8+bNG3n7+fPnSTp3zZo1U4+X9+mOHTu0ZcqU0ZYrV04bGhqaJs+FgbKBXLt2TduoUSOtnZ2dNnv27NoRI0Zog4ODDdUcSqT8+fOrP976Lvfv349c7+eff9YWKVJEa21trd7UO3fu5DE20UBZ8HyazoRAH374odbJyUn9bZUJRq5evRptHQmg5T0p7015jy5fvtxg7aW4yUQjixcv1pYtW1ZNBpQzZ05thw4d1ORAMfH9aXzu378f52el/J1Nyrnz9fXV9uvXT3UoZsqUSduxY8c0nZzNTP6XNn3XRERERESmgznKRERERER6MFAmIiIiItKDgTIRERERkR4MlImIiIiI9GCgTERERESkBwNlIiIiIiI9GCgTEREREenBQJmIiIiISA8GykREREREejBQJiIyAF9fX5iZmWHVqlXqdt++fVG6dGmTOxfG1O5mzZqhe/fuhm4GEaUjloZuABERARMmTEBAQIDJHQpjaveFCxfw1VdfGboZRJSOMFAmIjIChQsXhikylnY/efIEL168QPny5Q3dFCJKR5h6QUSUBn766ScUKFAA9vb2aNSoEe7cuRNvCoPu9qFDh1C2bFnY2dmhXr16ePDgAXx8fNC1a1c4OjqqQHXDhg2x9nfy5Ek0bNgQDg4OcHJyQo8ePfD8+XO9+/zzzz9RoUIFtW7VqlVx7ty5yHWuXr2Kli1bwsXFRbW9WLFimD17dpzt1tm6dasKWm1tbZErVy4MHz4cQUFBSdp3XKQHe9iwYciePTucnZ0xZswYnD17Vt0n2yIiSikMlImIUtmuXbswYMAANGjQANu2bVOBcpcuXRJ83NOnT1Uqwddff41ff/0Vd+/eRc+ePdGtWzeUKVMGW7ZsQaVKlfDhhx/i4cOH0YLk+vXrqwBZguhly5bhzJkzaNeund59DB06FCNHjsTGjRtVMNuhQweEhoaq+9u0aYNXr15h+fLl2L17N0aMGJFgqsWOHTvQuXNnlCxZEtu3b8eoUaOwZMkS1c6k7FufsLAwFbhLW+bOnaue3/Hjx9U23NzcVPBMRJRitERElKqqVaumrVOnTrRlEyZM0Mqf4JUrV6rbffr00ZYqVSryfrltZmamvXLlSuSy//3vf+oxo0ePjlz26tUrrYWFhfaHH36IXFa3bl1tzZo1tRqNJnLZ1atX1fZ2794d7z6OHDmi9vH3339rX7x4of69Y8eOOJ9bzHaLChUqaGvUqBFt2dKlS9W2/v3330TtOy7ffvutNlOmTFpPT8/IZQ8fPlSPa9GiRZyPIyJKDvYoExGlovDwcJVOID2lUUmPa0IkZaFUqVKRt93d3dV148aNI5dJ6oH0oj5+/FjdDgwMVD2s0mMt+5YeWLnIY/Pmzat6luPbh/QC63J+Jd0if/78GDt2LFavXq2WJeTNmze4ePFirOcnveDi2LFjidq3PlqtFj/88IPqnZfeY518+fKp1BSmXRBRSmOgTESUimSAmQSqMVMCcuTIkeBjJQiOytraOs7luvxfSZOQAPnLL7+ElZVVtMujR48iA+qE9iHbk/J1Bw4cQIkSJfDZZ5+pQLty5co4evRovGXvJKCN+fwkDcTGxkblVydm3/pcv34dXl5esb50yHN++/YtB/IRUYpj1QsiolTk6uoKS0vLWAPpnj17lir7k+BTAtxx48ahffv2se7Pli1bkrYnPdGbNm1SecMnTpxQ25W8ZQ8PD2TKlCnO/cd8vn5+fggODkbWrFmRXJ6enuo65peOzZs3q2tWvCCilMYeZSKiVGRhYYGKFSuqQXz6gruUJtUjatSooXpfpfc35kUqbySH9EhL1Q2pMOHv7x8ZtMYkwbMErDGfnwzWE7Vr10Zy6YJseW46kmry7bffInPmzChSpEiyt01EpA97lImIUplUrZCKEx999BE++OADlbO8Zs2aVNvfnDlzVGk4yQuW/WXJkkXl/R48eFC1QSpiJMa///6rqm7IdqQMnfQKz5w5UwXb8dVPnjx5surNlioXcrl586bqie7UqZOq1pFcUk5Ocqal1Jykl0jwLkGyBO3yZUR6somIUhJ7lImIUlnbtm1VebQ//vhDBZCS96uv9nFKqVmzpho0JwPrJDCWcmrffPONqoOclF7XnDlzqosExy1atMDAgQNVnrK0X3rK43u+kq5x+fJl9QVh1qxZagDe2rVr3+t5SQ6z9FRLeofUhZZayrJ9GRDItAsiSg1mUvoiVbZMRERERGTC2KNMRERERKQHA2UiIiIiIj0YKBMRERER6cFAmYiIiIhIDwbKRERERER6MFAmIiIiItKDgTIRERERkR4MlImIiIiI9GCgTERERESkBwNlIiIiIiI9GCgTEREREenBQJmIiIiISA8GykREREREiO3/M3hZCXdcEDwAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 726x440 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "fig, ax = plt.subplots(figsize=(6.6, 4.0))\n",
+    "dims = [d for d, _ in dimension_cases]\n",
+    "for name, ratios in by_dimension.items():\n",
+    "    ax.plot(dims, ratios, \"o-\", color=COLOURS[name], label=name, ms=6)\n",
+    "ax.axhline(1.0, color=\"black\", lw=1.0)\n",
+    "ax.axhspan(0.5, 2.0, color=\"#dbe4ee\", zorder=0, label=\"within a factor of two\")\n",
+    "ax.set(\n",
+    "    xlabel=\"dimension $d$\",\n",
+    "    ylabel=\"estimate / exact\",\n",
+    "    yscale=\"log\",\n",
+    "    title=\"The same problem, at four dimensions\",\n",
+    ")\n",
+    "ax.legend(fontsize=8, loc=\"lower left\")\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "86a29c4c",
+   "metadata": {},
+   "source": [
+    "The Gaussian mixture is seven orders of magnitude low at $d = 100$. That is\n",
+    "the claim the Safe-ICE paper makes about cross-entropy — \"in high dimensions,\n",
+    "its Gaussian proposals collapse onto a thin shell\" — and it is not a marginal\n",
+    "effect."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dbaa3c4a",
+   "metadata": {},
+   "source": [
+    "## What each of them costs\n",
+    "\n",
+    "Accuracy is only half of it. The methods differ by an order of magnitude in\n",
+    "how many limit-state evaluations they need, which is the entire question when\n",
+    "one evaluation is a finite-element solve."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "b7aaf1ee",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-19T15:01:15.928207Z",
+     "iopub.status.busy": "2026-08-19T15:01:15.927905Z",
+     "iopub.status.idle": "2026-08-19T15:01:16.495201Z",
+     "shell.execute_reply": "2026-08-19T15:01:16.494396Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "method         evaluations   informing the fit\n",
+      "------------------------------------------------\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Safe-ICE             3,000               100%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ICE-vMFNM            5,000               100%\n",
+      "CE-GM               14,000                26%\n",
+      "subset sim          10,000                n/a\n"
+     ]
+    }
+   ],
+   "source": [
+    "FITS_A_PROPOSAL = {\"Safe-ICE\", \"ICE-vMFNM\", \"CE-GM\"}\n",
+    "\n",
+    "print(f\"{'method':12s} {'evaluations':>13s} {'informing the fit':>19s}\")\n",
+    "print(\"-\" * 48)\n",
+    "for name, (cls, kwargs) in METHODS.items():\n",
+    "    _pf, diagnostics = cls(\n",
+    "        limit_state_function=FOUR_MODE, dimension=2, random_state=0, **kwargs\n",
+    "    ).run(verbose=False)\n",
+    "    total = diagnostics.get(\"n_evaluations\") or kwargs[\"N\"] * (\n",
+    "        len(diagnostics[\"iterations\"]) + 1\n",
+    "    )\n",
+    "    if name in FITS_A_PROPOSAL:\n",
+    "        discarded = diagnostics.get(\"samples_discarded\", 0.0)\n",
+    "        share = f\"{(total - discarded) / total:.0%}\"\n",
+    "    else:\n",
+    "        # Subset simulation has no proposal to fit, so the column is meaningless\n",
+    "        # rather than perfect.\n",
+    "        share = \"n/a\"\n",
+    "    print(f\"{name:12s} {total:13,d} {share:>18s}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d8b1d2a3",
+   "metadata": {},
+   "source": [
+    "Cross-entropy keeps only the best tenth of each iteration, which is the\n",
+    "\"diminishing statistical efficiency\" the paper points at. The smoothed\n",
+    "indicator that ICE and Safe-ICE use is precisely the fix: every sample\n",
+    "contributes something, weighted by how close it came."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2ce76259",
+   "metadata": {},
+   "source": [
+    "## Where each one stops\n",
+    "\n",
+    "Being fair about this matters more than the tables above, because a method's\n",
+    "limits are what decide whether it suits a given problem.\n",
+    "\n",
+    "**Safe-ICE.** Its smoothing is $\\Phi(-g/\\sigma)$, so it assumes $g$ is on a\n",
+    "scale comparable to $\\sigma_0$. That is now chosen automatically, but the\n",
+    "sensitivity is real: a limit state in physical units with a spread of 33 and a\n",
+    "fixed $\\sigma_0 = 1$ returns a third of the answer, quietly. It also needs a\n",
+    "limit state with a usable gradient — a connectivity problem returning $\\pm 1$\n",
+    "gives the smoothing nothing to work with.\n",
+    "\n",
+    "**ICE-vMFNM.** Accurate on average, but the number of components is a choice\n",
+    "made in advance and the answer depends on it: on the four-mode problem the\n",
+    "relative error of the mean runs 0.084 at $K=2$, 0.276 at $K=4$ and 0.290 at\n",
+    "$K=8$ — adding components makes it worse, and nothing tells you which to use.\n",
+    "With no penalty holding components apart it can also collapse onto one mode,\n",
+    "which happened on one seed in six above and cost a factor of eight.\n",
+    "\n",
+    "**CE-GM.** Fine in low dimension with few modes; unusable by $d=50$, and\n",
+    "loses modes on multi-modal problems regardless of $K$.\n",
+    "\n",
+    "**Subset simulation.** No proposal family to misfit, so nothing collapses —\n",
+    "but it needs far more evaluations for the same precision, and its estimate\n",
+    "carries a small bias at finite $N$ because the thresholds are estimated from\n",
+    "the same samples as the conditional probabilities. On the sphere at $d=2$ its\n",
+    "mean over twelve runs moves 0.90x, 1.01x, 1.02x of the exact value as $N$ goes\n",
+    "1000, 4000, 16000, with the coefficient of variation falling from 18.9% to\n",
+    "6.9%.\n",
+    "\n",
+    "The practical reading: use Safe-ICE for the estimate, and subset simulation to\n",
+    "check it. They share no machinery, so when they agree it is evidence about the\n",
+    "answer rather than about the code — which is how two defects in this\n",
+    "repository were found."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/06_comparing_estimators.py
+++ b/notebooks/06_comparing_estimators.py
@@ -1,0 +1,311 @@
+# ---
+# jupyter:
+#   jupytext:
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#   kernelspec:
+#     display_name: Python 3
+#     language: python
+#     name: python3
+# ---
+
+# %% [markdown]
+# # Four estimators, side by side
+#
+# The package implements four methods for the same question. This notebook runs
+# them on the same problems and, more usefully, shows where each one stops.
+#
+# | Method | Proposal | How the intermediate level is set |
+# | --- | --- | --- |
+# | **Safe-ICE** | vMF-Nakagami mixture plus a heavy-tailed component | smoothed indicator $\Phi(-g/\sigma)$ |
+# | **ICE-vMFNM** | vMF-Nakagami mixture | smoothed indicator $\Phi(-g/\sigma)$ |
+# | **CE-GM** | Gaussian mixture | hard threshold at the $\rho$-quantile |
+# | **Subset simulation** | none — MCMC in nested levels | hard threshold at the $p_0$-quantile |
+#
+# The first three are importance sampling: fit a proposal, reweight by $p/q$.
+# The fourth is not, which is what makes it useful as a check rather than a
+# second opinion from the same machinery.
+
+# %%
+import matplotlib.pyplot as plt
+import numpy as np
+from scipy import stats
+
+from safe_ice import (
+    CrossEntropyGaussianMixture,
+    ICEvMFNM,
+    SafeICE,
+    SubsetSimulation,
+)
+from safe_ice.problems.benchmarks import BenchmarkProblems
+
+plt.rcParams.update({"figure.dpi": 110, "font.size": 10, "figure.facecolor": "white"})
+
+METHODS = {
+    "Safe-ICE": (SafeICE, {"N": 1000, "max_iterations": 15}),
+    "ICE-vMFNM": (ICEvMFNM, {"K": 4, "N": 1000, "max_iterations": 15}),
+    "CE-GM": (CrossEntropyGaussianMixture, {"K": 4, "N": 2000}),
+    "subset sim": (SubsetSimulation, {"N": 2000}),
+}
+COLOURS = {
+    "Safe-ICE": "#1d3557",
+    "ICE-vMFNM": "#457b9d",
+    "CE-GM": "#c1121f",
+    "subset sim": "#2a9d8f",
+}
+SEEDS = range(5)
+
+
+def run_all(limit_state, dimension, seeds=SEEDS):
+    """Every method on one problem, returning estimates and evaluation counts."""
+    out = {}
+    for name, (cls, kwargs) in METHODS.items():
+        estimates, costs = [], []
+        for seed in seeds:
+            instance = cls(
+                limit_state_function=limit_state,
+                dimension=dimension,
+                random_state=seed,
+                **kwargs,
+            )
+            pf, diagnostics = instance.run(verbose=False)
+            estimates.append(pf)
+            costs.append(
+                diagnostics.get("n_evaluations")
+                or instance.N * (len(diagnostics["iterations"]) + 1)
+            )
+        out[name] = (np.array(estimates), int(np.median(costs)))
+    return out
+
+
+# %% [markdown]
+# ## Where they agree
+#
+# Two problems with answers known in closed form, so there is nothing to argue
+# about.
+
+
+# %%
+def sphere(beta):
+    return lambda u: beta - np.linalg.norm(u, axis=-1)
+
+
+problems = [
+    (
+        "two-mode, z=3",
+        BenchmarkProblems.two_mode_opposite_directions(z=3.0),
+        2,
+        float(2 * stats.norm.cdf(-3.0)),
+        "closed form",
+    ),
+    (
+        "sphere, d=2",
+        sphere(3.5),
+        2,
+        float(stats.chi2.sf(3.5**2, df=2)),
+        "closed form",
+    ),
+]
+
+for label, limit_state, dimension, reference, source in problems:
+    print(f"{label}  ({source}, P_F = {reference:.4e})")
+    for name, (estimates, cost) in run_all(limit_state, dimension).items():
+        median = float(np.median(estimates))
+        print(
+            f"    {name:12s} {median:.4e}  {median / reference:5.2f}x  "
+            f"{cost:7,d} evaluations"
+        )
+    print()
+
+# %% [markdown]
+# All four land on the answer. On a two-dimensional, gently-shaped problem the
+# choice of method barely matters — which is worth knowing, because it means the
+# differences below are not about one implementation being better written than
+# another.
+
+# %% [markdown]
+# ## Where multiple modes separate them
+#
+# The four-mode series system puts its failure region in four disconnected
+# lobes. A proposal that finds three of them returns three quarters of the
+# answer, and looks perfectly converged while doing so.
+
+# %%
+FOUR_MODE = BenchmarkProblems.four_mode_series_system(z=1.0)
+FOUR_MODE_PF = 6.465e-05  # crude MC over 2e7 samples
+
+four_mode_results = run_all(FOUR_MODE, 2, seeds=range(6))
+
+print(f"four-mode series system, reference {FOUR_MODE_PF:.4e}")
+print(f"    {'method':12s} {'median':>11s} {'ratio':>7s} {'worst seed':>11s}")
+print("    " + "-" * 45)
+for name, (estimates, _cost) in four_mode_results.items():
+    ratios = estimates / FOUR_MODE_PF
+    worst = ratios[np.argmax(np.abs(np.log(np.maximum(ratios, 1e-300))))]
+    print(
+        f"    {name:12s} {np.median(estimates):11.4e} "
+        f"{np.median(ratios):6.2f}x {worst:10.2f}x"
+    )
+
+
+# %%
+def lobes_covered(samples, g_values):
+    """How many of the four lobes the failing samples fall in."""
+    failing = np.asarray(samples)[np.asarray(g_values) <= 0]
+    if failing.size == 0:
+        return 0
+    keys = list(
+        zip(
+            np.sign(failing[:, 0] + failing[:, 1]).astype(int),
+            np.sign(failing[:, 0] - failing[:, 1]).astype(int),
+            strict=False,
+        )
+    )
+    counts = {}
+    for key in keys:
+        counts[key] = counts.get(key, 0) + 1
+    return sum(1 for count in counts.values() if count >= 3)
+
+
+print("lobes of the failure region the final samples reach (4 exist):")
+for name, (cls, kwargs) in METHODS.items():
+    found = []
+    for seed in range(6):
+        _pf, diagnostics = cls(
+            limit_state_function=FOUR_MODE, dimension=2, random_state=seed, **kwargs
+        ).run(verbose=False)
+        found.append(
+            lobes_covered(diagnostics["final_samples"], diagnostics["final_g_values"])
+        )
+    print(f"    {name:12s} {found}   median {int(np.median(found))}/4")
+
+# %% [markdown]
+# The lobe count explains the estimates above, and the three methods miss modes
+# for different reasons.
+#
+# CE-GM is consistently short, at three of four, because it fits a mixture to
+# the best tenth of each iteration and that concentrates wherever the first
+# elites happened to land. ICE-vMFNM usually finds all four, but one seed in six
+# collapsed to a single lobe — it has no penalty holding its components apart,
+# so nothing stops EM from merging them, and that one run is where its worst-case
+# 0.13x comes from. Safe-ICE's penalised EM is precisely the mechanism that
+# prevents it.
+#
+# Subset simulation reaches all four for a different reason again: its chains do
+# not fit anything, they walk, so there is no fitted object to collapse.
+
+# %% [markdown]
+# ## Where dimension separates them
+#
+# The prior's mass concentrates on a shell of radius $\sqrt{d}$. Representing
+# that with a Gaussian mixture is fine at $d = 10$ and hopeless by $d = 50$; a
+# vMF-Nakagami mixture is written in polar form, separating radius from
+# direction, and so does not have to represent a shell with an ellipsoid.
+
+# %%
+dimension_cases = [(2, 3.5), (10, 5.0), (50, 9.0), (100, 12.0)]
+by_dimension = {name: [] for name in METHODS}
+
+for d, beta in dimension_cases:
+    exact = float(stats.chi2.sf(beta**2, df=d))
+    for name, (estimates, _cost) in run_all(sphere(beta), d, seeds=range(3)).items():
+        by_dimension[name].append(float(np.median(estimates)) / exact)
+
+print(f"{'method':12s}" + "".join(f"{f'd={d}':>10s}" for d, _ in dimension_cases))
+print("-" * 52)
+for name, ratios in by_dimension.items():
+    print(f"{name:12s}" + "".join(f"{r:9.2f}x" for r in ratios))
+
+# %%
+fig, ax = plt.subplots(figsize=(6.6, 4.0))
+dims = [d for d, _ in dimension_cases]
+for name, ratios in by_dimension.items():
+    ax.plot(dims, ratios, "o-", color=COLOURS[name], label=name, ms=6)
+ax.axhline(1.0, color="black", lw=1.0)
+ax.axhspan(0.5, 2.0, color="#dbe4ee", zorder=0, label="within a factor of two")
+ax.set(
+    xlabel="dimension $d$",
+    ylabel="estimate / exact",
+    yscale="log",
+    title="The same problem, at four dimensions",
+)
+ax.legend(fontsize=8, loc="lower left")
+plt.tight_layout()
+plt.show()
+
+# %% [markdown]
+# The Gaussian mixture is seven orders of magnitude low at $d = 100$. That is
+# the claim the Safe-ICE paper makes about cross-entropy — "in high dimensions,
+# its Gaussian proposals collapse onto a thin shell" — and it is not a marginal
+# effect.
+
+# %% [markdown]
+# ## What each of them costs
+#
+# Accuracy is only half of it. The methods differ by an order of magnitude in
+# how many limit-state evaluations they need, which is the entire question when
+# one evaluation is a finite-element solve.
+
+# %%
+FITS_A_PROPOSAL = {"Safe-ICE", "ICE-vMFNM", "CE-GM"}
+
+print(f"{'method':12s} {'evaluations':>13s} {'informing the fit':>19s}")
+print("-" * 48)
+for name, (cls, kwargs) in METHODS.items():
+    _pf, diagnostics = cls(
+        limit_state_function=FOUR_MODE, dimension=2, random_state=0, **kwargs
+    ).run(verbose=False)
+    total = diagnostics.get("n_evaluations") or kwargs["N"] * (
+        len(diagnostics["iterations"]) + 1
+    )
+    if name in FITS_A_PROPOSAL:
+        discarded = diagnostics.get("samples_discarded", 0.0)
+        share = f"{(total - discarded) / total:.0%}"
+    else:
+        # Subset simulation has no proposal to fit, so the column is meaningless
+        # rather than perfect.
+        share = "n/a"
+    print(f"{name:12s} {total:13,d} {share:>18s}")
+
+# %% [markdown]
+# Cross-entropy keeps only the best tenth of each iteration, which is the
+# "diminishing statistical efficiency" the paper points at. The smoothed
+# indicator that ICE and Safe-ICE use is precisely the fix: every sample
+# contributes something, weighted by how close it came.
+
+# %% [markdown]
+# ## Where each one stops
+#
+# Being fair about this matters more than the tables above, because a method's
+# limits are what decide whether it suits a given problem.
+#
+# **Safe-ICE.** Its smoothing is $\Phi(-g/\sigma)$, so it assumes $g$ is on a
+# scale comparable to $\sigma_0$. That is now chosen automatically, but the
+# sensitivity is real: a limit state in physical units with a spread of 33 and a
+# fixed $\sigma_0 = 1$ returns a third of the answer, quietly. It also needs a
+# limit state with a usable gradient — a connectivity problem returning $\pm 1$
+# gives the smoothing nothing to work with.
+#
+# **ICE-vMFNM.** Accurate on average, but the number of components is a choice
+# made in advance and the answer depends on it: on the four-mode problem the
+# relative error of the mean runs 0.084 at $K=2$, 0.276 at $K=4$ and 0.290 at
+# $K=8$ — adding components makes it worse, and nothing tells you which to use.
+# With no penalty holding components apart it can also collapse onto one mode,
+# which happened on one seed in six above and cost a factor of eight.
+#
+# **CE-GM.** Fine in low dimension with few modes; unusable by $d=50$, and
+# loses modes on multi-modal problems regardless of $K$.
+#
+# **Subset simulation.** No proposal family to misfit, so nothing collapses —
+# but it needs far more evaluations for the same precision, and its estimate
+# carries a small bias at finite $N$ because the thresholds are estimated from
+# the same samples as the conditional probabilities. On the sphere at $d=2$ its
+# mean over twelve runs moves 0.90x, 1.01x, 1.02x of the exact value as $N$ goes
+# 1000, 4000, 16000, with the coefficient of variation falling from 18.9% to
+# 6.9%.
+#
+# The practical reading: use Safe-ICE for the estimate, and subset simulation to
+# check it. They share no machinery, so when they agree it is evidence about the
+# answer rather than about the code — which is how two defects in this
+# repository were found.

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -10,6 +10,7 @@ render directly on GitHub without running anything.
 | [03_high_dimensions.ipynb](03_high_dimensions.ipynb) | Accuracy from `d=2` to `d=200`, against the exact chi-square tail |
 | [04_how_it_works.ipynb](04_how_it_works.ipynb) | The four moving parts — smoothed indicator, sigma schedule, penalised EM, heavy-tailed component |
 | [05_flood_risk_real_data.ipynb](05_flood_risk_real_data.ipynb) | A real problem: 95 years of USGS gauge data, a levee, and three estimators that agree |
+| [06_comparing_estimators.ipynb](06_comparing_estimators.ipynb) | All four estimators on the same problems, and where each one stops |
 
 ## A note on the numbers
 
@@ -44,7 +45,7 @@ pip install -e ".[viz]"
 
 ## Runtime
 
-All five take a few minutes in total. The slowest cells are the ones that have
+All six take a few minutes in total. The slowest cells are the ones that have
 to be slow to make their point: `02` runs the heat transfer problem, where each
 limit-state evaluation is a finite-element solve, and `03` goes to 200
 dimensions. `05` reads its data from `data/`, so it needs no network access.


### PR DESCRIPTION
The roadmap's remaining "Next" item: all four estimators on the same problems, with the emphasis on where each one *stops* rather than where they agree.

On a two-dimensional, gently-shaped problem all four land on the answer within 20%. That is worth establishing first, because it means the differences below are properties of the methods rather than of how well each is written.

## Multiple modes separate them, for different reasons

Lobes reached out of four, six seeds on the four-mode problem:

| | lobes reached | worst seed |
| --- | --- | --- |
| Safe-ICE | `[4,4,4,4,4,4]` | 0.79x |
| ICE-vMFNM | `[4,4,1,4,4,4]` | **0.13x** |
| CE-GM | `[3,3,4,3,4,2]` | **0.17x** |
| subset simulation | `[4,4,4,4,4,4]` | 0.58x |

- **CE-GM** is consistently short because it fits to the best tenth of each iteration, which concentrates wherever the first elites landed.
- **ICE-vMFNM** usually finds all four but collapsed onto *one* on a single seed — it has no penalty holding its components apart, so nothing stops EM merging them. That one run is where the 0.13x comes from, and the penalised EM is exactly the mechanism Safe-ICE adds.
- **Subset simulation** reaches all four because its chains walk rather than fit, so there is no fitted object to collapse.

## Dimension separates them too

| method | d=2 | d=10 | d=50 | d=100 |
| --- | --- | --- | --- | --- |
| Safe-ICE | 1.01x | 0.98x | 0.97x | 0.96x |
| ICE-vMFNM | 1.00x | 0.92x | 1.04x | 0.90x |
| CE-GM | 0.90x | 1.03x | **0.00x** | **0.00x** |
| subset sim | 1.11x | 0.95x | 0.94x | 1.03x |

## Three of my claims were wrong and the output caught them

Worth naming, since the notebook's value is that its numbers are measured rather than asserted:

- I wrote that ICE-vMFNM "does not reliably" reach all four lobes. It usually does — the failure is rarer and sharper than that, one seed in six.
- I grouped it with the methods that "fit a mixture to an elite subset". It does not; it uses the smoothed indicator, like Safe-ICE.
- The cost table reported subset simulation as having 100% of its samples inform the fit. It fits nothing, so the column is `n/a`, not perfect.

## Even-handed about Safe-ICE

The closing section records its limits alongside the others': sensitivity to the scale of `g` (now handled automatically, but real), and its need for a limit state with a usable gradient — a connectivity problem returning ±1 gives the smoothing nothing to work with.

The practical reading it lands on: use Safe-ICE for the estimate and subset simulation to check it, because they share no machinery, and that is how two defects in this repository were found.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `notebooks/06_comparing_estimators` to run Safe-ICE, ICE‑vMFNM, CE‑GM, and subset simulation on the same problems, emphasizing where each method stops rather than where they agree. Updates README, notebooks index, CHANGELOG, and marks the notebook as Done on the roadmap.

- New files: `notebooks/06_comparing_estimators.ipynb` (with saved outputs) and `notebooks/06_comparing_estimators.py` (jupytext export). Results cover multi‑modal coverage (which lobes each method reaches), high‑dimension behavior (CE‑GM collapses by d≥50; others hold d=2–100), and cost accounting (subset simulation’s “informing the fit” is `n/a`).
- Corrections from measured output: ICE‑vMFNM usually reaches all modes (rare single‑mode collapse explains a worst seed), it uses the smoothed indicator (not elite fitting), and subset simulation does not fit a proposal.
- README/notebooks index list the sixth notebook; CHANGELOG summarizes findings. ROADMAP moves “comparison notebook” to Done and notes a follow‑up to re‑run notebooks periodically to avoid stale outputs. No code‑path or API changes.

<sup>Written for commit ca99e46d7e8bfd18972f0a64873319b090b3c4fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/adaptive-importance-sampling/pull/106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

