### PR TITLE
Check the notebooks are in step, and still run

### DIFF
--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -1,0 +1,92 @@
+name: Notebooks
+
+# The notebooks are committed with their outputs saved so they render on GitHub
+# without anyone running them, which means their numbers are pinned to whatever
+# the code did when they were produced. Two things can go wrong quietly, and
+# they need different cadences.
+#
+# Being out of step with their .py source is cheap to detect, so it runs on
+# every change that could cause it.
+#
+# Being out of date with the package is only detectable by re-running them,
+# which takes minutes, so it runs weekly and on demand. It reports rather than
+# committing: regenerating rewrites embedded images and would churn the diff on
+# every build, and deciding when to refresh a published figure belongs to
+# whoever is editing.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'notebooks/**'
+      - 'scripts/check_notebooks.py'
+  pull_request:
+    paths:
+      - 'notebooks/**'
+      - 'scripts/check_notebooks.py'
+  schedule:
+    # Mondays at 05:00 UTC. Only ever runs on the default branch.
+    - cron: '0 5 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: notebooks-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  in-step:
+    name: Notebooks match their sources
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+
+      - name: Install jupytext
+        run: |
+          python -m pip install --upgrade pip
+          # Reading the pair needs nothing but jupytext; the package itself is
+          # only required to run them, which this job does not do.
+          pip install jupytext
+
+      - name: Check each notebook matches its .py
+        run: python scripts/check_notebooks.py --sync
+
+  still-run:
+    name: Notebooks still run
+    # Only on a schedule or by hand: this executes every notebook, including a
+    # finite-element problem and a 200-dimensional sweep.
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+
+      - name: Install the package and the notebook tooling
+        run: |
+          python -m pip install --upgrade pip
+          # Nothing in the notebooks needs the viz extra; they plot with matplotlib.
+          pip install -e .
+          pip install jupytext ipykernel
+
+      - name: Re-run every notebook
+        run: python scripts/check_notebooks.py --execute
+
+      - name: Say what to do about it
+        if: failure()
+        run: |
+          echo "A notebook stopped running against the current package."
+          echo "Its committed outputs are now claims about a version that no"
+          echo "longer exists. Regenerate the affected ones with:"
+          echo "  jupytext --to ipynb --execute notebooks/<name>.py"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `scripts/check_notebooks.py` and a `Notebooks` workflow, because the
+  notebooks are committed with their outputs saved and nothing was re-running
+  them. Two things can go wrong quietly there, and they need different checks
+  at different cadences.
+
+  **Out of step.** Editing a `.py` and forgetting to regenerate leaves the
+  `.ipynb` showing older text and older numbers, and nothing about it looks
+  stale. `--sync` compares the cells of both, takes a second, and runs on every
+  change to `notebooks/`.
+
+  **Out of date.** The saved outputs are pinned to whatever the code did when
+  they were produced, so a change to an estimator silently turns them into
+  claims about a version that no longer exists. `--execute` re-runs each one and
+  fails if a cell raises. It takes minutes, so it runs weekly and on demand.
+
+  Neither writes anything. Regenerating rewrites embedded images and would churn
+  the diff on every build, and deciding when to refresh a published figure
+  belongs to whoever is editing.
+
 - `notebooks/06_comparing_estimators.ipynb`, running all four estimators on the
   same problems. The useful half is where each one stops rather than where they
   agree, and on a two-dimensional, gently-shaped problem they all land on the

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -73,6 +73,11 @@ tests for whatever was there:
   so a defect there misleads rather than corrupts, and the tests are shallow
   by design.
 
+### Done: the notebooks are checked rather than trusted
+
+`scripts/check_notebooks.py` catches both ways they go stale: `--sync` on every
+change, `--execute` weekly. Neither rewrites anything.
+
 ### Done: a notebook comparing all four
 
 `notebooks/06_comparing_estimators.ipynb` runs them on the same problems and
@@ -94,18 +99,8 @@ side by side on the same problems would be a reasonable next step.
 
 ## Next
 
-### Keep the notebooks from going quietly stale
-
-All six carry saved outputs so they render on GitHub, and nothing re-executes
-them. Every number in them is pinned to the behaviour of the version that ran
-them, so a change to an estimator leaves them wrong in a way no test catches --
-`tests/test_flood_data.py` guards one notebook's claims, and the rest are
-unguarded.
-
-A workflow that re-runs them and fails on error would close it, at a few
-minutes per build. Re-running on every push would also churn the committed
-outputs, so it probably wants to run on a schedule, or on changes to
-`safe_ice/` only, and report rather than commit.
+Nothing outstanding. What remains below was deferred deliberately rather than
+left undone.
 
 ## Later
 

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -43,6 +43,21 @@ with the package installed:
 pip install -e ".[viz]"
 ```
 
+## Keeping them honest
+
+They are committed with outputs, so nothing about a stale one looks stale.
+`scripts/check_notebooks.py` catches both ways that happens:
+
+```bash
+python scripts/check_notebooks.py --sync      # does each .ipynb match its .py?
+python scripts/check_notebooks.py --execute   # does each one still run?
+```
+
+The first runs in CI on every change here. The second runs weekly, because it
+re-executes everything. Neither rewrites a notebook: regenerating changes the
+embedded images, so when to refresh a published figure is a decision for
+whoever is editing.
+
 ## Runtime
 
 All six take a few minutes in total. The slowest cells are the ones that have

--- a/scripts/check_notebooks.py
+++ b/scripts/check_notebooks.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python
+"""Check the notebooks are in step with their sources, and still run.
+
+Every notebook under ``notebooks/`` is committed twice: as a jupytext
+percent-format ``.py``, which is the file to edit and the one that reviews as a
+normal diff, and as an ``.ipynb`` carrying saved outputs so it renders on GitHub
+without anyone running it.
+
+That arrangement has two ways of going quietly wrong, and they need different
+checks.
+
+**Out of step.** Editing the ``.py`` and forgetting to regenerate leaves the
+``.ipynb`` showing older text and older numbers. Nothing about it looks stale.
+``--sync`` compares the cells of both and is fast enough to run on every push.
+
+**Out of date.** The saved outputs are pinned to whatever the code did when they
+were produced. A change to an estimator does not touch the notebooks, so their
+numbers silently become claims about a version that no longer exists.
+``--execute`` re-runs each one and fails if any cell raises. It takes minutes,
+so it belongs on a schedule rather than on every push.
+
+Neither writes anything. Regenerating is a decision for whoever is editing::
+
+    jupytext --to ipynb --execute notebooks/01_getting_started.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+NOTEBOOKS = Path(__file__).resolve().parent.parent / "notebooks"
+
+
+def paired_notebooks() -> list[tuple[Path, Path]]:
+    """Every ``.py`` under ``notebooks/`` with its committed ``.ipynb``."""
+    pairs = []
+    for source in sorted(NOTEBOOKS.glob("*.py")):
+        pairs.append((source, source.with_suffix(".ipynb")))
+    return pairs
+
+
+def cell_sources(path: Path) -> list[str]:
+    """Cell contents of a notebook, whichever form it is stored in."""
+    import jupytext
+
+    notebook = jupytext.read(path)
+    return [cell["source"].strip() for cell in notebook.cells]
+
+
+def check_sync(pairs: list[tuple[Path, Path]]) -> int:
+    """Report any ``.ipynb`` whose cells differ from its ``.py``."""
+    problems = 0
+
+    for source, notebook in pairs:
+        if not notebook.exists():
+            print(f"MISSING  {notebook.name}: no committed notebook for {source.name}")
+            problems += 1
+            continue
+
+        from_source = cell_sources(source)
+        committed = cell_sources(notebook)
+
+        if from_source == committed:
+            print(f"ok       {notebook.name}: {len(committed)} cells in step")
+            continue
+
+        problems += 1
+        if len(from_source) != len(committed):
+            print(
+                f"STALE    {notebook.name}: {len(from_source)} cells in "
+                f"{source.name}, {len(committed)} in the notebook"
+            )
+        else:
+            differing = [
+                index
+                for index, (a, b) in enumerate(zip(from_source, committed, strict=True))
+                if a != b
+            ]
+            print(
+                f"STALE    {notebook.name}: cells {differing} differ from {source.name}"
+            )
+
+    return problems
+
+
+def check_execute(pairs: list[tuple[Path, Path]]) -> int:
+    """Re-run each notebook from its source and report any that fail.
+
+    The result goes to stdout and is discarded, which keeps this from touching
+    the committed notebooks. Writing to a file instead would also move the
+    kernel: jupytext runs it in the output's directory, so an executed copy sent
+    to a temporary folder broke the flood notebook's relative path to
+    ``data/``. Sending it nowhere leaves the working directory where the
+    notebooks expect it.
+    """
+    problems = 0
+
+    for source, _notebook in pairs:
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "jupytext",
+                "--to",
+                "ipynb",
+                "--execute",
+                "--output",
+                "-",
+                source.name,
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+            text=True,
+            cwd=str(NOTEBOOKS),
+            check=False,
+        )
+        if result.returncode == 0:
+            print(f"ok       {source.name}: runs")
+        else:
+            problems += 1
+            tail = (result.stderr or "").strip().splitlines()[-6:]
+            print(f"FAILED   {source.name}:")
+            for line in tail:
+                print(f"           {line}")
+
+    return problems
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the requested checks and return a shell exit code."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--sync",
+        action="store_true",
+        help="check each .ipynb matches its .py (fast)",
+    )
+    parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="re-run each notebook and fail if a cell raises (slow)",
+    )
+    args = parser.parse_args(argv)
+
+    if not (args.sync or args.execute):
+        args.sync = True
+
+    pairs = paired_notebooks()
+    if not pairs:
+        print(f"No notebooks found under {NOTEBOOKS}.", file=sys.stderr)
+        return 1
+
+    problems = 0
+    if args.sync:
+        print(f"Checking {len(pairs)} notebooks are in step with their sources")
+        problems += check_sync(pairs)
+        print()
+
+    if args.execute:
+        print(f"Re-running {len(pairs)} notebooks")
+        problems += check_execute(pairs)
+        print()
+
+    if problems:
+        print(f"{problems} problem(s). Regenerate with:")
+        print("  jupytext --to ipynb --execute notebooks/<name>.py")
+        return 1
+
+    # Only claim what was actually checked.
+    checked = " and ".join(
+        part for part, ran in (("in step", args.sync), ("running", args.execute)) if ran
+    )
+    print(f"All notebooks {checked}.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_check_notebooks.py
+++ b/tests/test_check_notebooks.py
@@ -1,0 +1,129 @@
+"""The notebook staleness check, which is only useful if it can fail.
+
+`scripts/check_notebooks.py` guards an arrangement that goes wrong quietly: each
+notebook is committed as a jupytext `.py` and as an `.ipynb` with saved outputs,
+and editing one without regenerating the other leaves a published notebook
+showing older text and older numbers with nothing about it looking stale.
+
+A check that cannot detect the thing it guards is worse than none, so most of
+these tests are about making it fail.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+SCRIPT = REPO / "scripts" / "check_notebooks.py"
+
+pytest.importorskip("jupytext", reason="the notebook check needs jupytext")
+
+
+@pytest.fixture(scope="module")
+def checker():
+    """Import the script as a module."""
+    spec = importlib.util.spec_from_file_location("check_notebooks", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["check_notebooks"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def notebook_pair(tmp_path, checker, monkeypatch):
+    """A miniature notebooks/ directory holding one matched pair."""
+    import jupytext
+
+    source = tmp_path / "example.py"
+    source.write_text(
+        "# %% [markdown]\n# A heading\n\n# %%\nresult = 2 + 2\nprint(result)\n",
+        encoding="utf-8",
+    )
+    jupytext.write(jupytext.read(source), tmp_path / "example.ipynb")
+
+    monkeypatch.setattr(checker, "NOTEBOOKS", tmp_path)
+    return source, tmp_path / "example.ipynb"
+
+
+class TestItPassesWhenItShould:
+    def test_a_matched_pair_reports_no_problems(self, checker, notebook_pair) -> None:
+        assert checker.check_sync(checker.paired_notebooks()) == 0
+
+    def test_the_real_repository_is_in_step(self, checker) -> None:
+        """The committed notebooks must match their sources right now."""
+        assert checker.check_sync(checker.paired_notebooks()) == 0
+
+    def test_it_finds_every_notebook(self, checker) -> None:
+        pairs = checker.paired_notebooks()
+        names = {source.name for source, _ in pairs}
+
+        assert len(pairs) >= 6
+        assert "01_getting_started.py" in names
+        assert all(notebook.suffix == ".ipynb" for _, notebook in pairs)
+
+
+class TestItFailsWhenItShould:
+    """The half that matters."""
+
+    def test_an_edited_source_is_caught(self, checker, notebook_pair, capsys) -> None:
+        source, _notebook = notebook_pair
+        source.write_text(
+            source.read_text(encoding="utf-8") + "\n# %%\nprint('added later')\n",
+            encoding="utf-8",
+        )
+
+        assert checker.check_sync(checker.paired_notebooks()) == 1
+        assert "STALE" in capsys.readouterr().out
+
+    def test_a_changed_cell_is_caught(self, checker, notebook_pair, capsys) -> None:
+        """Same number of cells, different contents: the easiest case to miss."""
+        source, _notebook = notebook_pair
+        source.write_text(
+            source.read_text(encoding="utf-8").replace("2 + 2", "3 + 3"),
+            encoding="utf-8",
+        )
+
+        assert checker.check_sync(checker.paired_notebooks()) == 1
+        out = capsys.readouterr().out
+        assert "STALE" in out
+        assert "differ" in out
+
+    def test_a_missing_notebook_is_caught(self, checker, notebook_pair, capsys) -> None:
+        _source, notebook = notebook_pair
+        notebook.unlink()
+
+        assert checker.check_sync(checker.paired_notebooks()) == 1
+        assert "MISSING" in capsys.readouterr().out
+
+    def test_main_returns_a_failing_exit_code(self, checker, notebook_pair) -> None:
+        source, _notebook = notebook_pair
+        source.write_text(
+            source.read_text(encoding="utf-8") + "\n# %%\nprint('drift')\n",
+            encoding="utf-8",
+        )
+
+        assert checker.main(["--sync"]) == 1
+
+    def test_main_succeeds_on_a_matched_pair(self, checker, notebook_pair) -> None:
+        assert checker.main(["--sync"]) == 0
+
+
+class TestReporting:
+    def test_it_only_claims_what_it_checked(
+        self, checker, notebook_pair, capsys
+    ) -> None:
+        """--sync says nothing about whether the notebooks still run."""
+        checker.main(["--sync"])
+
+        out = capsys.readouterr().out
+        assert "All notebooks in step." in out
+        assert "running" not in out
+
+    def test_sync_is_the_default(self, checker, notebook_pair, capsys) -> None:
+        checker.main([])
+        assert "in step" in capsys.readouterr().out


### PR DESCRIPTION
The roadmap's remaining item. The notebooks are committed with their outputs saved so they render on GitHub without anyone running them — and nothing was re-running them.

Two things go wrong quietly there, and they need different checks at different cadences:

**Out of step.** Editing a `.py` and forgetting to regenerate leaves the `.ipynb` showing older text and older numbers, with nothing about it looking stale. `--sync` compares the cells of both, takes a second, and runs on every change under `notebooks/`.

**Out of date.** The saved outputs are pinned to whatever the code did when they were produced, so a change to an estimator silently turns them into claims about a version that no longer exists. `--execute` re-runs each one and fails if a cell raises. It takes minutes, so it runs weekly and on `workflow_dispatch`.

**Neither writes anything.** Regenerating rewrites the embedded images and would churn the diff on every build, and deciding when to refresh a published figure belongs to whoever is editing.

## The execute check found a problem on its first run — in itself

`jupytext` runs the kernel in the *output file's* directory, so sending the executed copy to a temporary folder broke the flood notebook's relative path to `data/`:

```
FileNotFoundError: 'data\usgs_01646500_annual_peaks.csv'
```

Writing to stdout and discarding it leaves the working directory where the notebooks expect it, and writes even less than a temp file did. All six then run clean, with no `.ipynb` modified.

## The tests are mostly about making it fail

A guard that cannot detect what it guards is worse than none, so `tests/test_check_notebooks.py` checks it catches an edited source, a changed cell *with the same cell count* (the easiest case to miss), and a missing notebook — plus that `--sync` reports only "in step" and never claims the notebooks run, which it has not checked.

I verified the exit codes directly rather than through a pipe, having been caught earlier in this repository by `ruff format --check`'s status being swallowed by `| tail`.

With this the roadmap's "Next" is empty; what remains is deferred deliberately (PyPI, Docker, `safe-ice analyze`).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a CI check and script to keep notebooks accurate. Previously notebooks with saved outputs were never re-run; now we verify they stay in sync with their `.py` sources and still execute, without rewriting any files.

- The `Notebooks` workflow runs `scripts/check_notebooks.py --sync` on pushes/PRs touching `notebooks/**` or the script, and `--execute` weekly or on `workflow_dispatch`. `--sync` compares `.ipynb` cell sources to the paired `.py`; `--execute` runs each notebook via `jupytext` to stdout to avoid changing files and to keep the working directory correct.
- Tests in `tests/test_check_notebooks.py` ensure the guard fails on real drift (edited source, changed cell with same count, missing `.ipynb`) and that exit codes are correct.
- If the weekly job fails, regenerate affected notebooks locally: jupytext --to ipynb --execute notebooks/<name>.py

<sup>Written for commit 708cb53590bc9abdcfbb4cfafc5a81c29a7d5acb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/adaptive-importance-sampling/pull/107?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

