### PR TITLE
Release 0.4.0

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "Safe-ICE: Safe Cross-Entropy-Based Importance Sampling for rare event simulation",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "upload_type": "software",
   "creators": [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-08-19
+
 ### Added
 
 - `scripts/check_notebooks.py` and a `Notebooks` workflow, because the
@@ -91,6 +93,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   It is implemented as described rather than patched around, since those
   properties are the reason it is here.
 
+- **A worked example on real data**: `notebooks/05_flood_risk_real_data.ipynb`,
+  with `data/usgs_01646500_annual_peaks.csv` and `scripts/fetch_usgs_peaks.py`
+  to refetch it. Ninety-five water years of annual peak discharge on the
+  Potomac River, public domain, used to estimate the probability of a levee
+  being overtopped in a given year.
+
+  The discharge record is real; the channel hydraulics are a stylised wide
+  rectangular channel with a Manning roughness, and the notebook says so. Three
+  estimates, two of which share no machinery:
+
+  | method | P(overtopping) | evaluations |
+  | --- | --- | --- |
+  | crude Monte Carlo | `5.750e-05` | 2,000,000 |
+  | Safe-ICE | `5.391e-05` | 3,000 |
+  | subset simulation | `4.765e-05` | 10,000 |
+
+  The closing section is the point of using real data at all. Ninety-five years
+  cannot separate a Gumbel tail from a lognormal one -- neither is rejected by a
+  Kolmogorov-Smirnov test -- but they disagree about the answer by a factor of
+  nine, which dwarfs the 20% spread between the estimators. The estimator is
+  precise; the answer is not.
+
+- Four notebooks in `notebooks/`, executed with their outputs saved so the
+  plots and numbers render on GitHub without running anything: getting started,
+  the five benchmark problems against independent references, accuracy from
+  `d=2` to `d=200` against the exact chi-square tail, and a walk through the
+  smoothed indicator, sigma schedule, penalised EM and heavy-tailed component.
+
+  Every figure is measured when the notebook runs rather than typed in, and
+  references come from outside the package -- a closed form where one exists,
+  otherwise crude Monte Carlo. Results are reported as a spread across seeds
+  rather than a single run, since the estimator is stochastic and one run is a
+  draw from a distribution.
+
+  Each is paired with a jupytext percent-format `.py`, which is the file to
+  edit: it reviews as a normal diff where an `.ipynb` diff is mostly base64
+  image data. `jupytext` is declared in the `benchmark` dependency group.
+
 ### Changed
 
 - **`sigma0` now defaults to `"auto"`, chosen from the limit state rather than
@@ -127,30 +167,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   1.09x of their references, worst individual seeds between 0.79x and 1.30x.
   The pilot advances the random stream, so individual runs differ from before
   even where `sigma0` is identical.
-
-### Added
-
-- **A worked example on real data**: `notebooks/05_flood_risk_real_data.ipynb`,
-  with `data/usgs_01646500_annual_peaks.csv` and `scripts/fetch_usgs_peaks.py`
-  to refetch it. Ninety-five water years of annual peak discharge on the
-  Potomac River, public domain, used to estimate the probability of a levee
-  being overtopped in a given year.
-
-  The discharge record is real; the channel hydraulics are a stylised wide
-  rectangular channel with a Manning roughness, and the notebook says so. Three
-  estimates, two of which share no machinery:
-
-  | method | P(overtopping) | evaluations |
-  | --- | --- | --- |
-  | crude Monte Carlo | `5.750e-05` | 2,000,000 |
-  | Safe-ICE | `5.391e-05` | 3,000 |
-  | subset simulation | `4.765e-05` | 10,000 |
-
-  The closing section is the point of using real data at all. Ninety-five years
-  cannot separate a Gumbel tail from a lognormal one -- neither is rejected by a
-  Kolmogorov-Smirnov test -- but they disagree about the answer by a factor of
-  nine, which dwarfs the 20% spread between the estimators. The estimator is
-  precise; the answer is not.
 
 ### Fixed
 
@@ -266,24 +282,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `PenalizedEMOptimizer(penalized=False)` holds the penalty coefficient at
   zero, reducing the M-step to the plain weighted EM update of equation (19).
-
-### Added
-
-- Four notebooks in `notebooks/`, executed with their outputs saved so the
-  plots and numbers render on GitHub without running anything: getting started,
-  the five benchmark problems against independent references, accuracy from
-  `d=2` to `d=200` against the exact chi-square tail, and a walk through the
-  smoothed indicator, sigma schedule, penalised EM and heavy-tailed component.
-
-  Every figure is measured when the notebook runs rather than typed in, and
-  references come from outside the package -- a closed form where one exists,
-  otherwise crude Monte Carlo. Results are reported as a spread across seeds
-  rather than a single run, since the estimator is stochastic and one run is a
-  draw from a distribution.
-
-  Each is paired with a jupytext percent-format `.py`, which is the file to
-  edit: it reviews as a normal diff where an `.ipynb` diff is mostly base64
-  image data. `jupytext` is declared in the `benchmark` dependency group.
 
 ## [0.3.0] - 2026-08-18
 
@@ -825,6 +823,7 @@ quoted as `1.22e-5` against a measured `5.815e-05`.
   Karhunen-Loève expansion.
 - Performance evaluation and convergence analysis utilities.
 
-[Unreleased]: https://github.com/DiogoRibeiro7/adaptive-importance-sampling-ice/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/DiogoRibeiro7/adaptive-importance-sampling-ice/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/DiogoRibeiro7/adaptive-importance-sampling-ice/releases/tag/v0.4.0
 [0.3.0]: https://github.com/DiogoRibeiro7/adaptive-importance-sampling-ice/releases/tag/v0.3.0
 [0.2.0]: https://github.com/DiogoRibeiro7/adaptive-importance-sampling-ice/releases/tag/v0.2.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -24,7 +24,7 @@ keywords:
   - cross-entropy method
   - structural reliability
 license: MIT
-version: 0.3.0
+version: 0.4.0
 references:
   - type: article
     title: >-

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,9 +3,24 @@
 Where the project is and what is planned next. Items are listed in the order
 they are likely to be worked on, not by importance.
 
-## Now: 0.3.0
+## Now: 0.4.0
 
-0.3.0 is a second correctness release, and the one that checked the
+0.4.0 widens the package from one estimator to four, and adds the layer that
+lets any of them be applied to measured data at all. `ICEvMFNM` is the baseline
+the paper's tables compare against, `SubsetSimulation` shares no machinery with
+the importance-sampling code, and `CrossEntropyGaussianMixture` is the older
+method ICE improved on. `MarginalTransform` maps a problem stated in physical
+units into the standard normal space the estimators work in.
+
+Building the transform exposed a trap in the main entry point: `sigma0`
+defaulted to 1, which assumes the limit state is of order one, and a limit
+state in physical units returned a third of the right answer without any sign
+of trouble. It is now chosen from the limit state itself. That was found
+because subset simulation disagreed with Safe-ICE on a problem where it had no
+reason to, which is the whole argument for having a method that cannot be wrong
+in the same way.
+
+0.3.0 was a second correctness release, and the one that checked the
 implementation against the source paper equation by equation. It fixed the
 four-mode limit state, which had `sqrt(3.5)` where equation (37) has
 `7/sqrt(2)`; implemented the nonlinear oscillator and the heat transfer

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "safe-ice" %}
-{% set version = "0.3.0" %}
+{% set version = "0.4.0" %}
 
 package:
   name: {{ name|lower }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "safe-ice"
-version = "0.3.0"
+version = "0.4.0"
 description = "Safe Cross-Entropy-Based Importance Sampling for rare event simulation"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Cuts 0.4.0. Minor rather than patch: new capability throughout, plus one changed default (`sigma0`).

## What it adds

The package goes from one estimator to four, and gains the layer that lets any of them touch measured data.

| | |
| --- | --- |
| `ICEvMFNM` | the baseline the paper's tables compare against |
| `SubsetSimulation` | shares no machinery with the IS code, so it cross-checks rather than agrees |
| `CrossEntropyGaussianMixture` | the older method ICE improved on |
| `MarginalTransform` | physical units into standard normal space, with Nataf correlation |

Plus a worked example on 95 years of USGS gauge data, a notebook comparing all four and recording where each one *stops*, and a check that keeps the notebooks from going quietly stale.

## The one behavioural change

`sigma0` defaulted to `1`, which assumes the limit state is of order one. Every benchmark in the paper satisfies that, which is why it was invisible; a limit state in physical units does not.

| | old default | new default |
| --- | --- | --- |
| resistance minus load, physical units | 0.28x (worst seed 0.03x) | **1.00x** (worst 0.99x) |
| every paper benchmark | σ₀ = 1 | σ₀ = 1, unchanged |

It errs upwards — `max(1, std(g))` — because equation (10) only ever lowers sigma, so too-large recovers and too-small cannot. Pass a float to keep the old behaviour.

**It was found because subset simulation disagreed with Safe-ICE on a problem where it had no reason to.** That is the whole argument for carrying a method that cannot be wrong in the same way, and it is the second defect it has caught.

## Release housekeeping

The `[Unreleased]` section had accumulated **three separate `### Added` headings**, one per PR. Merged into one section per kind, with the entry count verified before and after so nothing was dropped.

Verified: 543 tests pass, `ruff`/`mypy`/`poetry check` clean, notebooks in step, and the built wheel carries all four estimators plus `transforms.py`. All four metadata files agree on 0.4.0 — `pyproject.toml`, `CITATION.cff`, `.zenodo.json` and the conda recipe — and `.zenodo.json` still parses as JSON after its regex rewrite.

After merge I will tag `v0.4.0`, which triggers the release workflow.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release 0.4.0 widens `safe-ice` from one estimator to four and adds a transform layer so estimators can run on measured data. It also changes the default sigma schedule start: `sigma0` now derives from the limit state to prevent under-scaling on problems in physical units.

- Behavior change: `sigma0` default was 1; now `sigma0="auto"` = max(1, std(g)) from a short pilot. Paper benchmarks are unchanged; results for physical-unit problems will shift upward. Seeds will not reproduce prior runs because the pilot advances the RNG. To keep the old behavior, pass a float for `sigma0`.

<sup>Written for commit 2e36027b02d53b773831fb24b2ed65446c549e94. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/adaptive-importance-sampling/pull/108?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

